### PR TITLE
Support for @ExampleObject and @RequestBody

### DIFF
--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
@@ -197,6 +197,7 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
@@ -224,7 +225,10 @@ interface PetOperations {
                             responseCode = "200",
                             description = "Save Pet",
                             content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = Pet.class))),
+                                    schema = @Schema(implementation = Pet.class),
+                                    examples = {
+                    @ExampleObject(name = "example-1", value = "{\\"name\\":\\"Charlie\\"}")
+                })),
                     @ApiResponse(
                             responseCode = "404",
                             description = "Page Not Found"
@@ -250,6 +254,10 @@ class MyBean {}
         operation.responses.'200'.content['application/json']
         operation.responses.'200'.content['application/json'].schema
         operation.responses.'200'.content['application/json'].schema.$ref == "#/components/schemas/Pet"
+        operation.responses.'200'.content['application/json'].examples
+        operation.responses.'200'.content['application/json'].examples.'example-1'
+        operation.responses.'200'.content['application/json'].examples.'example-1'.value
+        operation.responses.'200'.content['application/json'].examples.'example-1'.value.name == 'Charlie'
     }
 
     void "test parse the OpenAPI @Operation annotation"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/SchemaMetaAnnotationSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/SchemaMetaAnnotationSpec.groovy
@@ -147,4 +147,64 @@ class MyBean {}
         openAPI.components.schemas['MyAnn'].type == 'string'
         openAPI.components.schemas['MyAnn'].format == 'uuid'
     }
+
+
+    void "test that it possible to define custom RequestBody annotations at the type level"() {
+
+
+        given:"An API definition"
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.reactivex.*;
+import io.micronaut.http.annotation.*;
+import java.util.List;
+import com.fasterxml.jackson.annotation.*;
+import java.lang.annotation.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+
+@Controller("/pets")
+interface MyOps {
+
+    @Post("/")
+    String save(@MyAnn java.util.UUID uuid);
+}
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@RequestBody(description = "A pet", required = false, content = {
+        @Content(mediaType = "application/json",
+                 schema = @Schema(type = "string"))})
+@interface MyAnn {
+
+}
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        PathItem pathItem = openAPI.paths.get("/pets")
+
+        then:"it is included in the OpenAPI doc"
+        pathItem.post.requestBody
+        pathItem.post.requestBody.description == 'A pet'
+        !pathItem.post.requestBody.required
+        pathItem.post.requestBody.content.size() == 1
+        pathItem.post.requestBody.content['application/json'].schema
+        pathItem.post.requestBody.content['application/json'].schema.type == 'string'
+    }
 }


### PR DESCRIPTION
Added support for @ExampleObject and @RequestBody annotations, as well as jsons nested as a String (to be parsed by yaml)