### PR TITLE
Return value should be allowed to be multiline

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocParser.java
+++ b/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocParser.java
@@ -63,17 +63,13 @@ public class JavadocParser {
             for (char c : chars) {
                 switch (state) {
                     case RETURN_DESC:
-                        if (c == '\n') {
-                            state = TEXT;
-                            previousState = TEXT;
-                            javadocDescription.setReturnDescription(currentDescription.toString());
-                            currentDescription = description;
-                        }
+                        javadocDescription.setReturnDescription(currentDescription.toString().trim());
+                        // Notice pass through in case
                     case PARAM_DESC:
                         if (state == PARAM_DESC) {
                             javadocDescription.getParameters().put(currentParam.toString(), currentDescription.toString().trim());
                         }
-
+                        // Notice pass through in case
                     case TEXT:
                         if (c == '{' || c == '@') {
                             currentDoclet.delete(0, currentDoclet.length());

--- a/openapi/src/test/groovy/io/micronaut/openapi/javadoc/JavadocParserSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/javadoc/JavadocParserSpec.groovy
@@ -68,6 +68,41 @@ And more stuff.
 And more stuff.'''
         desc.returnDescription == 'The return value'
         desc.parameters['foo'] == 'The foo param'
+    }
+
+    void 'test parse multiline return value javadoc'() {
+
+        given:
+        JavadocParser parser = new JavadocParser()
+        JavadocDescription desc = parser.parse('''
+<p>This is a description with <b>bold</b> and {@code some code}.</p>
+
+And more stuff.
+
+@since 1.0
+@param foo The foo param
+With more foo param desctiption
+@param bar The {@code bar} param
+@return The {@value return} value
+with more return description
+
+as it is multiline
+''')
+
+
+        expect:
+        desc.methodDescription
+        desc.returnDescription
+        desc.parameters.size() == 2
+        desc.parameters['foo'] == '''The foo param
+With more foo param desctiption'''
+        desc.methodDescription == '''This is a description with bold and some code.
+
+And more stuff.'''
+        desc.returnDescription == '''The return value
+with more return description
+
+as it is multiline'''
 
     }
 }


### PR DESCRIPTION
Previously it switched to TEXT state on newline which would add remainder to description.
Fixes #45 