### PR TITLE
allOf is not appearing properly in generated schema

### DIFF
--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
@@ -330,14 +330,15 @@ class MyBean {}
         !(petSchema instanceof ComposedSchema)
         catSchema instanceof ComposedSchema
         dogSchema instanceof ComposedSchema
-        catSchema.type == 'object'
-        catSchema.properties.size() == 1
-        catSchema.properties['clawSize'].type == 'integer'
+        catSchema.type == null
+        catSchema.properties == null
         petSchema.type == 'object'
         petSchema.properties.size() == 2
 
-        ((ComposedSchema)catSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf.size() == 2
         ((ComposedSchema)catSchema).allOf[0].$ref == '#/components/schemas/Pet'
+        ((ComposedSchema)catSchema).allOf[1].type == 'object'
+        ((ComposedSchema)catSchema).allOf[1].properties['clawSize'].type == 'integer'
     }
 
 
@@ -454,17 +455,20 @@ class MyBean {}
         !(petSchema instanceof ComposedSchema)
         catSchema instanceof ComposedSchema
         dogSchema instanceof ComposedSchema
-        catSchema.type == 'object'
-        catSchema.properties.size() == 1
-        catSchema.properties['clawSize'].type == 'integer'
+        catSchema.type == null
+        catSchema.properties == null
         petSchema.description == 'Pet Desc'
         petSchema.type == 'object'
         petSchema.properties.size() == 2
 
-        ((ComposedSchema)catSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf.size() == 2
         ((ComposedSchema)catSchema).allOf[0].$ref == '#/components/schemas/Pet'
-        ((ComposedSchema)dogSchema).allOf.size() == 1
+        ((ComposedSchema)catSchema).allOf[1].type == 'object'
+        ((ComposedSchema)catSchema).allOf[1].properties.size() == 1
+        ((ComposedSchema)catSchema).allOf[1].properties['clawSize'].type == 'integer'
+        ((ComposedSchema)dogSchema).allOf.size() == 2
         ((ComposedSchema)dogSchema).allOf[0].$ref == '#/components/schemas/Pet'
+        ((ComposedSchema)dogSchema).allOf[1].properties.size() == 1
     }
 
 


### PR DESCRIPTION
Given the following classes with an `allOf`
```java

@Schema(description = "A")
public class A {
    @Schema(description = "a")
    @Nullable
    private String a;

    public String getA() {
        return a;
    }

    public void setA(String a) {
        this.a = a;
    }

}

@Schema(description = "B", allOf = A.class)
public class B extends A {
    @Schema(description = "b")
    @Nullable
    private String b;

    public String getB() {
        return b;
    }

    public void setB(String b) {
        this.b = b;
    }

}
```
Micronaut generates
```
components:
  schemas:
    A:
      type: object
      properties:
        a:
          type: string
          description: a
          nullable: true
      description: A
    B:
      type: object
      properties:
        b:
          type: string
          description: b
          nullable: true
      description: B
      allOf:
      - $ref: '#/components/schemas/A'
```
While what is expected is:
```
components:
  schemas:
    A:
      type: object
      properties:
        a:
          type: string
          description: a
          nullable: true
      description: A
    B:
      allOf:
      - $ref: '#/components/schemas/A'
      - type: object
        properties:
          b:
            type: string
            description: b
            nullable: true
        description: B
```
Reference: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
