### PR TITLE
Fix generation of to-array dictionaries

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -669,24 +669,20 @@ abstract class AbstractOpenApiVisitor  {
                     if (type.getTypeArguments().isEmpty()) {
                         schema.setAdditionalProperties(true);
                     } else {
-                        Element valueType = type.getTypeArguments().get("V");
+                        ClassElement valueType = type.getTypeArguments().get("V");
                         if (valueType.getName().equals(Object.class.getName())) {
                             schema.setAdditionalProperties(true);
                         } else {
-                            Schema additionalPropertiesSchema = getPrimitiveType(valueType.getName());
-                            if (additionalPropertiesSchema == null) {
-                                additionalPropertiesSchema = getSchemaDefinition(openAPI, context, valueType, definingElement, mediaTypes);
-                            }
-                            schema.setAdditionalProperties(additionalPropertiesSchema);
+                            schema.setAdditionalProperties(resolveSchema(openAPI, type, valueType, context, mediaTypes));
                         }
                     }
                 } else if (typeHelper.isIterable(type)) {
                     if (typeHelper.isArray(type)) {
-                        schema = resolveSchema(openAPI, definingElement, type, new ArrayTypeHelper(typeHelper.depth + 1), context, mediaTypes);
+                        schema = resolveSchema(openAPI, type, type, new ArrayTypeHelper(typeHelper.depth + 1), context, mediaTypes);
                     } else {
                         Optional<ClassElement> componentType = type.getFirstTypeArgument();
                         if (componentType.isPresent()) {
-                            schema = resolveSchema(openAPI, definingElement, componentType.get(), context, mediaTypes);
+                            schema = resolveSchema(openAPI, type, componentType.get(), context, mediaTypes);
                         } else {
                             schema = getPrimitiveType(Object.class.getName());
                         }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -235,6 +235,7 @@ class Pet {
     private Map freeForm;
     private Map<String, String> dictionariesPlain;
     private Map<String, Tag> tags;
+    private Map<String, List<Tag>> tagArrays;
 
     public void setAge(int a) {
         age = a;
@@ -300,6 +301,19 @@ class Pet {
     public void setTags(Map<String, Tag> tags) {
         this.tags = tags;
     }
+
+    /**
+     * A string-to-array dictionary
+     *
+     * @return A string-to-array dictionary
+     */
+    public Map<String, List<Tag>> getTagArrays() {
+        return tagArrays;
+    }
+
+    public void setTagArrays(Map<String, List<Tag>> tagArrays) {
+        this.tagArrays = tagArrays;
+    }
 }
 
 class Tag {
@@ -351,7 +365,7 @@ class MyBean {}
 
         then:"the components are valid"
         petSchema.type == 'object'
-        petSchema.properties.size() == 5
+        petSchema.properties.size() == 6
 
         petSchema.properties['age'].type == 'integer'
         petSchema.properties['age'].description == 'The Pet Age'
@@ -374,6 +388,11 @@ class MyBean {}
         tagSchema.properties['name'].type == "string"
         tagSchema.properties['name'].description == "The Tag Name"
         tagSchema.properties['description'].type == "string"
+
+        ((MapSchema) petSchema.properties['tagArrays']).type == "object"
+        ((MapSchema) petSchema.properties['tagArrays']).description == "A string-to-array dictionary"
+        ((ArraySchema)((MapSchema) petSchema.properties['tagArrays']).getAdditionalProperties()).getType() == "array"
+        ((ArraySchema)((MapSchema) petSchema.properties['tagArrays']).getAdditionalProperties()).getItems().$ref == "#/components/schemas/Tag"
     }
 
     void "test build OpenAPI doc for POJO type with javax.constraints"() {


### PR DESCRIPTION
This change comes as a proposition to address following comment:
https://github.com/micronaut-projects/micronaut-openapi/pull/346#issuecomment-721863733

It is practically inspited from #368, by recursively resolving schemas.

Note: recursive calls to `resolveSchema` specify the immediate outer class element as `definingElement`.