### PR TITLE
Default response description is required

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -189,9 +189,10 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
                 ApiResponse okResponse = new ApiResponse();
 
                 if (javadocDescription != null) {
-
                     String returnDescription = javadocDescription.getReturnDescription();
                     okResponse.setDescription(returnDescription);
+                } else {
+                    okResponse.setDescription(swaggerOperation.getOperationId() + " default response");
                 }
 
                 ClassElement returnType = element.getReturnType();

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
@@ -124,6 +124,9 @@ interface PetOperations<T extends String> {
     
     @Get("/extras/{extraId}")
     HttpResponse<T> findExtras(@PathVariable String extraId, HttpRequest request);
+    
+    @Get("/random")
+    HttpResponse<T> getRandomPet();
 }
 
 
@@ -176,6 +179,13 @@ class MyBean {}
         pathItem.get.responses['default'] != null
         pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
 
+        when:"the /getSomething path is retrieved"
+        pathItem = openAPI.paths.get("/pets/random")
+
+        then:"default response has default description"
+        pathItem.get.operationId == 'getRandomPet'
+        pathItem.get.responses['default'].description == 'getRandomPet default response'
+        pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
 
     }
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiParameterMappingSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiParameterMappingSpec.groovy
@@ -343,6 +343,7 @@ class MyBean {}
         then:"it is included in the OpenAPI doc"
         pathItem.get.operationId == 'getNetworks'
         pathItem.get.parameters.empty
+        pathItem.get.requestBody == null
     }
 }
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -687,8 +687,8 @@ class MyBean {}
 
         then:
         pathItem.post.operationId == 'completable'
-        pathItem.post.responses['default'] != null
-        pathItem.post.responses['default'].description == null
+        pathItem.post.responses['default']
+        pathItem.post.responses['default'].description == 'completable default response'
         pathItem.post.responses['default'].content == null
 
         when:"A Single<HttpResponse<T>> is returned"


### PR DESCRIPTION
When the generated yml file is validated, a bunch of errors show up because the default response description is missing. This issue is also mentioned in #46 

I'm not sure what is a sensible default response description, so I choose `openrationId + " default response"`

This PR also add an assert for the test case when requestBody is null