### PR TITLE
Fix #14 OpenAPI - schema annotation in ApiResponse is not used

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -537,6 +537,9 @@ abstract class AbstractOpenApiVisitor  {
         for (Object o : a) {
             AnnotationValue<?> sv = (AnnotationValue<?>) o;
             String name = sv.get(classifier, String.class).orElse(null);
+            if (name == null && classifier.equals("mediaType")) {
+                name = MediaType.APPLICATION_JSON;
+            }
             if (name != null) {
                 Map<CharSequence, Object> map = toValueMap(sv.getValues(), context);
                 mediaTypes.put(name, map);


### PR DESCRIPTION
Updated `annotationValueArrayToSubmap` to set name to "application/json" if classifier is mediaType and name is not defined on annotation value.