### PR TITLE
Change the group id of the openapi dependency

### DIFF
--- a/src/main/docs/guide/gettingStarted.adoc
+++ b/src/main/docs/guide/gettingStarted.adoc
@@ -1,6 +1,6 @@
 To enable this support you should add the following dependencies to your build configuration:
 
-dependency:micronaut-openapi[scope="annotationProcessor", version="{version}", groupId="io.micronaut.configuration"]
+dependency:micronaut-openapi[scope="annotationProcessor", version="{version}", groupId="io.micronaut.openapi"]
 
 Then the following compile time dependency:
 


### PR DESCRIPTION
As of the 2.0.0 release it appears that the maven group was changed to io.micronaut.openapi.