### PR TITLE
Publish snapshots for master only

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -62,7 +62,7 @@ if [[ $EXIT_STATUS -eq 0 ]]; then
         cd gh-pages
 
         # If this is the master branch then update the snapshot
-        if [[ $TRAVIS_BRANCH =~ ^master|[12]\..\.x$ ]]; then
+        if [[ $TRAVIS_BRANCH =~ ^master$ ]]; then
            mkdir -p snapshot
            cp -r ../build/docs/. ./snapshot/
            git add snapshot/*


### PR DESCRIPTION
It seems like each time we merge a PR in either master or 1.2.x branch then the snapshot documentation gets updated which shows inconsistent behavior. 

For instance, we have updated the documentation in the master branch to support Swagger UI views which is missing right now as the snapshot is pointing to 1.2.x.