### PR TITLE
Correct security requirement object definition

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -55,6 +55,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.reactivestreams.Publisher;
 
@@ -900,5 +901,22 @@ abstract class AbstractOpenApiVisitor  {
             }
 
         }
+    }
+
+    /**
+     * Maps annotation value to {@link io.swagger.v3.oas.annotations.security.SecurityRequirement}.
+     * Correct format is:
+     *  custom_name:
+     *    - custom_scope1
+     *    - custom_scope2
+     * @param r The value of {@link SecurityRequirement}.
+     * @return converted object.
+     */
+    protected SecurityRequirement mapToSecurityRequirement(AnnotationValue<io.swagger.v3.oas.annotations.security.SecurityRequirement> r) {
+        String name = r.getRequiredValue("name", String.class);
+        List<String> scopes = r.get("scopes", String[].class).map(Arrays::asList).orElse(Collections.EMPTY_LIST);
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList(name, scopes);
+        return securityRequirement;
     }
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -66,7 +66,6 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
 
 import javax.annotation.Nonnull;
@@ -515,10 +514,8 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
         List<AnnotationValue<io.swagger.v3.oas.annotations.security.SecurityRequirement>> securityAnnotations = element.getAnnotationValuesByType(io.swagger.v3.oas.annotations.security.SecurityRequirement.class);
         if (CollectionUtils.isNotEmpty(securityAnnotations)) {
             for (AnnotationValue<io.swagger.v3.oas.annotations.security.SecurityRequirement> r : securityAnnotations) {
-                JsonNode jn = toJson(r.getValues(), context);
                 try {
-                    Optional<SecurityRequirement> newRequirement = Optional.of(jsonMapper.treeToValue(jn, SecurityRequirement.class));
-                    newRequirement.ifPresent(swaggerOperation::addSecurityItem);
+                    swaggerOperation.addSecurityItem(mapToSecurityRequirement(r));
                 } catch (Exception e) {
                     context.warn("Error reading Swagger SecurityRequirement for element [" + element + "]: " + e.getMessage(), element);
                 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.openapi.visitor
 
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityScheme
 
@@ -97,7 +96,8 @@ class MyBean {}
         openAPI.tags.first().description == 'desc 1'
         openAPI.externalDocs.description == 'definition docs desc'
         openAPI.security.size() == 2
-        openAPI.security.first().name[0] == 'req 1'
+        openAPI.security[0] == ["req 1":["a", "b"]]
+        openAPI.security[1] == ["req 2":["b", "c"]]
         openAPI.servers.size() == 1
         openAPI.servers[0].description == 'server 1'
         openAPI.servers[0].url == 'http://foo'
@@ -176,8 +176,8 @@ class MyBean {}
         openAPI.tags.first().name == 'Tag 1'
         openAPI.tags.first().description == 'desc 1'
         openAPI.externalDocs.description == 'definition docs desc'
-        openAPI.security.size() == 2
-        openAPI.security.first().name[0] == 'req 1'
+            openAPI.security[0] == ["req 1":["a", "b"]]
+            openAPI.security[1] == ["req 2":["b", "c"]]
         openAPI.servers.size() == 1
         openAPI.servers[0].description == 'server 1'
         openAPI.servers[0].url == 'http://foo'

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiMergeSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiMergeSchemaSpec.groovy
@@ -83,7 +83,8 @@ class MyBean {}
         openAPI.tags.first().description == 'desc 1'
         openAPI.externalDocs.description == 'definition docs desc'
         openAPI.security.size() == 2
-        openAPI.security.first().name[0] == 'req 1'
+        openAPI.security[0] == ["req 1":["a", "b"]]
+        openAPI.security[1] == ["req 2":["b", "c"]]
         openAPI.servers.size() == 2
         openAPI.servers[0].description == 'server 1'
         openAPI.servers[0].url == 'http://foo'

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
@@ -378,8 +378,7 @@ class MyBean {}
         operation.tags.size() == 1
         operation.tags == ['pets']
         operation.security.size() == 1
-        operation.security.first().name == ['petstore-auth']
-        operation.security.first().scopes == ['write:pets']
+        operation.security.first() == ['petstore-auth': ['write:pets']]
         operation.responses.size() == 4
         operation.responses.default.content.size() == 1
         operation.responses.default.content['application/json']

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSecurityRequirementSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSecurityRequirementSpec.groovy
@@ -72,8 +72,7 @@ class MyBean {}
         expect:
         operation
         operation.security.size() == 1
-        operation.security.first().name == ['myOauth2Security']
-        operation.security.first().scopes == ['write: read']
+        operation.security[0]['myOauth2Security'] == ['write: read']
         openAPI.components.securitySchemes.size() == 1
         openAPI.components.securitySchemes['myOauth2Security'].type == SecurityScheme.Type.APIKEY
         openAPI.components.securitySchemes['myOauth2Security'].in == SecurityScheme.In.HEADER
@@ -128,8 +127,7 @@ class MyBean {}
         expect:
         operation
         operation.security.size() == 1
-        operation.security.first().name == ['myOauth2Security']
-        operation.security.first().scopes == ['write: read']
+        operation.security[0]['myOauth2Security'] == ['write: read']
         openAPI.components.securitySchemes.size() == 1
         openAPI.components.securitySchemes['myOauth2Security'].type == SecurityScheme.Type.OAUTH2
         openAPI.components.securitySchemes['myOauth2Security'].flows


### PR DESCRIPTION
According to https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securityRequirementObject and Swagger UI

Correct format should be:
```
custom_name:
        - scope1
        - scope2
```
not
```
name:
   - custom_name
scopes:
   - scope1
   - scope2 
```
