### PR TITLE
Generate schema for inner classes with `dot` instead of `dollar`

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -1256,10 +1256,13 @@ abstract class AbstractOpenApiVisitor  {
         if (metaAnnName != null && !io.swagger.v3.oas.annotations.media.Schema.class.getName().equals(metaAnnName)) {
             return NameUtils.getSimpleName(metaAnnName);
         }
+        String javaName;
         if (type instanceof TypedElement) {
-            return computeNameWithGenerics(((TypedElement) type).getType());
+            javaName = computeNameWithGenerics(((TypedElement) type).getType());
+        } else {
+            javaName = type.getSimpleName();
         }
-        return type.getSimpleName();
+        return javaName.replace("$", ".");
     }
 
     private String computeNameWithGenerics(ClassElement classElement) {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -44,6 +44,7 @@ class Pet {
     private int age;
     private String name;
     private List<String> tags;
+    public InnerBean inner;
 
     public void setAge(int a) {
         age = a;
@@ -84,6 +85,10 @@ class Pet {
     public void setTags(List<String> tags) {
         this.tags = tags;
     }
+    
+    public static class InnerBean {
+        public String xyz;
+    }
 }
 
 @javax.inject.Singleton
@@ -95,10 +100,12 @@ class MyBean {}
         when:"The OpenAPI is retrieved"
         OpenAPI openAPI = AbstractOpenApiVisitor.testReference
         Schema petSchema = openAPI.components.schemas['Pet']
+        Schema petInnerBeanSchema = openAPI.components.schemas['Pet.InnerBean']
 
         then:"the components are valid"
+        petInnerBeanSchema
         petSchema.type == 'object'
-        petSchema.properties.size() == 3
+        petSchema.properties.size() == 4
 
         petSchema.properties["tags"].type == "array"
         petSchema.properties["tags"].description == "The Pet Tags"


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-openapi/issues/286

`$` is not allowed by OpenApi: `Component names can only contain the characters A-Z a-z 0-9 - . _`