### PR TITLE
Documentation change for PropertyNamingStrategy

### DIFF
--- a/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
+++ b/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
@@ -113,6 +113,11 @@ tasks.withType(JavaCompile) {
 }
 ----
 
+or in gradle.properties 
+----
+org.gradle.jvmargs=-Dmicronaut.openapi.property.naming.strategy=SNAKE_CASE
+----
+
 or in maven:
 
 .Maven


### PR DESCRIPTION
In a Kotlin only project the system property `micronaut.openapi.property.naming.strategy` can be set in the `gradle.properties` file and will reflect the changes in the generated open api yml file.