### PR TITLE
Generate response mapping with status code instead of "default"

### DIFF
--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
@@ -318,10 +318,10 @@ class MyBean {}
         then:"it is included in the OpenAPI doc"
         pathItem.get.operationId == 'list'
         pathItem.get.description == 'List the pets'
-        pathItem.get.responses['default']
-        pathItem.get.responses['default'].description == 'a list of pet names'
-        pathItem.get.responses['default'].content['application/json'].schema
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'array'
+        pathItem.get.responses['200']
+        pathItem.get.responses['200'].description == 'a list of pet names'
+        pathItem.get.responses['200'].content['application/json'].schema
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'array'
 
         when:"the /{slug} path is retrieved"
         pathItem = openAPI.paths.get("/pets/{slug}")
@@ -337,8 +337,8 @@ class MyBean {}
         pathItem.get.parameters[0].description == 'The slug name'
         pathItem.get.parameters[0].schema.type == 'string'
         pathItem.get.responses.size() == 1
-        pathItem.get.responses['default'] != null
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
+        pathItem.get.responses['200'] != null
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'string'
 
         when:"the /extras/{extraId} path is retrieved"
         pathItem = openAPI.paths.get("/pets/extras/{extraId}")
@@ -351,16 +351,16 @@ class MyBean {}
         pathItem.get.parameters[0].schema
         pathItem.get.parameters[0].schema.type == 'string'
         pathItem.get.responses.size() == 1
-        pathItem.get.responses['default'] != null
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
+        pathItem.get.responses['200'] != null
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'string'
 
         when:"the /getSomething path is retrieved"
         pathItem = openAPI.paths.get("/pets/random")
 
         then:"default response has default description"
         pathItem.get.operationId == 'getRandomPet'
-        pathItem.get.responses['default'].description == 'getRandomPet default response'
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
+        pathItem.get.responses['200'].description == 'getRandomPet 200 response'
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'string'
 
     }
 
@@ -430,10 +430,10 @@ class MyBean {}
         then:"it is included in the OpenAPI doc"
         pathItem.get.operationId == 'list'
         pathItem.get.description == 'List the pets'
-        pathItem.get.responses['default']
-        pathItem.get.responses['default'].description == 'a list of pet names'
-        pathItem.get.responses['default'].content['application/json'].schema
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'array'
+        pathItem.get.responses['200']
+        pathItem.get.responses['200'].description == 'a list of pet names'
+        pathItem.get.responses['200'].content['application/json'].schema
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'array'
         pathItem.post.operationId == 'save'
         pathItem.post.requestBody
         pathItem.post.requestBody.required
@@ -455,18 +455,18 @@ class MyBean {}
         pathItem.get.parameters[0].description == 'The slug name'
         pathItem.get.parameters[0].schema.type == 'string'
         pathItem.get.responses.size() == 1
-        pathItem.get.responses['default'] != null
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'string'
+        pathItem.get.responses['200'] != null
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'string'
 
         when:"A flowable is returned"
         pathItem = openAPI.paths.get("/pets/flowable")
 
         then:
         pathItem.get.operationId == 'flowable'
-        pathItem.get.responses['default']
-        pathItem.get.responses['default'].description == 'a list of pet names'
-        pathItem.get.responses['default'].content['application/json'].schema
-        pathItem.get.responses['default'].content['application/json'].schema.type == 'array'
+        pathItem.get.responses['200']
+        pathItem.get.responses['200'].description == 'a list of pet names'
+        pathItem.get.responses['200'].content['application/json'].schema
+        pathItem.get.responses['200'].content['application/json'].schema.type == 'array'
     }
 
     void "test parse custom parameter data"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
@@ -325,11 +325,11 @@ class MyBean {}
         operation
         operation.responses
         operation.responses.size() == 1
-        operation.responses."default"
-        operation.responses."default".content
-        operation.responses."default".content."application/json"
-        operation.responses."default".content."application/json".schema
-        operation.responses."default".content."application/json".schema.$ref
+        operation.responses."200"
+        operation.responses."200".content
+        operation.responses."200".content."application/json"
+        operation.responses."200".content."application/json".schema
+        operation.responses."200".content."application/json".schema.$ref
     }
 
     void "test build OpenAPI doc for POJO with Inheritance and discriminator mapping"() {
@@ -529,11 +529,11 @@ class MyBean {}
         operation
         operation.responses
         operation.responses.size() == 1
-        operation.responses."default"
-        operation.responses."default".content
-        operation.responses."default".content."application/json"
-        operation.responses."default".content."application/json".schema
-        operation.responses."default".content."application/json".schema.$ref
+        operation.responses."200"
+        operation.responses."200".content
+        operation.responses."200".content."application/json"
+        operation.responses."200".content."application/json".schema
+        operation.responses."200".content."application/json".schema.$ref
     }
 
     void "test build OpenAPI doc for POJO with inheritance"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationHeadersSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationHeadersSpec.groovy
@@ -69,10 +69,10 @@ class MyBean {}
         expect:
         operation
         operation.responses.size() == 1
-        operation.responses.default.headers.size() == 1
-        operation.responses.default.headers['X-Rate-Limit-Limit'].description == 'The number of allowed requests in the current period'
-        operation.responses.default.headers['X-Rate-Limit-Limit'].schema
-        operation.responses.default.headers['X-Rate-Limit-Limit'].schema.type == 'integer'
+        operation.responses['200'].headers.size() == 1
+        operation.responses['200'].headers['X-Rate-Limit-Limit'].description == 'The number of allowed requests in the current period'
+        operation.responses['200'].headers['X-Rate-Limit-Limit'].schema
+        operation.responses['200'].headers['X-Rate-Limit-Limit'].schema.type == 'integer'
     }
 
     void "test parse the micronaut @Header annotation and body"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationLinkSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationLinkSpec.groovy
