### PR TITLE
#108 Generating an OpenAPI view with Kotlin

### DIFF
--- a/src/main/docs/guide/openApiViews.adoc
+++ b/src/main/docs/guide/openApiViews.adoc
@@ -21,6 +21,12 @@ JAVA_TOOL_OPTIONS=-Dmicronaut.openapi.views.spec=redoc.enabled=true,rapidoc.enab
         ./gradlew --no-daemon clean assemble
 ----
 
+or in gradle.properties:
+[source,properties]
+----
+org.gradle.jvmargs=-Dmicronaut.openapi.views.spec=redoc.enabled=true,rapidoc.enabled=true,swagger-ui.enabled=true,swagger-ui.theme=flattop
+----
+
 or in build.gradle as well:
 [source,kotlin]
 ----


### PR DESCRIPTION
In a multi-module gradle project that used Kotlin with a kotlin script file instead of a groovy script file, I was able to successfully generate the Open API views when setting the `org.gradle.jvmargs` property. This allowed me to not have to use the environment variable approach to generate the views correctly. When trying to use the `kapt` block in my `build.gradle.kts`, I could not successfully generate the views.