### PR TITLE
Context path aware openapi views.

### DIFF
--- a/openapi/src/main/resources/templates/rapidoc/index.html
+++ b/openapi/src/main/resources/templates/rapidoc/index.html
@@ -1,15 +1,44 @@
 <!doctype html>
 <!-- Important: must specify, else rendering will be effected -->
 <html>
-	<head>
-	    <title>{{title}}</title>
-	    <!-- Important: The Custom element uses utf8 characters -->
-	    <meta charset='utf-8' />
-	    <meta name='viewport' content='width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes' />
-	    <script src='https://unpkg.com/rapidoc{{rapidoc.version}}/dist/rapidoc-min.js'></script>
-	</head>
-	<body>
-	    <rapi-doc id='rapidoc' show-header='false' theme='{{rapidoc.theme}}' layout='{{rapidoc.layout}}' spec-url='{{specURL}}'>
-	    </rapi-doc>
-	</body>
+    <head>
+        <title>{{title}}</title>
+        <!-- Important: The Custom element uses utf8 characters -->
+        <meta charset='utf-8' />
+        <meta name='viewport' content='width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes' />
+        <script src='https://unpkg.com/rapidoc{{rapidoc.version}}/dist/rapidoc-min.js'></script>
+    </head>
+    <body>
+        <rapi-doc id='rapidoc' show-header='false' theme='{{rapidoc.theme}}' layout='{{rapidoc.layout}}'></rapi-doc>
+        <script>
+            var d = decodeURIComponent,
+                contextPath = d(document.cookie.replace(/(?:(?:^|.*;\s*)contextPath\s*\=\s*([^;]*).*$)|^.*$/, "$1")),
+                rapidoc = document.getElementById('rapidoc');
+            if (contextPath === '') {
+                const params = (function() {
+                  var query = {},
+                      a = window.location.search.substring(1).split('&'), pair;
+                  for (var i = a.length - 1; i >= 0; i--) {
+                      pair = a[i].split('=');
+                      query[d(pair[0])] = d(pair[1] || '');
+                  }
+                  return query;
+                })();
+                contextPath = (params.contextPath && params.contextPath !== '' ? params.contextPath : '');
+            }
+            rapidoc.setAttribute('spec-url', contextPath + '{{specURL}}');
+            if (contextPath !== '') {
+                rapidoc.setAttribute('server-url', window.location.origin + contextPath);
+                rapidoc.selectedServer = { 'url': window.location.origin + contextPath, 'computedUrl': window.location.origin + contextPath };
+                setTimeout(function() {
+                    if (rapidoc.resolvedSpec) {
+                        rapidoc.resolvedSpec.servers = [];
+                        rapidoc.requestUpdate();
+                    } else {
+                        setTimeout(this, 200);
+                    }
+                }, 200);
+            }
+        </script>
+    </body>
 </html>

--- a/openapi/src/main/resources/templates/redoc/index.html
+++ b/openapi/src/main/resources/templates/redoc/index.html
@@ -1,19 +1,36 @@
 <!doctype html>
 <html>
-	<head>
-	    <title>{{title}}</title>
-	    <meta charset='UTF-8' />
-	    <meta name='viewport' content='width=device-width, initial-scale=1' />
-	    <link href='https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700' rel='stylesheet' />
-	    <style>
-	      body {
-	        margin: 0;
-	        padding: 0;
-	      }
-	    </style>
-	</head>
-	<body>
-	    <redoc spec-url='{{specURL}}'></redoc>
-	    <script src='https://unpkg.com/redoc{{redoc.version}}/bundles/redoc.standalone.js'></script>
-	</body>
+    <head>
+        <title>{{title}}</title>
+        <meta charset='UTF-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <link href='https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700' rel='stylesheet' />
+        <style>
+          body {
+            margin: 0;
+            padding: 0;
+          }
+        </style>
+    </head>
+    <body>
+        <redoc></redoc>
+        <script src='https://unpkg.com/redoc{{redoc.version}}/bundles/redoc.standalone.js'></script>
+        <script>
+            var d = decodeURIComponent,
+                contextPath = d(document.cookie.replace(/(?:(?:^|.*;\s*)contextPath\s*\=\s*([^;]*).*$)|^.*$/, "$1"));
+            if (contextPath === '') {
+                const params = (function() {
+                  var query = {},
+                      a = window.location.search.substring(1).split('&'), pair;
+                  for (var i = a.length - 1; i >= 0; i--) {
+                      pair = a[i].split('=');
+                      query[d(pair[0])] = d(pair[1] || '');
+                  }
+                  return query;
+                })();
+                contextPath = (params.contextPath && params.contextPath !== '' ? params.contextPath : '');
+            }
+            Redoc.init(contextPath + '{{specURL}}');
+         </script>
+    </body>
 </html>

--- a/openapi/src/main/resources/templates/swagger-ui/index.html
+++ b/openapi/src/main/resources/templates/swagger-ui/index.html
@@ -1,39 +1,62 @@
 <!doctype html>
 <html lang='en'>
