### PR TITLE
Support mixed type arrays

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -64,6 +64,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.reactivestreams.Publisher;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.validation.constraints.*;
 import java.io.IOException;
@@ -377,6 +378,9 @@ abstract class AbstractOpenApiVisitor  {
             Optional<String> impl = ((AnnotationValue<?>) annotationValue).get("implementation", String.class);
             Optional<String> type = ((AnnotationValue<?>) annotationValue).get("type", String.class);
             Optional<String> format = ((AnnotationValue<?>) annotationValue).get("format", String.class);
+            final Optional<String[]> anyOf = annotationValue.get("anyOf", Argument.of(String[].class));
+            final Optional<String[]> oneOf = annotationValue.get("oneOf", Argument.of(String[].class));
+            final Optional<String[]> allOf = annotationValue.get("allOf", Argument.of(String[].class));
             Optional<ClassElement> classElement = Optional.empty();
             PrimitiveType primitiveType = null;
             if (impl.isPresent()) {
@@ -392,9 +396,7 @@ abstract class AbstractOpenApiVisitor  {
             }
             if (classElement.isPresent()) {
                 if (primitiveType == null) {
-                    final OpenAPI openAPI = resolveOpenAPI(context);
-                    final ArraySchema schema = arraySchema(resolveSchema(openAPI, null, classElement.get(), context, null));
-                    schemaToValueMap(arraySchemaMap, schema);
+                    classElement.ifPresent(element -> bindSchemaForClassElement(context, arraySchemaMap, element, true));
                 } else {
                     // For primitive type, just copy description field is present.
                     final Schema items = primitiveType.createProperty();
@@ -402,6 +404,10 @@ abstract class AbstractOpenApiVisitor  {
                     final ArraySchema schema = arraySchema(items);
                     schemaToValueMap(arraySchemaMap, schema);
                 }
+            } else if (io.swagger.v3.oas.annotations.media.ArraySchema.class.getName().equals(av.getAnnotationName()) && (anyOf.isPresent() || oneOf.isPresent() || allOf.isPresent())) {
+                anyOf.ifPresent(anyOfList -> bindSchemaForComposite(context, arraySchemaMap, anyOfList, "anyOf", true));
+                oneOf.ifPresent(oneOfList -> bindSchemaForComposite(context, arraySchemaMap, oneOfList, "oneOf", true));
+                allOf.ifPresent(allOfList -> bindSchemaForComposite(context, arraySchemaMap, allOfList, "allOf", true));
             } else {
                 arraySchemaMap.putAll(resolveAnnotationValues(context, av));
             }
@@ -733,11 +739,13 @@ abstract class AbstractOpenApiVisitor  {
         final Optional<String[]> allOf = av.get("allOf", Argument.of(String[].class));
         if (io.swagger.v3.oas.annotations.media.Schema.class.getName().equals(av.getAnnotationName()) && impl.isPresent()) {
             final String className = impl.get();
-            bindSchemaForClassName(context, valueMap, className);
+            final Optional<ClassElement> classElement = context.getClassElement(className);
+            classElement.ifPresent(element -> bindSchemaForClassElement(context, valueMap, element, false));
         }
         if (io.swagger.v3.oas.annotations.media.DiscriminatorMapping.class.getName().equals(av.getAnnotationName()) && schema.isPresent()) {
             final String className = schema.get();
-            bindSchemaForClassName(context, valueMap, className);
+            final Optional<ClassElement> classElement = context.getClassElement(className);
+            classElement.ifPresent(element -> bindSchemaForClassElement(context, valueMap, element, false));
         }
         if (io.swagger.v3.oas.annotations.media.Schema.class.getName().equals(av.getAnnotationName()) && (anyOf.isPresent() || oneOf.isPresent() || allOf.isPresent())) {
             anyOf.ifPresent(anyOfList -> bindSchemaForComposite(context, valueMap, anyOfList, "anyOf"));
@@ -747,17 +755,31 @@ abstract class AbstractOpenApiVisitor  {
     }
 
     private void bindSchemaForComposite(VisitorContext context, Map<CharSequence, Object> valueMap, String[] classNames, String key) {
-        final List<Map<CharSequence, Object>> namesToSchemas = Arrays.stream(classNames).map(className -> {
-            final Optional<ClassElement> classElement = context.getClassElement(className);
-            final OpenAPI openAPI = resolveOpenAPI(context);
-            Map<CharSequence, Object> schemaMap = new HashMap<>();
-            if (classElement.isPresent()) {
-                final Schema schema = resolveSchema(openAPI, null, classElement.get(), context, null);
-                schemaToValueMap(schemaMap, schema);
-            }
-            return schemaMap;
-        }).collect(Collectors.toList());
-        valueMap.put(key, namesToSchemas);
+        bindSchemaForComposite(context, valueMap, classNames, key, false);
+    }
+
+    private void bindSchemaForComposite(VisitorContext context, Map<CharSequence, Object> valueMap, String[] classNames, String key, boolean isArraySchema) {
+        final List<Schema> namesToSchemas = Arrays.stream(classNames)
+                .map(className -> {
+                    final Optional<ClassElement> classElement = context.getClassElement(className);
+                    final OpenAPI openAPI = resolveOpenAPI(context);
+                    return classElement.map(element -> resolveSchema(openAPI, null, element, context, null)).orElse(null);
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        final ComposedSchema composedSchema = new ComposedSchema();
+        if (key.equals("oneOf")) {
+            composedSchema.oneOf(namesToSchemas);
+        } else if (key.equals("anyOf")) {
+            composedSchema.anyOf(namesToSchemas);
+        } else if (key.equals("allOf")) {
+            composedSchema.allOf(namesToSchemas);
+        }
+        if (isArraySchema) {
+            schemaToValueMap(valueMap, arraySchema(composedSchema));
+        } else {
+            schemaToValueMap(valueMap, composedSchema);
+        }
     }
 
     private void bindSchemaForClassName(VisitorContext context, Map<CharSequence, Object> valueMap, String className) {
@@ -765,6 +787,16 @@ abstract class AbstractOpenApiVisitor  {
         final OpenAPI openAPI = resolveOpenAPI(context);
         if (classElement.isPresent()) {
             final Schema schema = resolveSchema(openAPI, null, classElement.get(), context, null);
+            schemaToValueMap(valueMap, schema);
+        }
+    }
+
+    private void bindSchemaForClassElement(VisitorContext context, Map<CharSequence, Object> valueMap, @Nonnull ClassElement classElement, boolean isArraySchema) {
+        final OpenAPI openAPI = resolveOpenAPI(context);
+        final Schema schema = resolveSchema(openAPI, null, classElement, context, null);
+        if (isArraySchema) {
+            schemaToValueMap(valueMap, arraySchema(schema));
+        } else {
             schemaToValueMap(valueMap, schema);
         }
     }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.openapi.visitor
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.ObjectSchema
 
 class OpenApiOperationParseSpec extends AbstractTypeElementSpec {
@@ -182,8 +183,95 @@ class MyBean {}
         operationNames.responses.'200'.content.size() == 1
         operationNames.responses.'200'.content['application/json']
         operationNames.responses.'200'.content['application/json'].schema
+        operationNames.responses."200".content["application/json"].schema instanceof ArraySchema
         operationNames.responses.'200'.content['application/json'].schema.type == "array"
         ((ArraySchema) operationNames.responses.'200'.content['application/json'].schema).items.type == "string"
+    }
+
+    void "test parse the OpenAPI @ApiResponse Content with mixed type Arrays"() {
+
+        given:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.util.List;
+
+class Pet {
+
+    private String name;
+
+    public Pet(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+class Dog extends Pet {
+
+    public Dog(String name) {
+        super(name);
+    }
+}
+
+class Cat extends Pet {
+
+    public Cat(String name) {
+        super(name);
+    }
+}
+
+@Controller("/pet")
+interface PetOperations {
+
+    @Operation(summary = "Get a list of pets",
+            description = "Get a list of pets registered in the system",
+            responses = {@ApiResponse(responseCode = "200",
+                    description = "The response for the pet request",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(oneOf = {Cat.class, Dog.class}))
+                    )
+            )}
+    )
+    @Get
+    List<? extends Pet> list();
+}
+
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+
+        Operation operation = AbstractOpenApiVisitor.testReference?.paths?.get("/pet")?.get
+
+        expect:
+        operation
+        operation.summary == "Get a list of pets"
+        operation.responses.size() == 1
+        operation.responses."200".content.size() == 1
+        operation.responses."200".content["application/json"]
+        operation.responses."200".content["application/json"].schema instanceof ArraySchema
+        ((ArraySchema) operation.responses."200".content["application/json"].schema).type == "array"
+        ((ArraySchema) operation.responses."200".content["application/json"].schema).items instanceof ComposedSchema
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.size() == 2
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf[1].$ref == 2
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.$ref == "#/components/schemas/Cat"}
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.$ref == "#/components/schemas/Dog"}
     }
 
     void "test parse the OpenAPI @ApiResponse Content with @Schema annotation"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
@@ -269,9 +269,8 @@ class MyBean {}
         ((ArraySchema) operation.responses."200".content["application/json"].schema).type == "array"
         ((ArraySchema) operation.responses."200".content["application/json"].schema).items instanceof ComposedSchema
         ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.size() == 2
-        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf[1].$ref == 2
-        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.$ref == "#/components/schemas/Cat"}
-        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.$ref == "#/components/schemas/Dog"}
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.get$ref() == "#/components/schemas/Cat"}
+        ((ComposedSchema) ((ArraySchema) operation.responses."200".content["application/json"].schema).items).oneOf.any {it.get$ref() == "#/components/schemas/Dog"}
     }
 
     void "test parse the OpenAPI @ApiResponse Content with @Schema annotation"() {


### PR DESCRIPTION
In OpenAPI mixed type arrays can be defined using `oneOf` as:
```
type: array
items:
  oneOf:
    - type: string
    - type: integer
```
Currently, it is not possible with Micronaut OpenAPI where if an operation returns mixed type array such as:
```
@Controller("/pet")
interface PetOperations {

    @Operation(summary = "Get a list of pets",
            description = "Get a list of pets registered in the system",
            responses = {@ApiResponse(responseCode = "200",
                    description = "The response for the pet request",
                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
                            array = @ArraySchema(schema = @Schema(oneOf = {Cat.class, Dog.class}))
                    )
            )}
    )
    @Get
    List<? extends Pet> list();
}
```

The generated OpenAPI YAML contains incorrect information:

```
paths:
  /pet:
    get:
      summary: Get a list of pets
      description: Get a list of pets registered in the system
      operationId: list
      parameters: []
      responses:
        200:
          description: The response for the pet request
          content:
            application/json:
              schema:
                type: object
```

The expected output is: 
```
# ...
          content:
            application/json:
              schema:
                type: "array"
                items:
                  oneOf:
                  - '#/components/schemas/Cat'
                  - '#/components/schemas/Dog'

```