### PR TITLE
Fix duplicate required properties

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -451,7 +451,11 @@ abstract class AbstractOpenApiVisitor  {
             parentSchema.addProperties(propertyName, propertySchema);
 
             if (!element.isAnnotationPresent(Nullable.class)) {
-                parentSchema.addRequiredItem(propertyName);
+                List<String> requiredList = parentSchema.getRequired();
+                // Check for duplicates
+                if (requiredList == null || !requiredList.contains(propertyName)) {
+                    parentSchema.addRequiredItem(propertyName);
+                }
             }
         }
     }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -777,7 +777,7 @@ interface PetOperations<T extends Pet> {
     Single<T> save(@Body T pet);
 }
 
-@Schema(name="MyPet", description="Pet description")
+@Schema(name="MyPet", description="Pet description", requiredProperties={"type", "age", "name"})
 class Pet {
     private PetType type;
     private int age;


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-openapi/pull/65
introduces support for 'requiredProperties' attribute, but it can lead to have duplicate entries
in the generated yaml.