### PR TITLE
Fix deprecation warnings

### DIFF
--- a/openapi/build.gradle
+++ b/openapi/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     }
 }
 
+compileJava.options.compilerArgs += '-deprecation'
+
 test {
     useJUnitPlatform()
 }

--- a/openapi/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElementExt.java
+++ b/openapi/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElementExt.java
@@ -320,7 +320,7 @@ public class JavaClassElementExt extends JavaClassElement {
     private JavaPropertyElement toPropertyElement(String propertyName, BeanPropertyData value, final AnnotationMetadata annotationMetadata) {
         return new JavaPropertyElement(
                 value.declaringType == null ? this : value.declaringType,
-                value.getter,
+                (Element) value.getter,
                 annotationMetadata,
                 propertyName,
                 value.type,

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -44,6 +44,7 @@ import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementModifier;
+import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.EnumElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MemberElement;
@@ -642,7 +643,7 @@ abstract class AbstractOpenApiVisitor  {
                isNullable = true;
                type = type.getFirstTypeArgument().orElse(null);
             }
-            
+
             if (type != null) {
 
                 String typeName = type.getName();
@@ -700,7 +701,7 @@ abstract class AbstractOpenApiVisitor  {
                         break;
                     }
                 }
-                
+
                 if (!isStream && (isPublisher || isObservable)) {
                     schema = arraySchema(schema);
                 } else if (isNullable) {
@@ -1372,7 +1373,7 @@ abstract class AbstractOpenApiVisitor  {
                 processPropertyElements(openAPI, context, type, schema, fluentMethodsProperties, mediaTypes);
             }
 
-            final List<FieldElement> publicFields = classElement.getFields(mods -> mods.contains(ElementModifier.PUBLIC) && mods.size() == 1);
+            final List<FieldElement> publicFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.modifiers(mods -> mods.contains(ElementModifier.PUBLIC) && mods.size() == 1));
 
             processPropertyElements(openAPI, context, type, schema, publicFields, mediaTypes);
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -26,6 +26,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.GeneratedFile;
@@ -346,7 +347,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             return path;
         }
         // default location
-        Optional<GeneratedFile> generatedFile = visitorContext.visitMetaInfFile("swagger/" + fileName);
+        Optional<GeneratedFile> generatedFile = visitorContext.visitMetaInfFile("swagger/" + fileName, Element.EMPTY_ELEMENT_ARRAY);
         if (generatedFile.isPresent()) {
             URI uri = generatedFile.get().toURI();
             // happens in tests 'mem:///CLASS_OUTPUT/META-INF/swagger/swagger.yml'


### PR DESCRIPTION
This change proposes to address the few remaining deprecation warnings as suggested by micronaut API's javadoc:
* `ClassElement.getFields` -> `ClassElement.getEnclosedElements(ALL_FIELDS)`
* `JavaPropertyElement(..., ExecutableElement, ...)` -> `JavaPropertyElement(..., Element, ...)`
* `VisitorContext.visitMetaInfFile(String)` -> `VisitorContext.visitMetaInfFile(String, EMPTY_ELEMENT_ARRAY)`

The `-deprecation` option is only added to help locate future deprecation warnings.