### PR TITLE
Swagger 2.x to Swagger 3.x

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,3 +1,3 @@
-Micronaut includes experimental support for producing OpenAPI (Swagger) YAML at compilation time. Micronaut will at compile time produce a Swagger 2.x compliant YAML file just based on the regular Micronaut annotations and the javadoc comments within your code.
+Micronaut includes experimental support for producing OpenAPI (Swagger) YAML at compilation time. Micronaut will at compile time produce a Swagger 3.x compliant YAML file just based on the regular Micronaut annotations and the javadoc comments within your code.
 
-You can customize the generated Swagger using the standard https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations[Swagger Annotations].
+You can customize the generated Swagger using the standard https://github.com/swagger-api/swagger-core/wiki/Swagger-3.X---Annotations[Swagger Annotations].


### PR DESCRIPTION
The swagger yaml that is being produced is, as of Micronaut 1.1.1 and May 15, 2019, OpenAPI 3.0.1.

Thus, code and documentation should be updated to 3.x.

