### PR TITLE
Issue #204 - Bad option name 'micronaut.openapi.server.context-path' …

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -83,7 +83,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     /**
      * System property for server context path.
      */
-    public static final String MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH = "micronaut.openapi.server.context-path";
+    public static final String MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH = "micronaut.openapi.server.context.path";
     /**
      * System property for naming strategy. One jackson PropertyNamingStrategy.
      */

--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -154,7 +154,7 @@ In micronaut configuration file you can define a server context path (with `micr
 Since the yaml specification file and the views are generated at compile time, these resources are not aware of this runtime setting.
 
 It is still possible for the views to work in case a context path is defined:
-* Set `micronaut.openapi.server.context-path` property for compile time resolution,
+* Set `micronaut.openapi.server.context.path` property for compile time resolution,
 * Use a `HttpServerFilter` that will add a cookie, or
 * Add a parameter to the url.
 
@@ -162,7 +162,7 @@ The view will first look for the cookie and if not present for the parameter.
 
 === Compile Time Resolution
 
-Either set `micronaut.openapi.server.context-path` as a System Property or in `openapi.properties`, then all paths will be prepend with the
+Either set `micronaut.openapi.server.context.path` as a System Property or in `openapi.properties`, then all paths will be prepend with the
 specified value at compile time.
 
 If you want the resolution of the context path at runtime use one of the following methods:


### PR DESCRIPTION
…provided by processor

Looks like '-' is not allowed in processor option name.
https://docs.oracle.com/javase/7/docs/api/javax/annotation/processing/Processor.html#getSupportedOptions()

renamed `micronaut.openapi.server.context-path` to `micronaut.openapi.server.context.path`