### PR TITLE
Add support for multipart/form-data file upload.

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -376,11 +376,14 @@ abstract class AbstractOpenApiVisitor  {
         av.get("schema", AnnotationValue.class).ifPresent(annotationValue -> {
             Optional<String> impl = ((AnnotationValue<?>) annotationValue).get("implementation", String.class);
             Optional<String> type = ((AnnotationValue<?>) annotationValue).get("type", String.class);
+            Optional<String> format = ((AnnotationValue<?>) annotationValue).get("format", String.class);
             Optional<ClassElement> classElement = Optional.empty();
+            PrimitiveType primitiveType = null;
             if (impl.isPresent()) {
                 classElement = context.getClassElement(impl.get());
             } else if (type.isPresent()) {
-                PrimitiveType primitiveType = PrimitiveType.fromName(type.get());
+                // if format is "binary", we want PrimitiveType.BINARY
+                primitiveType = PrimitiveType.fromName(format.isPresent() && format.get().equals("binary") ? format.get() : type.get());
                 if (primitiveType != null) {
                     classElement = context.getClassElement(primitiveType.getKeyClass());
                 } else {
@@ -388,9 +391,17 @@ abstract class AbstractOpenApiVisitor  {
                 }
             }
             if (classElement.isPresent()) {
-                final OpenAPI openAPI = resolveOpenAPI(context);
-                final ArraySchema schema = arraySchema(resolveSchema(openAPI, null, classElement.get(), context, null));
-                schemaToValueMap(arraySchemaMap, schema);
+                if (primitiveType == null) {
+                    final OpenAPI openAPI = resolveOpenAPI(context);
+                    final ArraySchema schema = arraySchema(resolveSchema(openAPI, null, classElement.get(), context, null));
+                    schemaToValueMap(arraySchemaMap, schema);
+                } else {
+                    // For primitive type, just copy description field is present.
+                    final Schema items = primitiveType.createProperty();
+                    items.setDescription((String) annotationValue.get("description", String.class).orElse(null));
+                    final ArraySchema schema = arraySchema(items);
+                    schemaToValueMap(arraySchemaMap, schema);
+                }
             } else {
                 arraySchemaMap.putAll(resolveAnnotationValues(context, av));
             }
@@ -444,7 +455,8 @@ abstract class AbstractOpenApiVisitor  {
             boolean isPublisher = false;
             boolean isObservable = false;
 
-            if (isContainerType(type)) {
+            // StreamingFileUpload implements Publisher, but it should be not considered as a Publisher in the spec file
+            if (!type.isAssignable("io.micronaut.http.multipart.StreamingFileUpload") && isContainerType(type)) {
                 isPublisher = type.isAssignable(Publisher.class.getName()) && !type.isAssignable("reactor.core.publisher.Mono");
                 isObservable = type.isAssignable("io.reactivex.Observable") && !type.isAssignable("reactor.core.publisher.Mono");
                 type = type.getFirstTypeArgument().orElse(null);
@@ -453,6 +465,15 @@ abstract class AbstractOpenApiVisitor  {
             if (type != null) {
 
                 String typeName = type.getName();
+                // File upload case
+                if ("io.micronaut.http.multipart.StreamingFileUpload".equals(typeName) ||
+                    "io.micronaut.http.multipart.CompletedFileUpload".equals(typeName) ||
+                    "io.micronaut.http.multipart.CompletedPart".equals(typeName) ||
+                    "io.micronaut.http.multipart.PartData".equals(typeName)) {
+                    isPublisher = isPublisher && ! "io.micronaut.http.multipart.PartData".equals(typeName);
+                    // For file upload, we use PrimitiveType.BINARY
+                    typeName = PrimitiveType.BINARY.name();
+                }
                 PrimitiveType primitiveType = PrimitiveType.fromName(typeName);
                 if (ClassUtils.isJavaLangType(typeName)) {
                     schema = getPrimitiveType(typeName);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -452,6 +452,10 @@ public class OpenApiControllerVisitor extends AbstractOpenApiVisitor implements 
                                 Schema propertySchema = resolveSchema(openAPI, parameter, parameter.getType(), context, mediaType.toString());
                                 if (propertySchema != null) {
 
+                                    Optional<String> description = parameter.getValue(io.swagger.v3.oas.annotations.Parameter.class, "description", String.class);
+                                    if (description.isPresent()) {
+                                        propertySchema.setDescription(description.get());
+                                    }
                                     processSchemaProperty(context, parameter, parameter.getType(), schema, propertySchema);
 
                                     propertySchema.setNullable(parameter.isAnnotationPresent(Nullable.class));

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadBodyParameterSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadBodyParameterSpec.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BinarySchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.parameters.RequestBody
+
+class OpenApiFileUploadBodyParameterSpec extends AbstractTypeElementSpec {
+    def setup() {
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+    }
+
+    void "test parse the OpenAPI for file upload"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import javax.inject.Singleton;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.PartData;
+import io.micronaut.http.multipart.StreamingFileUpload;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Singleton
+@Controller("/")
+@Tag(name = "UploadOpenApi")
+class UploadOpenApiController {
+
+    @Post(value = "/receive-flow-control", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> partData(
+            @Parameter(description = "File Parts.", schema = @Schema(type = "string", format = "binary"))
+            Flowable<PartData> file) {
+        return Single.just("");
+    }
+
+    @Post(value = "/receive-complete-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> complete(
+            @Parameter(description = "Completed File.", schema = @Schema(type = "string", format = "binary"))
+            CompletedFileUpload file) {
+        return Single.just("");
+    }
+
+    @Post(value = "/receive-streaming-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> streaming(
+            @Parameter(description = "Streaming File.", schema = @Schema(type = "string", format = "binary"))
+            StreamingFileUpload file) {
+        return Single.just("");
+    }
+
+    @Post(value = "/receive-streaming-multiple", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> multipleStreaming(
+            @Parameter(description = "Streaming File 1.", schema = @Schema(type = "string", format = "binary"))
+            StreamingFileUpload file1,
+            @Parameter(description = "Streaming File 2.", schema = @Schema(type = "string", format = "binary"))
+            StreamingFileUpload file2) {
+        return Single.just("");
+    }
+
+    @Post(value = "/receive-streaming-iterable", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> streamingIterable(
+            @Parameter(description = "List of Files.", array = @ArraySchema(schema = @Schema(type = "string", format = "binary")))
+            Flowable<StreamingFileUpload> files) {
+        return Single.just("");
+    }
+
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:
+        openAPI
+        openAPI.paths.size() == 5
+
+        when:
+        Operation operation = openAPI.paths?.get("/receive-flow-control")?.post
+        RequestBody requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "File Parts."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-complete-file")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "Completed File."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-file")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "Streaming File."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-multiple")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file1']
+        requestBody.content['multipart/form-data'].schema.properties['file1'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file1'].description == "Streaming File 1."
+        requestBody.content['multipart/form-data'].schema.properties['file2']
+        requestBody.content['multipart/form-data'].schema.properties['file2'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file2'].description == "Streaming File 2."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-iterable")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['files']
+        requestBody.content['multipart/form-data'].schema.properties['files'] instanceof ArraySchema
+        requestBody.content['multipart/form-data'].schema.properties['files'].description == 'List of Files.'
+        requestBody.content['multipart/form-data'].schema.properties['files'].items  instanceof BinarySchema
+
+        expect:
+        operation
+        operation.responses.size() == 1
+    }
+
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadSpec.groovy
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BinarySchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.parameters.RequestBody
+
+class OpenApiFileUploadSpec extends AbstractTypeElementSpec {
+    def setup() {
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+    }
+
+    void "test parse the OpenAPI for file upload"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import javax.inject.Singleton;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.PartData;
+import io.micronaut.http.multipart.StreamingFileUpload;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Singleton
+@Controller("/")
+@Tag(name = "Upload")
+class UploadController {
+
+    /**
+     * Single streaming file upload. Receiving PartData.
+     * @param file The file parts.
+     * @return nothing.
+     */
+    @Post(value = "/receive-flow-control", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> partData(Flowable<PartData> file) {
+        return Single.just("");
+    }
+
+    /**
+     * Single file upload. Receiving CompletedFileUpload.
+     * @param file The complete file.
+     * @return nothing.
+     */
+    @Post(value = "/receive-complete-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> complete(CompletedFileUpload file) {
+        return Single.just(Long.toString(file.getSize()));
+    }
+
+    /**
+     * Single streaming file upload. Receiving StreamingFileUpload.
+     * @param file The streaming file.
+     * @return nothing.
+     */
+    @Post(value = "/receive-streaming-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> streaming(StreamingFileUpload file) {
+        return Single.just("");
+    }
+
+    /**
+     * Two streaming files upload. Receiving StreamingFileUpload.
+     * @param file1 The streaming file 1.
+     * @param file2 The streaming file 2.
+     * @return nothing.
+     */
+    @Post(value = "/receive-streaming-multiple", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> multipleStreaming(StreamingFileUpload file1, StreamingFileUpload file2) {
+        return Single.just("");
+    }
+
+    /**
+     * Multiple streaming files upload. Receiving StreamingFileUpload.
+     * @param files The streaming files.
+     * @return nothing.
+     */
+    @Post(value = "/receive-streaming-iterable", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    Single<String> streamingIterable(Flowable<StreamingFileUpload> files) {
+        return Single.just("");
+    }
+}
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:
+        openAPI
+        openAPI.paths.size() == 5
+
+        when:
+        Operation operation = openAPI.paths?.get("/receive-flow-control")?.post
+        RequestBody requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "The file parts."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-complete-file")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "The complete file."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-file")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file']
+        requestBody.content['multipart/form-data'].schema.properties['file'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file'].description == "The streaming file."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-multiple")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['file1']
+        requestBody.content['multipart/form-data'].schema.properties['file1'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file1'].description == "The streaming file 1."
+        requestBody.content['multipart/form-data'].schema.properties['file2']
+        requestBody.content['multipart/form-data'].schema.properties['file2'] instanceof BinarySchema
+        requestBody.content['multipart/form-data'].schema.properties['file2'].description == "The streaming file 2."
+
+        expect:
+        operation
+        operation.responses.size() == 1
+
+        when:
+        operation = openAPI.paths?.get("/receive-streaming-iterable")?.post
+        requestBody = operation.requestBody
+
+        then:
+        requestBody.required
+        requestBody.content
+        requestBody.content.size() == 1
+        requestBody.content['multipart/form-data'].schema
+        requestBody.content['multipart/form-data'].schema instanceof ObjectSchema
+        requestBody.content['multipart/form-data'].schema.properties['files']
+        requestBody.content['multipart/form-data'].schema.properties['files'] instanceof ArraySchema
+        requestBody.content['multipart/form-data'].schema.properties['files'].description == 'The streaming files.'
+        requestBody.content['multipart/form-data'].schema.properties['files'].items  instanceof BinarySchema
+
+        expect:
+        operation
+        operation.responses.size() == 1
+    }
+
+}


### PR DESCRIPTION
As micronaut uses StreamingFileUpload, CompletedFileUpload or PartData, this lead to special cases when generating the spec file.

refs: 
- https://swagger.io/docs/specification/describing-request-body/file-upload/
- https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#considerations-for-file-uploads

These are the currently supported cases
```java
@Controller("/")
class UploadController {

    /**
     * Single streaming file upload. Receiving PartData.
     * @param file The file parts.
     * @return nothing.
     */
    @Post(value = "/receive-flow-control", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
    Single<String> partData(Flowable<PartData> file) {
        return Single.just("");
    }

    /**
     * Single file upload. Receiving CompletedFileUpload.
     * @param file The complete file.
     * @return nothing.
     */
    @Post(value = "/receive-complete-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
    Single<String> complete(CompletedFileUpload file) {
        return Single.just(Long.toString(file.getSize()));
    }

    /**
     * Single streaming file upload. Receiving StreamingFileUpload.
     * @param file The streaming file.
     * @return nothing.
     */
    @Post(value = "/receive-streaming-file", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
    Single<String> streaming(StreamingFileUpload file) {
        return Single.just("");
    }

    /**
     * Two streaming files upload. Receiving StreamingFileUpload.
     * @param file1 The streaming file 1.
     * @param file2 The streaming file 2.
     * @return nothing.
     */
    @Post(value = "/receive-streaming-multiple", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
    Single<String> multipleStreaming(StreamingFileUpload file1, StreamingFileUpload file2) {
        return Single.just("");
    }

    /**
     * Multiple streaming files upload. Receiving StreamingFileUpload.
     * @param files The streaming files.
     * @return nothing.
     */
    @Post(value = "/receive-streaming-iterable", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
    Single<String> streamingIterable(Flowable<StreamingFileUpload> files) {
        return Single.just("");
    }
}
```