### PR TITLE
maven compile args requires "-J" prefix

### DIFF
--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -37,7 +37,7 @@ or in maven:
             <configuration>
                 <fork>true</fork>
                 <compilerArgs>
-                    <arg>-Dmicronaut.openapi.views.spec=rapidoc.enabled=true,swagger-ui.enabled=true,swagger-ui.theme=flattop</arg>
+                    <arg>-J-Dmicronaut.openapi.views.spec=rapidoc.enabled=true,swagger-ui.enabled=true,swagger-ui.theme=flattop</arg>
                     ...
                 </compilerArgs>
             </configuration>


### PR DESCRIPTION
see "-Joption" at https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html#options

otherwise, it results in an "invalid flag" error