### PR TITLE
Handle multiple content types

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -174,7 +174,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
                                 }
                             });
                 } catch (IOException e) {
-                    context.warn("Unable to read  file from "+ directory.getFileName() + ": " + e.getMessage() , classElement);
+                    context.warn("Unable to read  file from " + directory.getFileName() + ": " + e.getMessage() , classElement);
                 }
             }
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -407,7 +407,7 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
 
                     RequestBody requestBody = new RequestBody();
                     final Content content = new Content();
-                    consumesMediaTypes = consumesMediaTypes.isEmpty() ? OptionalValues.of(List.class, Collections.singletonMap("value", MediaType.APPLICATION_JSON)): consumesMediaTypes;
+                    consumesMediaTypes = consumesMediaTypes.isEmpty() ? OptionalValues.of(List.class, Collections.singletonMap("value", MediaType.APPLICATION_JSON)) : consumesMediaTypes;
                     consumesMediaTypes.forEach((key, mediaTypeList) -> {
                         for (Object mediaType: mediaTypeList) {
                             io.swagger.v3.oas.models.media.MediaType mt = new io.swagger.v3.oas.models.media.MediaType();

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.openapi.visitor
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.MapSchema
@@ -923,5 +924,101 @@ class MyBean {}
         pathItem.post.requestBody.content['application/json'].schema.properties.size() == 2
         pathItem.post.requestBody.content['application/json'].schema.properties['name'].type == 'string'
         !pathItem.post.requestBody.content['application/json'].schema.properties['name'].nullable
+    }
+
+
+    void "test build OpenAPI for response with multiple content types"() {
+        given: "An API definition"
+        when:
+        buildBeanDefinition('test.MyBean','''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+
+import java.util.List;
+
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    /**
+     * Find a pet by a slug
+     *
+     * @param slug The slug name
+     * @return A pet or 404
+     */
+    @Produces({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
+    @Get("/{slug}")
+    T find(String slug);
+}
+
+class Pet {
+    private int age;
+    private String name;
+    private List<String> tags;
+
+    public void setAge(int a) {
+        age = a;
+    }
+
+    /**
+     * The Pet Age
+     *
+     * @return The Pet Age
+     */
+    public int getAge() {
+        return age;
+    }
+
+    public void setName(String n) {
+        name = n;
+    }
+
+    /**
+     * The Pet Name
+     *
+     * @return The Pet Name
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    /**
+     * The Pet Tags
+     *  
+     * @return The Tag
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"The state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:"The operation has only one path"
+        openAPI.paths.size() == 1
+
+        when: "The GET /pets/{slug} operation is retrieved"
+        Operation operation = openAPI.paths?.get("/pets/{slug}")?.get
+
+        then: "The response has multiple content types"
+        operation.responses.size() == 1
+        operation.responses.default.content.size() == 2
+        operation.responses.default.content['application/json'].schema
+        operation.responses.default.content['application/x-www-form-urlencoded'].schema
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -1118,7 +1118,7 @@ class MyBean {}
         operation.requestBody.content['application/x-www-form-urlencoded'].schema
     }
 
-    void "test build OpenAPI for body with multiple content types and parameters"() {
+    void "test build OpenAPI for multiple content types and parameters"() {
         given: "An API definition"
         when:
         buildBeanDefinition('test.MyBean','''
@@ -1145,6 +1145,112 @@ interface PetOperations<T extends Pet> {
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
     @Post("/")
     T save(String name, int age);
+}
+
+class Pet {
+    private int age;
+    private String name;
+    private List<String> tags;
+
+    public void setAge(int a) {
+        age = a;
+    }
+
+    /**
+     * The Pet Age
+     *
+     * @return The Pet Age
+     */
+    public int getAge() {
+        return age;
+    }
+
+    public void setName(String n) {
+        name = n;
+    }
+
+    /**
+     * The Pet Name
+     *
+     * @return The Pet Name
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    /**
+     * The Pet Tags
+     *  
+     * @return The Tag
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"The state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:"The operation has only one path"
+        openAPI.paths.size() == 1
+
+        when: "The POST /pets operation is retrieved"
+        Operation operation = openAPI.paths?.get("/pets")?.post
+
+        then: "The body has multiple content types"
+        operation.requestBody
+        operation.requestBody.content.size() == 2
+        operation.requestBody.content['application/json'].schema
+        operation.requestBody.content['application/x-www-form-urlencoded'].schema
+    }
+
+    void "test build OpenAPI for multiple content types and @Parameter"() {
+        given: "An API definition"
+        when:
+        buildBeanDefinition('test.MyBean','''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+
+import java.util.List;
+
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    /**
+     * Saves a Pet
+     *
+     * @param name The Pet name
+     * @param aget The Pet age
+     * @return A pet or 404
+     */
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
+    @Post("/")
+    T save(@Parameter(
+            name = "name",
+            in = ParameterIn.PATH,
+            description = "The Pet Name",
+            required = true,
+            schema = @Schema(type = "string")
+        ) String name, int age);
 }
 
 class Pet {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -926,7 +926,6 @@ class MyBean {}
         !pathItem.post.requestBody.content['application/json'].schema.properties['name'].nullable
     }
 
-
     void "test build OpenAPI for response with multiple content types"() {
         given: "An API definition"
         when:
@@ -1020,5 +1019,199 @@ class MyBean {}
         operation.responses.default.content.size() == 2
         operation.responses.default.content['application/json'].schema
         operation.responses.default.content['application/x-www-form-urlencoded'].schema
+    }
+
+    void "test build OpenAPI for body with multiple content types"() {
+        given: "An API definition"
+        when:
+        buildBeanDefinition('test.MyBean','''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+
+import java.util.List;
+
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    /**
+     * Saves a Pet
+     *
+     * @param pet The Pet details
+     * @return A pet or 404
+     */
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
+    @Post("/")
+    T save(@Body T pet);
+  
+}
+
+class Pet {
+    private int age;
+    private String name;
+    private List<String> tags;
+
+    public void setAge(int a) {
+        age = a;
+    }
+
+    /**
+     * The Pet Age
+     *
+     * @return The Pet Age
+     */
+    public int getAge() {
+        return age;
+    }
+
+    public void setName(String n) {
+        name = n;
+    }
+
+    /**
+     * The Pet Name
+     *
+     * @return The Pet Name
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    /**
+     * The Pet Tags
+     *  
+     * @return The Tag
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"The state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:"The operation has only one path"
+        openAPI.paths.size() == 1
+
+        when: "The POST /pets operation is retrieved"
+        Operation operation = openAPI.paths?.get("/pets")?.post
+
+        then: "The body has multiple content types"
+        operation.requestBody
+        operation.requestBody.content.size() == 2
+        operation.requestBody.content['application/json'].schema
+        operation.requestBody.content['application/x-www-form-urlencoded'].schema
+    }
+
+    void "test build OpenAPI for body with multiple content types and parameters"() {
+        given: "An API definition"
+        when:
+        buildBeanDefinition('test.MyBean','''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+
+import java.util.List;
+
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    /**
+     * Saves a Pet
+     *
+     * @param name The Pet name
+     * @param aget The Pet age
+     * @return A pet or 404
+     */
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
+    @Post("/")
+    T save(String name, int age);
+}
+
+class Pet {
+    private int age;
+    private String name;
+    private List<String> tags;
+
+    public void setAge(int a) {
+        age = a;
+    }
+
+    /**
+     * The Pet Age
+     *
+     * @return The Pet Age
+     */
+    public int getAge() {
+        return age;
+    }
+
+    public void setName(String n) {
+        name = n;
+    }
+
+    /**
+     * The Pet Name
+     *
+     * @return The Pet Name
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    /**
+     * The Pet Tags
+     *  
+     * @return The Tag
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"The state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:"The operation has only one path"
+        openAPI.paths.size() == 1
+
+        when: "The POST /pets operation is retrieved"
+        Operation operation = openAPI.paths?.get("/pets")?.post
+
+        then: "The body has multiple content types"
+        operation.requestBody
+        operation.requestBody.content.size() == 2
+        operation.requestBody.content['application/json'].schema
+        operation.requestBody.content['application/x-www-form-urlencoded'].schema
     }
 }


### PR DESCRIPTION
Updated OpenApiApplicationVisitor to handle multiple content types in a response, request body, and parameters.