### PR TITLE
Ensure the Schema name isn't null when merged in

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -180,6 +180,13 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             Optional.ofNullable(from.getPaths()).ifPresent(paths -> paths.forEach(to::path));
             Optional.ofNullable(from.getComponents()).ifPresent(components -> {
                 Map<String, Schema> schemas = components.getSchemas();
+
+                schemas.forEach((k, v) -> {
+                  if (v.getName() == null) {
+                    v.setName(k); 
+                  }
+                });
+                
                 if (schemas != null && !schemas.isEmpty()) {
                     schemas.forEach(to::schema);
                 }


### PR DESCRIPTION
I'm somewhat confused by this problem. I have a project where I'm merging in a custom made openapi file containing schemas to replace the micronaut-generated schemas. Since the object schemas being replaced are `@AutoValue` objects that don't lend themselves well for generation like ordinary beans do, this for now seems like the easiest option to achieve a full openapi spec.

Trying it out with a simple proof of concept, this seems to work well. However when I implement the same thing in the greater project, every Schema that I'm trying to overwrite has a null reference. (i.e. `#/components/schemas/null`, rather than `#/components/schemas/Foo`). I haven't been able to figure out why this should be the case (as I'm having trouble debugging this issue, maven's forked compile goal seems to hide all errors and logging) - the projects are as far as I can see identically configured (https://micronaut-projects.github.io/micronaut-openapi/latest/guide/index.html#mergingSchemas), yet yield different results when processed. I'm hoping someone here can enlighten me as to what might be the cause of this, despite me not being able to provide a means of demonstrating this behaviour.

Either way, the enclosed patch seems to resolve the issue. It makes sure the schema name is set before merging with the existing spec.

Happy to learn what might be going on here. Thanks and cheers.