### PR TITLE
Completable response does not have body

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -195,6 +195,10 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
                 }
 
                 ClassElement returnType = element.getReturnType();
+
+                if (returnType != null && returnType.isAssignable("io.reactivex.Completable")) {
+                  returnType = null;
+                }
                 if (returnType != null && isResponseType(returnType)) {
                     returnType = returnType.getFirstTypeArgument().orElse(returnType);
                 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -585,6 +585,9 @@ interface PetOperations<T extends Pet> {
 
     @Post("/")
     Single<T> save(@Body T pet);
+    
+    @Post("/completable")
+    Completable completable(@Body T pet);
 }
 
 //@Schema
@@ -674,6 +677,16 @@ class MyBean {}
         pathItem.get.responses['default'].content['application/json'].schema
         pathItem.get.responses['default'].content['application/json'].schema.type == 'array'
         pathItem.get.responses['default'].content['application/json'].schema.items.$ref == '#/components/schemas/Pet'
+
+        when:"A completable is returned"
+        pathItem = openAPI.paths.get("/pets/completable")
+
+        then:
+        pathItem.post.operationId == 'completable'
+        pathItem.post.responses['default'] != null
+        pathItem.post.responses['default'].description == null
+        pathItem.post.responses['default'].content == null
+
     }
 
 


### PR DESCRIPTION
From Micronaut 1.2.0, Completable is supported as controller return type (https://docs.micronaut.io/latest/guide/introduction.html#_completable_support)

The completable response should not have body, so the default response should be left empty.