-
-<head>
-    <meta charset='UTF-8' />
-    <title>{{title}}</title>
-    <link rel='icon' type='image/png' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/favicon-32x32.png' sizes='32x32' />
-    <link rel='icon' type='image/png' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/favicon-16x16.png' sizes='16x16' />
-    <script src='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui-bundle.js'></script>
-    <script src='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui-standalone-preset.js'></script>
-    <link rel='stylesheet' type='text/css' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui.css' />
-    {{swagger-ui.theme}}
-</head>
-
-<body>
-    <div id='swagger-ui'></div>
-
-    <script>
-        window.onload = function() {
-            var ui = SwaggerUIBundle({
-                url: '{{specURL}}',
-                dom_id: '#swagger-ui',
-                deepLinking: {{swagger-ui.deep-linking}},
-                validatorUrl: null,
-                presets: [
-                    SwaggerUIBundle.presets.apis,
-                    SwaggerUIStandalonePreset
-                ],
-                plugins: [
-                    SwaggerUIBundle.plugins.DownloadUrl
-                ],
-                layout: '{{swagger-ui.layout}}'
-            });
-            window.ui = ui;
-        }
-    </script>
-</body>
-
+    <head>
+        <meta charset='UTF-8' />
+        <title>{{title}}</title>
+        <link rel='icon' type='image/png' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/favicon-32x32.png' sizes='32x32' />
+        <link rel='icon' type='image/png' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/favicon-16x16.png' sizes='16x16' />
+        <script src='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui-bundle.js'></script>
+        <script src='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui-standalone-preset.js'></script>
+        <link rel='stylesheet' type='text/css' href='https://unpkg.com/swagger-ui-dist{{swagger-ui.version}}/swagger-ui.css' />
+        {{swagger-ui.theme}}
+    </head>
+    <body>
+        <div id='swagger-ui'></div>
+        <script>
+            window.onload = function() {
+                var d = decodeURIComponent,
+                    contextPath = d(document.cookie.replace(/(?:(?:^|.*;\s*)contextPath\s*\=\s*([^;]*).*$)|^.*$/, "$1"));
+                if (contextPath === '') {
+                    const params = (function() {
+                      var query = {},
+                          a = window.location.search.substring(1).split('&'), pair;
+                      for (var i = a.length - 1; i >= 0; i--) {
+                        pair = a[i].split('=');
+                        query[d(pair[0])] = d(pair[1] || '');
+                      }
+                      return query;
+                    })();
+                    contextPath = (params.contextPath && params.contextPath !== '' ? params.contextPath : '');
+                }
+                const ui = SwaggerUIBundle({
+                      url: contextPath + '{{specURL}}',
+                      dom_id: '#swagger-ui',
+                      deepLinking: {{swagger-ui.deep-linking}},
+                      validatorUrl: null,
+                      presets: [
+                          SwaggerUIBundle.presets.apis,
+                          SwaggerUIStandalonePreset
+                      ],
+                      plugins: [
+                          SwaggerUIBundle.plugins.DownloadUrl
+                      ],
+                      layout: '{{swagger-ui.layout}}'
+                  });
+                window.ui = ui;
+                if (contextPath !== '') {
+                    const location = window.location.origin + contextPath;
+                    ui.getConfigs().requestInterceptor = req => {
+                        if (req.url.startsWith(contextPath) && ! req.url.startsWith('http')) {
+                            return req;
+                        }
+                        var idx = req.url.indexOf(location);
+                        if (idx < 0) {
+                            req.url = location + req.url.substring(window.location.origin.length);
+                        }
+                        return req;
+                    };
+                }
+            }
+        </script>
+    </body>
 </html>

--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -100,3 +100,58 @@ micronaut:
 ....
 ----
 You will need to set the `mapping.path` property accordingly: `micronaut.openapi.views.spec=mapping.path=swaggerYAML...`.
+
+== Server Context Path
+
+In micronaut configuration file you can define a server context path (with `micronaut.server.context-path`) which serves has a base path for all routes.
+Since the yaml specification file and the views are generated at compile time, these resources are not aware of this runtime setting.
+
+It is still possible for the views to work in case a context path is defined:
+* Use a `HttpServerFilter` that will add a cookie, or
+* Add a parameter to the url.
+
+The view will first look for the cookie and if not present for the parameter.
+
+=== HttpServerFilter
+
+Create a `HttpServerFilter` that will add a cookie with name `contextPath`.
+
+.HttpServerFilter for context-path
+[source,java]
+----
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.reactivestreams.Publisher;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+
+@Requires(property = "micronaut.server.context-path")
+@Filter(methods = {HttpMethod.GET, HttpMethod.HEAD}, patterns = {"/**/rapidoc*", "/**/redoc*", "/**/swagger-ui*"})
+public class OpenApiViewCookieContextPathFilter implements HttpServerFilter {
+    private final Cookie contextPathCookie;
+
+    OpenApiViewCookieContextPathFilter(@Value("${micronaut.server.context-path}") String contextPath) {
+        this.contextPathCookie = Cookie.of("contextPath", URLEncoder.encode(contextPath, StandardCharsets.UTF_8) + ";max-age=2;samesite");
+    }
+
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        return Publishers.map(chain.proceed(request), response -> response.cookie(contextPathCookie));
+    }
+
+}
+----
+
+=== URL Parameter
+
+Just add a parameter to the view url. For instance if the context path is set to `/context/path` you will access your view with `http://localhost:8080/context/path/swagger-ui?contextPath=%2Fcontext%2Fpath`.


### PR DESCRIPTION
Some logic added for the open views to work in case a server context path is defined

You need to pass a parameter to the view with the defined context path:

http://localhost:8080/context/path/swagger-ui?contextPath=%2Fcontext%2Fpath.