### PR TITLE
Specify Property naming strategy a compile time.

### DIFF
--- a/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
+++ b/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
@@ -91,3 +91,46 @@ paths:
         404:
           description: Person not found
 ----
+
+You can control how the Schema property names are dumped by setting the `micronaut.openapi.property.naming.strategy` system property. It accepts one of
+the following *jackson*'s `PropertyNamingStrategy`:
+- *SNAKE_CASE*,
+- *UPPER_CAMEL_CASE*,
+- *LOWER_CAMEL_CASE*,
+- *LOWER_CASE* and
+- *KEBAB_CASE*.
+
+For instance in gradle:
+
+.Gradle
+[source,groovy]
+----
+tasks.withType(JavaCompile) {
+    options.fork = true
+    options.forkOptions.jvmArgs << '-Dmicronaut.openapi.property.naming.strategy=SNAKE_CASE'
+
+    ...
+}
+----
+
+or in maven:
+
+.Maven
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <fork>true</fork>
+                <compilerArgs>
+                    <arg>-J-Dmicronaut.openapi.property.naming.strategy=SNAKE_CASE</arg>
+                    ...
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----


### PR DESCRIPTION
Should fix https://github.com/micronaut-projects/micronaut-openapi/issues/24

based on the following:
https://gist.github.com/silas/3b41e6ed4031c11f919767a74829ffea
https://github.com/swagger-api/swagger-core/blob/26d72bf5fd2d54e5e514ddcf3861d125d2f95b42/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/override/SnakeCaseConverterTest.java

Uses a system property to specify the schema naming strategy property.