### PR TITLE
Added kapt config for Kotlin projects basedo on gradle

### DIFF
--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -21,6 +21,16 @@ JAVA_TOOL_OPTIONS=-Dmicronaut.openapi.views.spec=redoc.enabled=true,rapidoc.enab
         ./gradlew --no-daemon clean assemble
 ----
 
+or in build.gradle as well:
+[source,kotlin]
+----
+kapt {
+    arguments {
+        arg("micronaut.openapi.views.spec", "redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true,swagger-ui.theme=flattop")
+    }
+}
+
+----
 or in Gradle for Java projects:
 
 .Gradle


### PR DESCRIPTION
There is a possibilitiy to add arguments directly to kapt, not only through system properties.