### PR TITLE
Issue #274 - Take schema description from class javadoc.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/openapi/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElementExt.java
+++ b/openapi/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElementExt.java
@@ -83,8 +83,13 @@ public class JavaClassElementExt extends JavaClassElement {
     }
 
     private static boolean sameType(String type, DeclaredType dt) {
-        Element elt = dt.asElement();
-        return (elt instanceof TypeElement) && type.equals(((TypeElement) elt).getQualifiedName().toString());
+        final Element elt = dt.asElement();
+        return elt instanceof TypeElement && type.equals(((TypeElement) elt).getQualifiedName().toString());
+    }
+
+    @Override
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(visitorContext.getElements().getDocComment(classElement));
     }
 
     @Override
@@ -138,7 +143,7 @@ public class JavaClassElementExt extends JavaClassElement {
         WildcardType wType = (WildcardType) dType.getTypeArguments().iterator().next();
         TypeMirror tm = wType.getSuperBound();
         // check for Void
-        if ((tm instanceof DeclaredType) && sameType("kotlin.Unit", (DeclaredType) tm)) {
+        if (tm instanceof DeclaredType && sameType("kotlin.Unit", (DeclaredType) tm)) {
             return new JavaVoidElement();
         } else {
             return ((JavaParameterElement) parameter).parameterizedClassElement(tm, jcontext, info);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -641,12 +641,12 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
     private JavadocDescription getMethodDescription(MethodElement element,
             io.swagger.v3.oas.models.Operation swaggerOperation) {
         String descr = description(element);
-        JavadocDescription javadocDescription = element.getDocumentation().map(s -> new JavadocParser().parse(s))
-                .orElse(null);
         if (StringUtils.isNotEmpty(descr) && StringUtils.isEmpty(swaggerOperation.getDescription())) {
             swaggerOperation.setDescription(descr);
             swaggerOperation.setSummary(descr);
         }
+        JavadocDescription javadocDescription = element.getDocumentation().map(s -> new JavadocParser().parse(s))
+                .orElse(null);
         if (javadocDescription != null && StringUtils.isEmpty(swaggerOperation.getDescription())) {
             swaggerOperation.setDescription(javadocDescription.getMethodDescription());
             swaggerOperation.setSummary(javadocDescription.getMethodDescription());

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -788,14 +788,7 @@ abstract class AbstractOpenApiVisitor  {
             element.findAnnotation(Pattern.class).flatMap(p -> p.get("regexp", String.class)).ifPresent(finalSchemaToBind::setPattern);
         }
 
-        Optional<String> documentation = element.getDocumentation();
-        if (StringUtils.isEmpty(schemaToBind.getDescription())) {
-            String doc = documentation.orElse(null);
-            if (doc != null) {
-                JavadocDescription desc = new JavadocParser().parse(doc);
-                schemaToBind.setDescription(desc.getMethodDescription());
-            }
-        }
+        setSchemaDocumentation(element, schemaToBind);
         if (element.isAnnotationPresent(Deprecated.class)) {
             schemaToBind.setDeprecated(true);
         }
@@ -808,6 +801,17 @@ abstract class AbstractOpenApiVisitor  {
             schemaToBind.setNullable(true);
         }
         return schemaToBind;
+    }
+
+    private void setSchemaDocumentation(Element element, Schema schemaToBind) {
+        if (StringUtils.isEmpty(schemaToBind.getDescription())) {
+            Optional<String> documentation = element.getDocumentation();
+            String doc = documentation.orElse(null);
+            if (doc != null) {
+                JavadocDescription desc = new JavadocParser().parse(doc);
+                schemaToBind.setDescription(desc.getMethodDescription());
+            }
+        }
     }
 
     /**
@@ -1083,8 +1087,10 @@ abstract class AbstractOpenApiVisitor  {
             }
         }
         if (schema != null) {
+            setSchemaDocumentation(type, schema);
             Schema schemaRef = new Schema();
             schemaRef.set$ref(schemaRef(schema.getName()));
+            schemaRef.setDescription(schema.getDescription());
             return schemaRef;
         }
         return null;

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiArraySchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiArraySchemaSpec.groovy
@@ -73,7 +73,7 @@ class MyBean {}
         openAPI.components.schemas['Pets'].properties['pets'].description == 'a list of Pets'
         openAPI.components.schemas['Pets'].properties['pets'].minItems == 2
         openAPI.components.schemas['Pets'].properties['pets'].items.$ref == '#/components/schemas/Pet'
-        openAPI.components.schemas['Pets'].properties['pets'].items.description == null
+        openAPI.components.schemas['Pets'].properties['pets'].items.description == 'Pet'
         openAPI.components.schemas['Pets'].properties['pets'].items.nullable == null
 
         openAPI.components.schemas['Pets'].properties['ids'].nullable == false


### PR DESCRIPTION
Unfortunately it does not work for $ref, swagger ignore all others properties when set:
https://github.com/swagger-api/swagger-core/blob/1aa6f1f82c5a3e7e075e8dba606d2210da70a097/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SchemaSerializer.java#L29

```java
@Override
    public void serialize(
            Schema value, JsonGenerator jgen, SerializerProvider provider)
            throws IOException {

        // handle ref schema serialization skipping all other props
        if (StringUtils.isBlank(value.get$ref())) {
            defaultSerializer.serialize(value, jgen, provider);
        } else {
            jgen.writeStartObject();
            jgen.writeStringField("$ref", value.get$ref());
            jgen.writeEndObject();
        }
    }
```