### PR TITLE
#108 Updated Views Documentation

### DIFF
--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -55,6 +55,37 @@ or in Maven:
 </build>
 ----
 
+or in Maven with Groovy:
+
+.Maven + Groovy
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>micronaut.openapi.views.spec</name>
+                  <value>rapidoc.enabled=true,swagger-ui.enabled=true,swagger-ui.theme=flattop</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+</build>
+----
+
 The views will be generated to the `META-INF/swagger/views/[swagger-ui | redoc | rapidoc]` directory of your project’s class output.
 
 The following properties are supported:


### PR DESCRIPTION
For Groovy + Maven project the system properties are not passed from `compilerArgs` configuration parameter of "maven-compiler-plugin" and instead we need to set 'micronaut.openapi.views' system property via properties-maven-plugin > set-system-properties.


Here is the [Sample Application](https://github.com/puneetbehl/maven-groovy-swagger)
