### PR TITLE
Fix: server context must be added to spec-url

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.visitor.VisitorContext;
 
 /**
@@ -47,6 +48,7 @@ public final class OpenApiViewConfig {
     private String mappingPath;
     private String title;
     private String specFile;
+    private String serverContextPath = "";
     private SwaggerUIConfig swaggerUIConfig;
     private RedocConfig redocConfig;
     private RapidocConfig rapidocConfig;
@@ -164,6 +166,14 @@ public final class OpenApiViewConfig {
     }
 
     /**
+     * Sets the server context path.
+     * @param contextPath The server context path.
+     */
+    public void setServerContextPath(String contextPath) {
+        this.serverContextPath = contextPath == null ? "" : contextPath;
+    }
+
+    /**
      * Returns the title for the generated views.
      * @return A title.
      */
@@ -184,7 +194,7 @@ public final class OpenApiViewConfig {
      * @return A path.
      */
     public String getSpecURL() {
-        return '/' + mappingPath + '/' + specFile;
+        return StringUtils.prependUri(serverContextPath, StringUtils.prependUri(mappingPath, specFile));
     }
 
     /**

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -313,6 +313,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         if (cfg.isEnabled()) {
             cfg.setTitle(title);
             cfg.setSpecFile(specFile);
+            cfg.setServerContextPath(getConfigurationProperty(MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH));
             cfg.render(destinationDir.resolve("views"), visitorContext);
         }
     }

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewRenderSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewRenderSpec.groovy
@@ -15,11 +15,13 @@
  */
 package io.micronaut.openapi.view
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 import io.micronaut.openapi.view.OpenApiViewConfig
+import io.micronaut.openapi.visitor.OpenApiApplicationVisitor
 import spock.lang.Specification
 
 class OpenApiOperationViewRenderSpec extends Specification {
@@ -29,6 +31,59 @@ class OpenApiOperationViewRenderSpec extends Specification {
     }
 
     void "test render OpenApiView specification"() {
+        given:
+        String spec = "redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true"
+        OpenApiViewConfig cfg = OpenApiViewConfig.fromSpecification(spec, new Properties())
+        Path outputDir = Paths.get("output")
+        cfg.title = "OpenAPI documentation"
+        cfg.specFile = "swagger.yml"
+        cfg.render(outputDir, null)
+
+        expect:
+        cfg.enabled == true
+        cfg.mappingPath == "swagger"
+        cfg.rapidocConfig != null
+        cfg.redocConfig != null
+        cfg.swaggerUIConfig != null
+        cfg.title == "OpenAPI documentation"
+        cfg.specFile == "swagger.yml"
+        cfg.specURL == "/swagger/swagger.yml"
+        Files.exists(outputDir.resolve("redoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("rapidoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("swagger-ui").resolve("index.html"))
+        outputDir.resolve("redoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("rapidoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("swagger-ui").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+    }
+
+    void "test render OpenApiView specification with server context path"() {
+        given:
+        String spec = "redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true"
+        OpenApiViewConfig cfg = OpenApiViewConfig.fromSpecification(spec, new Properties())
+        Path outputDir = Paths.get("output")
+        cfg.title = "OpenAPI documentation"
+        cfg.specFile = "swagger.yml"
+        cfg.serverContextPath = "/context-path"
+        cfg.render(outputDir, null)
+
+        expect:
+        cfg.enabled == true
+        cfg.mappingPath == "swagger"
+        cfg.rapidocConfig != null
+        cfg.redocConfig != null
+        cfg.swaggerUIConfig != null
+        cfg.title == "OpenAPI documentation"
+        cfg.specFile == "swagger.yml"
+        cfg.specURL == "/context-path/swagger/swagger.yml"
+        Files.exists(outputDir.resolve("redoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("rapidoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("swagger-ui").resolve("index.html"))
+        outputDir.resolve("redoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("rapidoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("swagger-ui").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+    }
+
+    void "test render OpenApiView specification custom mapping path"() {
         given:
         String spec = "mapping.path=somewhere,redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true"
         OpenApiViewConfig cfg = OpenApiViewConfig.fromSpecification(spec, new Properties())
@@ -49,6 +104,35 @@ class OpenApiOperationViewRenderSpec extends Specification {
         Files.exists(outputDir.resolve("redoc").resolve("index.html"))
         Files.exists(outputDir.resolve("rapidoc").resolve("index.html"))
         Files.exists(outputDir.resolve("swagger-ui").resolve("index.html"))
+        outputDir.resolve("redoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("rapidoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("swagger-ui").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
     }
 
+    void "test render OpenApiView specification with custom mapping path and server context path"() {
+        given:
+        String spec = "mapping.path=somewhere,redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true"
+        OpenApiViewConfig cfg = OpenApiViewConfig.fromSpecification(spec, new Properties())
+        Path outputDir = Paths.get("output")
+        cfg.title = "OpenAPI documentation"
+        cfg.specFile = "swagger.yml"
+        cfg.serverContextPath = "/context-path"
+        cfg.render(outputDir, null)
+
+        expect:
+        cfg.enabled == true
+        cfg.mappingPath == "somewhere"
+        cfg.rapidocConfig != null
+        cfg.redocConfig != null
+        cfg.swaggerUIConfig != null
+        cfg.title == "OpenAPI documentation"
+        cfg.specFile == "swagger.yml"
+        cfg.specURL == "/context-path/somewhere/swagger.yml"
+        Files.exists(outputDir.resolve("redoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("rapidoc").resolve("index.html"))
+        Files.exists(outputDir.resolve("swagger-ui").resolve("index.html"))
+        outputDir.resolve("redoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("rapidoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+        outputDir.resolve("swagger-ui").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains(cfg.getSpecURL())
+    }
 }


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-openapi/pull/170
add the ablity to add context path at compile time by prepending openapi spec paths with it
but was missing adding context-path to spec-url in generated views.