@@ -73,11 +73,11 @@ class MyBean {}
         expect:
         operation
         operation.responses.size() == 1
-        operation.responses.default.links.size() == 1
-        operation.responses.default.links.address.operationId == 'getAddress'
-        operation.responses.default.links.address.parameters.size() == 1
-        operation.responses.default.links.address.parameters['userId'] == '$request.query.userId'
-        operation.responses.default.links.address.extensions.'x-custom'.prop1 == "prop1Val"
+        operation.responses['200'].links.size() == 1
+        operation.responses['200'].links.address.operationId == 'getAddress'
+        operation.responses['200'].links.address.parameters.size() == 1
+        operation.responses['200'].links.address.parameters['userId'] == '$request.query.userId'
+        operation.responses['200'].links.address.extensions.'x-custom'.prop1 == "prop1Val"
 
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationParseSpec.groovy
@@ -304,9 +304,9 @@ class MyBean {}
         operation.security.get(0).containsKey('petstore-auth')
         operation.security.get(0).get('petstore-auth') == ['write:pets']
         operation.responses.size() == 4
-        operation.responses.default.content.size() == 1
-        operation.responses.default.content['application/json']
-        operation.responses.default.content['application/json'].schema
+        operation.responses.'200'.content.size() == 1
+        operation.responses.'200'.content['application/json']
+        operation.responses.'200'.content['application/json'].schema
         operation.responses.'400'.description == 'Invalid ID supplied'
 
     }
@@ -373,9 +373,9 @@ class MyBean {}
         operation.security.get(0).containsKey('petstore-auth')
         operation.security.get(0).get('petstore-auth') == ['write:pets']
         operation.responses.size() == 4
-        operation.responses.default.content.size() == 1
-        operation.responses.default.content['application/json']
-        operation.responses.default.content['application/json'].schema
+        operation.responses.'200'.content.size() == 1
+        operation.responses.'200'.content['application/json']
+        operation.responses.'200'.content['application/json'].schema
         operation.responses.'400'.description == 'Invalid ID supplied'
 
     }
@@ -447,10 +447,10 @@ class MyBean {}
         operation.security.get(0).containsKey('petstore-auth')
         operation.security.get(0).get('petstore-auth') == ['write:pets']
         operation.responses.size() == 4
-        operation.responses.default.content.size() == 1
-        operation.responses.default.content['application/json']
-        operation.responses.default.content['application/json'].schema
-        operation.responses.default.extensions.'x-custom'.prop1 == "prop1Val"
+        operation.responses.'200'.content.size() == 1
+        operation.responses.'200'.content['application/json']
+        operation.responses.'200'.content['application/json'].schema
+        operation.responses.'200'.extensions.'x-custom'.prop1 == "prop1Val"
         operation.responses.'400'.description == 'Invalid ID supplied'
 
     }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaGenericsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaGenericsSpec.groovy
@@ -328,7 +328,7 @@ class MyBean {}
         expect:
         operation
         operation.responses.size() == 1
-        operation.responses.default.content['application/json'].schema.$ref == '#/components/schemas/ResponseOfPet'
+        operation.responses['200'].content['application/json'].schema.$ref == '#/components/schemas/ResponseOfPet'
         operation.requestBody.content['application/json'].schema.$ref == '#/components/schemas/RequestOfPet'
         openAPI.components.schemas['Pet'].properties['age'].type == 'integer'
         openAPI.components.schemas['ResponseOfPet'].properties['result'].$ref == '#/components/schemas/Pet'
@@ -474,7 +474,7 @@ class MyBean {}
         expect:
         operation
         operation.responses.size() == 1
-        operation.responses.default.content['application/json'].schema.$ref == '#/components/schemas/Time'
+        operation.responses['200'].content['application/json'].schema.$ref == '#/components/schemas/Time'
         openAPI.components.schemas['Quantity_Time.TimeUnit_'].type == 'object'
         openAPI.components.schemas['Quantity_Time.TimeUnit_'].properties['amount'].type == 'number'
         openAPI.components.schemas['Quantity_Time.TimeUnit_'].properties['unit'].$ref == '#/components/schemas/TimeUnit'

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
@@ -105,6 +105,8 @@ class MyBean {}
         expect:
         operation
         operation.responses.size() == 1
+        operation.responses["200"].description == "updatePet 200 response"
+        operation.responses["200"].content == null
 
         openAPI.components.schemas['Base'].properties['money'].type == 'integer'
 

--- a/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
+++ b/src/main/docs/guide/controllersAndSwaggerAnnotations.adoc
@@ -33,7 +33,7 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        200:
           description: The greeting
           content:
             text/plain:
@@ -81,7 +81,7 @@ paths:
           minLength: 1
           type: string
       responses:
-        default:
+        200:
           content:
             text/plain:
               schema:


### PR DESCRIPTION
https://swagger.io/docs/specification/describing-responses/ specifies that the status code should be the response key.

Also improves how `@ApiResponse` can be used, if one found with the same status code or `default` it will be used. 
The content is set if it's missing.

Fixes https://github.com/micronaut-projects/micronaut-openapi/issues/215