### PR TITLE
#409 - Set consistent ordering for yaml map properties

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -131,10 +132,11 @@ import static java.util.stream.Collectors.toMap;
  * @since 1.0
  */
 abstract class AbstractOpenApiVisitor  {
-    static final String ATTR_TEST_MODE = "io.micronaut.OPENAPI_TEST";
     static final String ATTR_OPENAPI = "io.micronaut.OPENAPI";
     static OpenAPI testReference;
+    static String testYamlReference;
 
+    private static final String ATTR_TEST_MODE = "io.micronaut.OPENAPI_TEST";
     private static final Lock VISITED_ELEMENTS_LOCK = new ReentrantLock();
     private static final String ATTR_VISITED_ELEMENTS = "io.micronaut.OPENAPI.visited.elements";
 
@@ -145,7 +147,7 @@ abstract class AbstractOpenApiVisitor  {
     /**
      * The YAML mapper.
      */
-    ObjectMapper yamlMapper = Yaml.mapper();
+    ObjectMapper yamlMapper = Yaml.mapper().enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 
     /**
      * Stores the current in progress type.
@@ -271,7 +273,7 @@ abstract class AbstractOpenApiVisitor  {
         if (openAPI == null) {
             openAPI = new OpenAPI();
             context.put(ATTR_OPENAPI, openAPI);
-            if (Boolean.getBoolean(ATTR_TEST_MODE)) {
+            if (isTestMode()) {
                 testReference = openAPI;
             }
         }
@@ -1546,4 +1548,9 @@ abstract class AbstractOpenApiVisitor  {
         }
         return tagList;
     }
+
+    boolean isTestMode() {
+        return Boolean.getBoolean(ATTR_TEST_MODE);
+    }
+
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
@@ -1,0 +1,242 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+
+class OpenApiOutputYamlSpec extends AbstractTypeElementSpec {
+
+    void "test paths and schemas for OpenAPI are sorted"() {
+        given:"An API definition"
+            System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+
+        when:
+            BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.management.endpoint.annotation.Endpoint;
+import io.micronaut.management.endpoint.annotation.Delete;
+import io.micronaut.management.endpoint.annotation.Write;
+import io.micronaut.management.endpoint.annotation.Selector;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.info.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.tags.*;
+import io.swagger.v3.oas.annotations.servers.*;
+import io.swagger.v3.oas.annotations.security.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "the title",
+                version = "0.0",
+                description = "My API"
+        )
+)
+class Application {
+
+}
+@Controller("/endpoint3")
+class ThirdEndpointController {
+    @Get("/")
+    public HttpResponse<String> path() {
+        return null;
+    }
+    @Get("/path2")
+    public HttpResponse<String> path2() {
+        return null;
+    }
+    @Get("/path1")
+    public HttpResponse<String> path1() {
+        return null;
+    }
+}
+@Controller("/endpoint1")
+class FirstEndpointController {
+    @Get("/")
+    public HttpResponse<String> getPath() {
+        return null;
+    }
+    @Get("/path1")
+    public HttpResponse<String> path1() {
+        return null;
+    }
+    @Get("/path2")
+    public HttpResponse<String> path2() {
+        return null;
+    }
+}
+@Controller("/endpoint2")
+class SecondEndpointController {
+    @Get("/path2")
+    public HttpResponse<String> path2() {
+        return null;
+    }
+    @Get("/path1")
+    public HttpResponse<String> path1() {
+        return null;
+    }
+    @Get("/")
+    public HttpResponse<Person> path() {
+        return null;
+    }
+}
+@Introspected
+class Person {
+    private String name;
+    private Integer debtValue;
+    private Integer totalGoals;
+    public Person(String name,
+                  Integer debtValue,
+                  Integer totalGoals) {
+        this.name = name;
+        this.debtValue = debtValue;
+        this.totalGoals = totalGoals;
+    }
+    public String getName() {
+        return name;
+    }
+    public Integer getDebtValue() {
+        return debtValue;
+    }
+    public Integer getTotalGoals() {
+        return totalGoals;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    public void setDebtValue(Integer debtValue) {
+        this.debtValue = debtValue;
+    }
+    public void setTotalGoals(Integer totalGoals) {
+        this.totalGoals = totalGoals;
+    }
+}
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"the yaml is written"
+            AbstractOpenApiVisitor.testYamlReference != null
+
+        then:"paths are sorted and schemas are sorted"
+            AbstractOpenApiEndpointVisitor.testYamlReference.contains('''\
+paths:
+  /endpoint1:
+    get:
+      operationId: getPath
+      parameters: []
+      responses:
+        "200":
+          description: getPath 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint1/path1:
+    get:
+      operationId: path1
+      parameters: []
+      responses:
+        "200":
+          description: path1 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint1/path2:
+    get:
+      operationId: path2
+      parameters: []
+      responses:
+        "200":
+          description: path2 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint2:
+    get:
+      operationId: path
+      parameters: []
+      responses:
+        "200":
+          description: path 200 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Person\'
+  /endpoint2/path1:
+    get:
+      operationId: path1
+      parameters: []
+      responses:
+        "200":
+          description: path1 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint2/path2:
+    get:
+      operationId: path2
+      parameters: []
+      responses:
+        "200":
+          description: path2 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint3:
+    get:
+      operationId: path
+      parameters: []
+      responses:
+        "200":
+          description: path 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint3/path1:
+    get:
+      operationId: path1
+      parameters: []
+      responses:
+        "200":
+          description: path1 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+  /endpoint3/path2:
+    get:
+      operationId: path2
+      parameters: []
+      responses:
+        "200":
+          description: path2 200 response
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        debtValue:
+          type: integer
+          format: int32
+        name:
+          type: string
+        totalGoals:
+          type: integer
+          format: int32''')
+    }
+
+}


### PR DESCRIPTION
Fixes #409. 

Note: I first tried with: 
```
OpenApi sortOpenApi(OpenApi openApi) {
    yaml = serialize(openApi)
    return deserlialize(yaml)
}
```

But in that case some unit tests failed, since OpenApi ObjectMapper Deserializator does not handle some openApi cases that are written by hand in Unit tests. So some fields that Unit tests expect were not present in sorted deserialized OpenApi object. 

After that I decided to check actual raw yaml output in tests.