### PR TITLE
Add support for rapipdf

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
@@ -136,9 +136,9 @@ public final class OpenApiViewConfig {
 
     private void render(Renderer renderer, Path outputDir, String templateName, VisitorContext visitorContext) throws IOException {
         String template = readTemplateFromClasspath(templateName);
+        template = renderer.render(template);
         template = replacePlaceHolder(template, "specURL", getSpecURL(), "");
         template = replacePlaceHolder(template, "title", getTitle(), "");
-        template = renderer.render(template);
         if (!Files.exists(outputDir)) {
             Files.createDirectories(outputDir);
         }
@@ -182,30 +182,6 @@ public final class OpenApiViewConfig {
      */
     public void setSpecFile(String specFile) {
         this.specFile = specFile;
-    }
-
-    /**
-     * Returns the rapidoc config.
-     * @return A RapidocConfig.
-     */
-    public RapidocConfig getRapidoc() {
-        return rapidocConfig;
-    }
-
-    /**
-     * Returns the redoc config.
-     * @return A RedocConfig.
-     */
-    public RedocConfig getRedoc() {
-        return redocConfig;
-    }
-
-    /**
-     * Returns the swagger-ui config.
-     * @return A SwaggerUIConfig.
-     */
-    public SwaggerUIConfig getSwaggerUi() {
-        return swaggerUIConfig;
     }
 
     @Override

--- a/openapi/src/main/java/io/micronaut/openapi/view/RapiPDFConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/RapiPDFConfig.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.view;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * RapiPDF configuration.
+ *
+ * @author croudet
+ */
+public final class RapiPDFConfig extends AbstractViewConfig implements Renderer {
+    private static final String LINK = "<script src='https://unpkg.com/rapipdf{{rapipdf.version}}/dist/rapipdf-min.js'></script>";
+    private static final String TAG = "<rapi-pdf id='rapi-pdf' {{rapipdf.attributes}}></rapi-pdf>";
+    private static final String SPEC = "document.getElementById('rapi-pdf').setAttribute('spec-url', contextPath + '{{specURL}}');";
+    private static final Map<String, Object> DEFAULT_OPTIONS = new HashMap<>(6);
+
+    // https://mrin9.github.io/RapiPdf/
+    private static final Map<String, Function<String, Object>> VALID_OPTIONS = new HashMap<>(20);
+
+    static {
+        VALID_OPTIONS.put("style", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("spec-url", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("button-label", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("button-bg", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("button-color", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("input-bg",  AbstractViewConfig::asString);
+        VALID_OPTIONS.put("input-color",  AbstractViewConfig::asString);
+        VALID_OPTIONS.put("hide-input", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("pdf-primary-color", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("pdf-alternate-color", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("pdf-title", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("pdf-footer-text", AbstractViewConfig::asString);
+        VALID_OPTIONS.put("pdf-schema-style", new EnumConverter<>(SchemaStyle.class));
+        VALID_OPTIONS.put("include-info", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("include-toc", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("include-security", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("include-api-details", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("include-api-list", AbstractViewConfig::asBoolean);
+        
+        DEFAULT_OPTIONS.put("style", "width: 122px;height: 25px;font-size: 15px;display: inline-block;padding-bottom: -15px;padding-top: 5px;padding-left: 12px;margin-left: 12px");
+        DEFAULT_OPTIONS.put("hide-input", Boolean.TRUE);
+        DEFAULT_OPTIONS.put("button-bg", "#b44646");
+        DEFAULT_OPTIONS.put("pdf-title", "{{title}}");
+    }
+
+    /**
+     * Rapipdf schema styles.
+     */
+    enum SchemaStyle {
+        OBJECT, TABLE;
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase(Locale.US);
+        }
+    }
+    
+    private boolean enabled; //false
+
+    private RapiPDFConfig() {
+        super("rapipdf.");
+    }
+
+    /**
+     * Builds a RapiPDFConfig given a set of properties.
+     * @param properties A set of properties.
+     * @return A RapipdfConfig.
+     */
+    static RapiPDFConfig fromProperties(Map<String, String> properties) {
+        RapiPDFConfig cfg = new RapiPDFConfig();
+        cfg.enabled = "true".equals(properties.getOrDefault("rapipdf.enabled", Boolean.FALSE.toString()));
+        return AbstractViewConfig.fromProperties(cfg, DEFAULT_OPTIONS, properties);
+    }
+
+    @Override
+    public String render(String template) {
+        if (enabled) {
+            String script = OpenApiViewConfig.replacePlaceHolder(LINK, "rapipdf.version", version, "@");
+            String rapipdfTag = OpenApiViewConfig.replacePlaceHolder(TAG, "rapipdf.attributes", toHtmlAttributes(), "");
+            template = OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.script", script, "");
+            template = OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.specurl", SPEC, "");
+            return OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.tag", rapipdfTag, "");
+        } else {
+            template = OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.script", "", "");
+            template = OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.specurl", "", "");
+            return OpenApiViewConfig.replacePlaceHolder(template, "rapipdf.tag", "", "");
+        }
+    }
+
+    @Override
+    protected Function<String, Object> getConverter(String key) {
+        return VALID_OPTIONS.get(key);
+    }
+}

--- a/openapi/src/main/java/io/micronaut/openapi/view/RapidocConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/RapidocConfig.java
@@ -164,6 +164,8 @@ public final class RapidocConfig extends AbstractViewConfig implements Renderer 
         }
     }
 
+    private RapiPDFConfig rapiPDFConfig;
+
     private RapidocConfig() {
         super("rapidoc.");
     }
@@ -174,11 +176,14 @@ public final class RapidocConfig extends AbstractViewConfig implements Renderer 
      * @return A RapidocConfig.
      */
     static RapidocConfig fromProperties(Map<String, String> properties) {
-        return AbstractViewConfig.fromProperties(new RapidocConfig(), DEFAULT_OPTIONS, properties);
+        RapidocConfig cfg = new RapidocConfig();
+        cfg.rapiPDFConfig = RapiPDFConfig.fromProperties(properties);
+        return AbstractViewConfig.fromProperties(cfg, DEFAULT_OPTIONS, properties);
     }
 
     @Override
     public String render(String template) {
+        template = rapiPDFConfig.render(template);
         template = OpenApiViewConfig.replacePlaceHolder(template, "rapidoc.version", version, "@");
         return OpenApiViewConfig.replacePlaceHolder(template, "rapidoc.attributes", toHtmlAttributes(), "");
     }

--- a/openapi/src/main/java/io/micronaut/openapi/view/RedocConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/RedocConfig.java
@@ -23,8 +23,6 @@ import java.util.function.Function;
 /**
  * ReDoc configuration.
  *
- * Currently only the version can be set.
- *
  * @author croudet
  */
 public final class RedocConfig extends AbstractViewConfig implements Renderer {

--- a/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 /**
  * Swagger-ui configuration.
- * https://github.com/ostranme/swagger-ui-themes/tree/develop/themes/3.x
+ *
  * @author croudet
  */
 public final class SwaggerUIConfig extends AbstractViewConfig implements Renderer {
@@ -114,14 +114,6 @@ public final class SwaggerUIConfig extends AbstractViewConfig implements Rendere
             template = template.replace("{{swagger-ui.theme}}", "");
         }
         return template;
-    }
-
-    /**
-     * Returns the version of swagger-ui to use.
-     * @return The version.
-     */
-    public String getVersion() {
-        return version;
     }
 
     @Override

--- a/openapi/src/main/resources/templates/rapidoc/index.html
+++ b/openapi/src/main/resources/templates/rapidoc/index.html
@@ -7,9 +7,10 @@
         <meta charset='utf-8' />
         <meta name='viewport' content='width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes' />
         <script src='https://unpkg.com/rapidoc{{rapidoc.version}}/dist/rapidoc-min.js'></script>
+        {{rapipdf.script}}
     </head>
     <body>
-        <rapi-doc id='rapidoc' {{rapidoc.attributes}}></rapi-doc>
+        <rapi-doc id='rapidoc' {{rapidoc.attributes}}>{{rapipdf.tag}}</rapi-doc>
         <script>
             const extract = function(v) {
                     return decodeURIComponent(v.replace(/(?:(?:^|.*;\s*)contextPath\s*\=\s*([^;]*).*$)|^.*$/, "$1"));
@@ -24,6 +25,7 @@
                 });
             }
             rapidoc.setAttribute('spec-url', contextPath + '{{specURL}}');
+            {{rapipdf.specurl}}
         </script>
     </body>
 </html>

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewParseSpec.groovy
@@ -37,9 +37,9 @@ class OpenApiOperationViewParseSpec extends Specification {
         expect:
         cfg.enabled == true
         cfg.mappingPath == "somewhere"
-        cfg.rapidoc != null
-        cfg.redoc != null
-        cfg.swaggerUi != null
+        cfg.rapidocConfig != null
+        cfg.redocConfig != null
+        cfg.swaggerUIConfig != null
     }
     
     void "test parse OpenApiView specification, redoc enabled"() {
@@ -50,10 +50,10 @@ class OpenApiOperationViewParseSpec extends Specification {
         expect:
         cfg.enabled == true
         cfg.mappingPath == "swagger"
-        cfg.rapidoc == null
-        cfg.swaggerUi == null
-        cfg.redoc != null
-        cfg.redoc.version == "version123"
+        cfg.rapidocConfig == null
+        cfg.swaggerUIConfig == null
+        cfg.redocConfig != null
+        cfg.redocConfig.version == "version123"
     }
     
     void "test parse OpenApiView specification, rapidoc enabled"() {
@@ -64,12 +64,12 @@ class OpenApiOperationViewParseSpec extends Specification {
         expect:
         cfg.enabled == true
         cfg.mappingPath == "swagger"
-        cfg.redoc == null
-        cfg.swaggerUi == null
-        cfg.rapidoc != null
-        cfg.rapidoc.version == "version123"
-        cfg.rapidoc.options['theme'] == RapidocConfig.Theme.LIGHT
-        cfg.rapidoc.options['layout'] == RapidocConfig.Layout.ROW
+        cfg.redocConfig == null
+        cfg.swaggerUIConfig == null
+        cfg.rapidocConfig != null
+        cfg.rapidocConfig.version == "version123"
+        cfg.rapidocConfig.options['theme'] == RapidocConfig.Theme.LIGHT
+        cfg.rapidocConfig.options['layout'] == RapidocConfig.Layout.ROW
     }
     
     void "test parse OpenApiView specification, swagger-ui enabled"() {
@@ -80,11 +80,11 @@ class OpenApiOperationViewParseSpec extends Specification {
         expect:
         cfg.enabled == true
         cfg.mappingPath == "swagger"
-        cfg.redoc == null
-        cfg.rapidoc == null
-        cfg.swaggerUi != null
-        cfg.swaggerUi.version == "version123"
-        cfg.swaggerUi.theme == SwaggerUIConfig.Theme.FLATTOP
-        cfg.swaggerUi.options['deepLinking'] == false
+        cfg.redocConfig == null
+        cfg.rapidocConfig == null
+        cfg.swaggerUIConfig != null
+        cfg.swaggerUIConfig.version == "version123"
+        cfg.swaggerUIConfig.theme == SwaggerUIConfig.Theme.FLATTOP
+        cfg.swaggerUIConfig.options['deepLinking'] == false
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewRenderSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewRenderSpec.groovy
@@ -40,9 +40,9 @@ class OpenApiOperationViewRenderSpec extends Specification {
         expect:
         cfg.enabled == true
         cfg.mappingPath == "somewhere"
-        cfg.rapidoc != null
-        cfg.redoc != null
-        cfg.swaggerUi != null
+        cfg.rapidocConfig != null
+        cfg.redocConfig != null
+        cfg.swaggerUIConfig != null
         cfg.title == "OpenAPI documentation"
         cfg.specFile == "swagger.yml"
         cfg.specURL == "/somewhere/swagger.yml"

--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -1,4 +1,4 @@
-Micronaut can generate views for your generated OpenApi specification. Currently https://github.com/swagger-api/swagger-ui[swagger-ui], https://github.com/Rebilly/ReDoc[redoc] and https://github.com/mrin9/RapiDoc[rapidoc] are supported.
+Micronaut can generate views for your generated OpenApi specification. Currently https://github.com/swagger-api/swagger-ui[swagger-ui], https://github.com/Rebilly/ReDoc[redoc] and https://github.com/mrin9/RapiDoc[rapidoc] are supported. With _rapidoc_ you can also use https://mrin9.github.io/RapiPdf/[rapipdf] to generate a PDF from your spec file.
 
 The resources needed to render the views (javascript, css, ...) are loaded from CDNs: https://unpkg.com[unpkg.com] and https://fonts.googleapis.com/[fonts.googleapis.com].
 
@@ -97,11 +97,18 @@ The following properties are supported:
  * `redoc.version=[string]`: The version of redoc to use. Default is to use the latest available.
  * `redoc.[expand-default-server-variables, menu-toggle, only-required-in-samples, payload-sample-idx, sort-props-alphabetically, untrusted-spec, expand-responses, show-extensions, native-scrollbars, path-in-middle-panel, suppress-warnings, hide-hostname, disable-search, json-sample-expand-level, scroll-y-offset, hide-download-button, no-auto-auth, theme, hide-single-request-sample-tab, required-props-first, hide-loading]`. See https://github.com/Redocly/redoc#redoc-options-object for a description.
  * `rapidoc.version=[string]`: The version of rapidoc to use. Default is to use the latest available.
- * `rapidoc.[schema-style, allow-api-list-style-selection, nav-accent-color, show-header, schema-expand-level, response-area-height, allow-authentication, default-api-server, match-paths, allow-server-selection, api-key-name, nav-hover-bg-color, goto-path, theme, text-color, bg-color, api-key-value, header-color, primary-color, sort-tags, nav-bg-color, render-style, heading-text, allow-try, layout, sort-endpoints-by, allow-spec-url-load, nav-text-color, nav-hover-text-color, show-info, regular-font, allow-spec-file-load, server-url, schema-description-expanded, allow-search, api-key-location, mono-font, default-schema-tab]`. See https://mrin9.github.io/RapiDoc/api.html for a descriptions.
+ * `rapidoc.[schema-style, allow-api-list-style-selection, nav-accent-color, show-header, schema-expand-level, response-area-height, allow-authentication, default-api-server, match-paths, allow-server-selection, api-key-name, nav-hover-bg-color, goto-path, theme, text-color, bg-color, api-key-value, header-color, primary-color, sort-tags, nav-bg-color, render-style, heading-text, allow-try, layout, sort-endpoints-by, allow-spec-url-load, nav-text-color, nav-hover-text-color, show-info, regular-font, allow-spec-file-load, server-url, schema-description-expanded, allow-search, api-key-location, mono-font, default-schema-tab]`. See https://mrin9.github.io/RapiDoc/api.html for a description.
  * `swagger-ui.version=[string]`: The version of swagger-ui to use. Default is to use the latest available.
  * `swagger-ui.[displayOperationId, oauth2RedirectUrl, showMutatedRequest, deepLinking, supportedSubmitMethods, defaultModelsExpandDepth, layout, defaultModelRendering, docExpansion, filter, validatorUrl, showCommonExtensions, maxDisplayedTags, withCredentials, displayRequestDuration, showExtensions]`. See https://github.com/swagger-api/swagger-ui/blob/HEAD/docs/usage/configuration.md for a description.
  * `swagger-ui.theme=[DEFAULT | MATERIAL | FEELING_BLUE | FLATTOP | MONOKAI | MUTED | NEWSPAPER | OUTLINE]`: The theme of swagger-ui to use. These are case insensitive. Default is `DEFAULT`. See https://github.com/ostranme/swagger-ui-themes
  
+Rapidoc also supports RapiPDF, to enable it use `rapipdf.enabled=true`.
+It will add a button to the view to generate a PDF from the spec file.
+
+Rapipdf supports the following options:
+
+ * `rapipdf.[include-api-details, pdf-title, include-api-list, include-security, input-bg, hide-input, pdf-footer-text, button-bg, pdf-primary-color, pdf-schema-style, button-label, pdf-alternate-color, include-info, include-toc, button-color, style, input-color, spec-url]`. See https://mrin9.github.io/RapiPdf/ for a description.
+
 To expose the views, you also must expose the generated `yaml`:
 
 .Exposing Swagger YAML And Views


### PR DESCRIPTION
rapipdf allows to generate a PDF from a spec file (in the browser).

Adds a button to rapidoc view when enabled.