### PR TITLE
Indicate that the swagger support does not support Groovy.

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,3 +1,5 @@
 Micronaut includes experimental support for producing OpenAPI (Swagger) YAML at compilation time. Micronaut will at compile time produce a Swagger 3.x compliant YAML file just based on the regular Micronaut annotations and the javadoc comments within your code.
 
+This does *not* currently support Groovy.
+
 You can customize the generated Swagger using the standard https://github.com/swagger-api/swagger-core/wiki/Swagger-3.X---Annotations[Swagger Annotations].


### PR DESCRIPTION
Currently there is no indication that Swagger support does not support Groovy unless you happen to try the cli:
mn create-app my-openapi-app --features swagger-java --lang groovy
If you are trying to add swagger support to an existing groovy project it just doesn't work.