### PR TITLE
#392 - Improved support for @RequestBean. Ignore static fields/constants

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -17,7 +17,6 @@ package io.micronaut.openapi.visitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.annotation.processing.visitor.JavaClassElementExt;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
@@ -71,7 +70,6 @@ import io.swagger.v3.oas.models.servers.Server;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.security.Principal;
 import java.util.*;
@@ -647,6 +645,9 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
             List<Parameter> swaggerParameters, boolean hasExistingParameters, TypedElement parameter,
             List<TypedElement> extraBodyParameters) {
         for (FieldElement field : parameter.getType().getFields()) {
+            if (field.isStatic()) {
+                continue;
+            }
             processParameter(context, openAPI, swaggerOperation, javadocDescription, permitsRequestBody, pathVariables,
                     consumesMediaTypes, swaggerParameters, hasExistingParameters, field, extraBodyParameters);
         }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
@@ -41,6 +41,8 @@ class MyController {
 @Introspected
 class MyRequestBean {
 
+    public static final String HEADER_CONTENT_TYPE = "Content-type";
+    
     HttpRequest<?> httpRequest;
    
     @PathVariable("pV")
@@ -53,7 +55,7 @@ class MyRequestBean {
     
     @Nullable
     @Parameter(description="Any content type")
-    @Header("Content-type")
+    @Header(HEADER_CONTENT_TYPE)
     private String contentType;
     
     public MyRequestBean(HttpRequest<?> httpRequest, String pathVariable, String queryValue, String contentType) {


### PR DESCRIPTION
I changed the test code so that it defines the name of the header using a constant, the test failed.

Ignoring static fields fixed the test.