### PR TITLE
allOf is not appearing properly in generated schema

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -699,6 +699,18 @@ abstract class AbstractOpenApiVisitor  {
         }
     }
 
+    private void checkAllOf(ComposedSchema composedSchema) {
+        if (composedSchema != null && composedSchema.getAllOf() != null && !composedSchema.getAllOf().isEmpty()) {
+            if (composedSchema.getProperties() != null && !composedSchema.getProperties().isEmpty()) {
+                // put all properties as siblings of allOf
+                ObjectSchema propSchema = new ObjectSchema();
+                propSchema.properties(composedSchema.getProperties());
+                composedSchema.setProperties(null);
+                composedSchema.addAllOfItem(propSchema);
+            }
+        }
+    }
+
     private Schema getSchemaDefinition(
             @Nullable String mediaType,
             OpenAPI openAPI,
@@ -729,27 +741,34 @@ abstract class AbstractOpenApiVisitor  {
                     schema = jsonMapper.treeToValue(schemaJson, Schema.class);
 
                     if (schema != null) {
+                        ComposedSchema composedSchema = null;
                         if (schema instanceof ComposedSchema) {
+                            composedSchema = (ComposedSchema) schema;
                             final Optional<String[]> allOf = schemaValue.get("allOf", String[].class);
                             if (allOf.isPresent() && allOf.get().length > 0) {
                                 final String[] names = allOf.get();
                                 List<Schema> schemaList = namesToSchemas(mediaType, openAPI, context, names);
-
-                                ((ComposedSchema) schema).allOf(schemaList);
+                                for (Schema s: schemaList) {
+                                    composedSchema.addAllOfItem(s);
+                                }
                             }
 
                             final Optional<String[]> anyOf = schemaValue.get("anyOf", String[].class);
                             if (anyOf.isPresent() && anyOf.get().length > 0) {
                                 final String[] names = anyOf.get();
                                 List<Schema> schemaList = namesToSchemas(mediaType, openAPI, context, names);
-                                ((ComposedSchema) schema).anyOf(schemaList);
+                                for (Schema s: schemaList) {
+                                    composedSchema.addAnyOfItem(s);
+                                }
                             }
 
                             final Optional<String[]> oneof = schemaValue.get("oneOf", String[].class);
                             if (oneof.isPresent() && oneof.get().length > 0) {
                                 final String[] names = oneof.get();
                                 List<Schema> schemaList = namesToSchemas(mediaType, openAPI, context, names);
-                                ((ComposedSchema) schema).oneOf(schemaList);
+                                for (Schema s: schemaList) {
+                                    composedSchema.addOneOfItem(s);
+                                }
                             }
 
                             schema.setType("object");
@@ -757,8 +776,9 @@ abstract class AbstractOpenApiVisitor  {
                         if (type instanceof EnumElement) {
                             schema.setType("string");
                             schema.setEnum(((EnumElement) type).values());
-                        } else if (schema instanceof ObjectSchema || schema instanceof ComposedSchema) {
+                        } else if (schema instanceof ObjectSchema || composedSchema != null) {
                             populateSchemaProperties(mediaType, openAPI, context, type, schema);
+                            checkAllOf(composedSchema);
                         }
                         schema.setName(schemaName);
                         schemas.put(schemaName, schema);
@@ -804,7 +824,7 @@ abstract class AbstractOpenApiVisitor  {
 
                                     final Schema parentSchema = getSchemaDefinition(mediaType, openAPI, context, superElement, null);
                                     if (parentSchema != null) {
-                                        ((ComposedSchema) schema).allOf(Collections.singletonList(parentSchema));
+                                        ((ComposedSchema) schema).addAllOfItem(parentSchema);
                                     }
                                     superType = superElement.getSuperType();
                                 }
@@ -817,6 +837,9 @@ abstract class AbstractOpenApiVisitor  {
                         schemas.put(schemaName, schema);
 
                         populateSchemaProperties(mediaType, openAPI, context, type, schema);
+                        if (schema instanceof ComposedSchema) {
+                            checkAllOf((ComposedSchema) schema);
+                        }
                     }
                 }
             }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
@@ -331,13 +331,14 @@ class MyBean {}
         catSchema instanceof ComposedSchema
         dogSchema instanceof ComposedSchema
         catSchema.type == 'object'
-        catSchema.properties.size() == 1
-        catSchema.properties['clawSize'].type == 'integer'
+        catSchema.properties == null
+        //catSchema.properties['clawSize'].type == 'integer'
         petSchema.type == 'object'
         petSchema.properties.size() == 2
 
-        ((ComposedSchema)catSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf.size() == 2
         ((ComposedSchema)catSchema).allOf[0].$ref == '#/components/schemas/Pet'
+        ((ComposedSchema)catSchema).allOf[1].properties['clawSize'].type == 'integer'
     }
 
 
@@ -455,16 +456,18 @@ class MyBean {}
         catSchema instanceof ComposedSchema
         dogSchema instanceof ComposedSchema
         catSchema.type == 'object'
-        catSchema.properties.size() == 1
-        catSchema.properties['clawSize'].type == 'integer'
+        catSchema.properties == null
         petSchema.description == 'Pet Desc'
         petSchema.type == 'object'
         petSchema.properties.size() == 2
 
-        ((ComposedSchema)catSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf.size() == 2
         ((ComposedSchema)catSchema).allOf[0].$ref == '#/components/schemas/Pet'
-        ((ComposedSchema)dogSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf[1].properties.size() == 1
+        ((ComposedSchema)catSchema).allOf[1].properties['clawSize'].type == 'integer'
+        ((ComposedSchema)dogSchema).allOf.size() == 2
         ((ComposedSchema)dogSchema).allOf[0].$ref == '#/components/schemas/Pet'
+        ((ComposedSchema)dogSchema).allOf[1].properties.size() == 1
     }
 
 


### PR DESCRIPTION
Given the following classes with an `allOf`
```java

@Schema(description = "A")
public class A {
    @Schema(description = "a")
    @Nullable
    private String a;

    public String getA() {
        return a;
    }

    public void setA(String a) {
        this.a = a;
    }

}

@Schema(description = "B", allOf = A.class)
public class B extends A {
    @Schema(description = "b")
    @Nullable
    private String b;

    public String getB() {
        return b;
    }

    public void setB(String b) {
        this.b = b;
    }

}
```
Micronaut generates
```
components:
  schemas:
    A:
      type: object
      properties:
        a:
          type: string
          description: a
          nullable: true
      description: A
    B:
      type: object
      properties:
        b:
          type: string
          description: b
          nullable: true
      description: B
      allOf:
      - $ref: '#/components/schemas/A'
```
While what is expected is:
```
components:
  schemas:
    A:
      type: object
      properties:
        a:
          type: string
          description: a
          nullable: true
      description: A
    B:
      type: object
      description: B
      allOf:
      - $ref: '#/components/schemas/A'
      - type: object
        properties:
          b:
            type: string
            description: b
            nullable: true
```
Reference: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

