### PR TITLE
Default the Operation Summary To Be The Same Value As The Description

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -155,6 +155,7 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
 
             if (javadocDescription != null && StringUtils.isEmpty(swaggerOperation.getDescription())) {
                 swaggerOperation.setDescription(javadocDescription.getMethodDescription());
+                swaggerOperation.setSummary(javadocDescription.getMethodDescription());
             }
 
             setOperationOnPathItem(pathItem, swaggerOperation, httpMethod);


### PR DESCRIPTION
OpenAPI uses the summary in the API UI to put a friendly description to the endpoint.  This can be accomplished via manually adding an `@Operation(summary = "foo")` annotation, but if we have a description we should default it to that.

![image](https://user-images.githubusercontent.com/41924046/56808239-fe75d500-67fe-11e9-80b1-8dc4d3253af9.png)
