### PR TITLE
Add support for @RequestBean

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -42,8 +42,11 @@ import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.http.uri.UriMatchVariable;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.TypedElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.openapi.javadoc.JavadocDescription;
 import io.micronaut.openapi.javadoc.JavadocParser;
@@ -69,6 +72,7 @@ import io.swagger.v3.oas.models.servers.Server;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.security.Principal;
 import java.util.*;
@@ -232,7 +236,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
      */
     protected abstract String description(MethodElement element);
 
-    private boolean hasNoBindingAnnotationOrType(ParameterElement parameter) {
+    private boolean hasNoBindingAnnotationOrType(TypedElement parameter) {
         return !parameter.isAnnotationPresent(io.swagger.v3.oas.annotations.parameters.RequestBody.class) &&
                 !parameter.isAnnotationPresent(QueryValue.class) &&
                 !parameter.isAnnotationPresent(PathVariable.class) &&
@@ -240,6 +244,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                 !parameter.isAnnotationPresent(Part.class) &&
                 !parameter.isAnnotationPresent(CookieValue.class) &&
                 !parameter.isAnnotationPresent(Header.class) &&
+                !parameter.isAnnotationPresent(RequestBean.class) &&
                 !isResponseType(parameter.getType());
     }
 
@@ -304,7 +309,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
 
         Map<String, UriMatchVariable> pathVariables = pathVariables(matchTemplate);
         List<MediaType> consumesMediaTypes = consumesMediaTypes(element);
-        List<ParameterElement> extraBodyParameters = new ArrayList<>();
+        List<TypedElement> extraBodyParameters = new ArrayList<>();
         processParameters(element, context, openAPI, swaggerOperation, javadocDescription, permitsRequestBody, pathVariables, consumesMediaTypes, extraBodyParameters);
 
         processExtraBodyParameters(context, httpMethod, openAPI, swaggerOperation, javadocDescription, consumesMediaTypes, extraBodyParameters);
@@ -320,7 +325,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                                             io.swagger.v3.oas.models.Operation swaggerOperation,
                                             JavadocDescription javadocDescription,
                                             List<MediaType> consumesMediaTypes,
-                                            List<ParameterElement> extraBodyParameters) {
+                                            List<TypedElement> extraBodyParameters) {
         RequestBody requestBody = swaggerOperation.getRequestBody();
         if (HttpMethod.requiresRequestBody(httpMethod) || HttpMethod.permitsRequestBody(httpMethod) && !extraBodyParameters.isEmpty()) {
             if (requestBody == null) {
@@ -350,7 +355,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                     schema = extraBodyParametersSchema;
                     mediaType.setSchema(composedSchema);
                 }
-                for (ParameterElement parameter : extraBodyParameters) {
+                for (TypedElement parameter : extraBodyParameters) {
                     processBodyParameter(context, openAPI, javadocDescription, MediaType.of(mediaTypeName), schema, parameter);
                 }
             });
@@ -362,7 +367,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                                    boolean permitsRequestBody,
                                    Map<String, UriMatchVariable> pathVariables,
                                    List<MediaType> consumesMediaTypes,
-                                   List<ParameterElement> extraBodyParameters) {
+                                   List<TypedElement> extraBodyParameters) {
         List<Parameter> swaggerParameters = swaggerOperation.getParameters();
         boolean hasExistingParameters = CollectionUtils.isNotEmpty(swaggerParameters);
         if (!hasExistingParameters) {
@@ -378,8 +383,8 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
     private void processParameter(VisitorContext context, OpenAPI openAPI,
                                   io.swagger.v3.oas.models.Operation swaggerOperation, JavadocDescription javadocDescription,
                                   boolean permitsRequestBody, Map<String, UriMatchVariable> pathVariables, List<MediaType> consumesMediaTypes,
-                                  List<Parameter> swaggerParameters, boolean hasExistingParameters, ParameterElement parameter,
-                                  List<ParameterElement> extraBodyParameters) {
+                                  List<Parameter> swaggerParameters, boolean hasExistingParameters, TypedElement parameter,
+                                  List<TypedElement> extraBodyParameters) {
         ClassElement parameterType = parameter.getGenericType();
 
         if (ignoreParameter(parameter)) {
@@ -395,6 +400,12 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
         if (parameter.isAnnotationPresent(Body.class)) {
             processBody(context, openAPI, swaggerOperation, javadocDescription, permitsRequestBody,
                     consumesMediaTypes, parameter, parameterType);
+            return;
+        }
+
+        if (parameter.isAnnotationPresent(RequestBean.class)) {
+            processRequestBean(context, openAPI, swaggerOperation, javadocDescription, permitsRequestBody, pathVariables,
+                    consumesMediaTypes, swaggerParameters, hasExistingParameters, parameter, extraBodyParameters);
             return;
         }
 
@@ -434,7 +445,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
     }
 
     private void processBodyParameter(VisitorContext context, OpenAPI openAPI, JavadocDescription javadocDescription,
-                                      MediaType mediaType, Schema schema, ParameterElement parameter) {
+                                      MediaType mediaType, Schema schema, TypedElement parameter) {
         Schema propertySchema = resolveSchema(openAPI, parameter, parameter.getType(), context,
                 Collections.singletonList(mediaType));
         if (propertySchema != null) {
@@ -459,8 +470,8 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
     }
 
     private Parameter processMethodParameterAnnotation(VisitorContext context, boolean permitsRequestBody,
-                                                       Map<String, UriMatchVariable> pathVariables, ParameterElement parameter,
-                                                       List<ParameterElement> extraBodyParameters) {
+                                                       Map<String, UriMatchVariable> pathVariables, TypedElement parameter,
+                                                       List<TypedElement> extraBodyParameters) {
         Parameter newParameter = null;
         String parameterName = parameter.getName();
         if (!parameter.hasStereotype(Bindable.class) && pathVariables.containsKey(parameterName)) {
@@ -594,7 +605,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
 
     private void processBody(VisitorContext context, OpenAPI openAPI,
                              io.swagger.v3.oas.models.Operation swaggerOperation, JavadocDescription javadocDescription,
-                             boolean permitsRequestBody, List<MediaType> consumesMediaTypes, ParameterElement parameter,
+                             boolean permitsRequestBody, List<MediaType> consumesMediaTypes, TypedElement parameter,
                              ClassElement parameterType) {
         if (!permitsRequestBody) {
             return;
@@ -627,6 +638,17 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
         } else {
             final Content currentContent = requestBody.getContent();
             content.forEach((key, value) -> currentContent.putIfAbsent(key, value));
+        }
+    }
+
+    private void processRequestBean(VisitorContext context, OpenAPI openAPI,
+            io.swagger.v3.oas.models.Operation swaggerOperation, JavadocDescription javadocDescription,
+            boolean permitsRequestBody, Map<String, UriMatchVariable> pathVariables, List<MediaType> consumesMediaTypes,
+            List<Parameter> swaggerParameters, boolean hasExistingParameters, TypedElement parameter,
+            List<TypedElement> extraBodyParameters) {
+        for (FieldElement field : parameter.getType().getFields()) {
+            processParameter(context, openAPI, swaggerOperation, javadocDescription, permitsRequestBody, pathVariables,
+                    consumesMediaTypes, swaggerParameters, hasExistingParameters, field, extraBodyParameters);
         }
     }
 
@@ -770,7 +792,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
         }
     }
 
-    private boolean ignoreParameter(ParameterElement parameter) {
+    private boolean ignoreParameter(TypedElement parameter) {
         return parameter.isAnnotationPresent(Hidden.class) ||
                 parameter.isAnnotationPresent(JsonIgnore.class) ||
                 parameter.getValue(io.swagger.v3.oas.annotations.Parameter.class, "hidden", Boolean.class)

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
@@ -1,0 +1,112 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+
+class OpenApiRequestBeanSpec extends AbstractTypeElementSpec {
+
+    def setup() {
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+    }
+
+    void "test basic @RequestBean annotation"() {
+        given:
+            buildBeanDefinition('test.MyBean', '''
+
+package test;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.parameters.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.security.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.links.*;
+import java.util.List;
+
+@Controller("/")
+class MyController {
+
+    @Get("/{pV}")
+    public Response updatePet(@RequestBean MyRequestBean bean) {
+        return null;
+    }
+}
+
+@Introspected
+class MyRequestBean {
+
+    HttpRequest<?> httpRequest;
+   
+    @PathVariable("pV")
+    @Parameter(description="Any path variable")
+    private String pathVariable;
+    
+    @QueryValue("qV")
+    @Parameter(description="Any query value")
+    private String queryValue;
+    
+    @Nullable
+    @Parameter(description="Any content type")
+    @Header("Content-type")
+    private String contentType;
+    
+    public MyRequestBean(HttpRequest<?> httpRequest, String pathVariable, String queryValue, String contentType) {
+        this.httpRequest = httpRequest;
+        this.pathVariable = pathVariable;
+        this.queryValue = queryValue;
+        this.contentType = contentType;
+    }
+
+    public HttpRequest<?> getHttpRequest() {
+        return httpRequest;
+    }
+    
+    public String getPathVariable() {
+        return pathVariable;
+    }
+    
+    public String getQueryValue() {
+        return queryValue;
+    }
+    
+    public String getContentType() {
+        return contentType;
+    }
+ 
+}
+
+class Response {}
+
+@javax.inject.Singleton
+class MyBean {}
+
+''')
+
+            OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+            Operation operation = openAPI.paths?.get("/{pV}")?.get
+
+        expect:
+            operation
+            operation.parameters
+            operation.parameters.size() == 3
+            operation.parameters[0].name == 'pV'
+            operation.parameters[0].description == 'Any path variable'
+            operation.parameters[0].in == 'path'
+            operation.parameters[0].required
+            operation.parameters[1].name == 'qV'
+            operation.parameters[1].description == 'Any query value'
+            operation.parameters[1].in == 'query'
+            operation.parameters[1].required
+            operation.parameters[2].name == 'Content-type'
+            operation.parameters[2].description == 'Any content type'
+            operation.parameters[2].in == 'header'
+            !operation.parameters[2].required
+    }
+
+}


### PR DESCRIPTION
As title says this adds support for `@RequestBean` and closes https://github.com/micronaut-projects/micronaut-openapi/issues/345.

Fairly simple implementation: for every field of RequestBean class `processParameter` method is called. The only inconvenience is that I had to change some usages of `ParameterElement` to  `TypedElement`. 