### PR TITLE
fixes #363 adds support for schema READ_ONLY and WRITE_ONLY accessModes

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -435,6 +434,12 @@ abstract class AbstractOpenApiVisitor  {
                     final Map<String, Object> discriminatorMap = getDiscriminatorMap(newValues);
                     discriminatorMap.put("propertyName", parseJsonString(value).orElse(value));
                     newValues.put("discriminator", discriminatorMap);
+                } else if (key.equals("accessMode")) {
+                    if(io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY.toString().equals(value)) {
+                        newValues.put("readOnly", Boolean.TRUE);
+                    } else if (io.swagger.v3.oas.annotations.media.Schema.AccessMode.WRITE_ONLY.toString().equals(value)) {
+                        newValues.put("writeOnly", Boolean.TRUE);
+                    }
                 } else {
                     newValues.put(key, parseJsonString(value).orElse(value));
                 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
@@ -825,4 +825,322 @@ public class MyBean {}
         openAPI.components.schemas["Person"].required.contains("debt_value")
     }
 
+    void "test READ_ONLY accessMode correctly results in setting readOnly to true"() {
+
+        when:
+        buildBeanDefinition("test.MyBean", '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.validation.constraints.*;
+
+@Controller
+class PersonController {
+
+    @Operation(
+            summary = "Fetch the person information",
+            description = "Fetch the person name, debt and goals information",
+            parameters = { @Parameter(name = "name", required = true, description = "The person name", in = ParameterIn.PATH) },
+            responses = {
+                    @ApiResponse(description = "The person information",
+                        content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema( implementation = Person.class )
+                    ))
+            }
+    )
+    @Get("/person/{name}")
+    HttpResponse<Person> get(@NotBlank String name) {
+        return HttpResponse.ok();
+    }
+}
+
+/**
+ * The person information.
+ */
+@Introspected
+class Person {
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private Integer id;
+
+    @NotBlank
+    private String name;
+
+    @NegativeOrZero
+    private Integer debtValue;
+
+    @PositiveOrZero
+    private Integer totalGoals;
+
+    public Person(Integer id,
+                  @NotBlank String name,
+                  @NegativeOrZero Integer debtValue,
+                  @PositiveOrZero Integer totalGoals) {
+
+        this.id = id;
+        this.name = name;
+        this.debtValue = debtValue;
+        this.totalGoals = totalGoals;
+    }
+    
+    /**
+     * The person's generated id.
+     *
+     * @return The id
+     */
+    public Integer getId() {
+        return id;
+    }
+
+     /**
+     * The person full name.
+     *
+     * @return The name
+     */
+    public String getName() {
+        return name;
+    }
+
+     /**
+     * The total debt amount.
+     *
+     * @return The debtValue
+     */
+    public Integer getDebtValue() {
+        return debtValue;
+    }
+
+     /**
+     * The total number of person's goals.
+     *
+     * @return The totalGoals
+     */
+    public Integer getTotalGoals() {
+        return totalGoals;
+    }
+    
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDebtValue(Integer debtValue) {
+        this.debtValue = debtValue;
+    }
+
+    public void setTotalGoals(Integer totalGoals) {
+        this.totalGoals = totalGoals;
+    }
+}
+
+@javax.inject.Singleton
+public class MyBean {}
+
+''')
+
+        then:
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        openAPI?.paths?.get("/person/{name}")?.get
+        openAPI.components.schemas["Person"]
+        openAPI.components.schemas["Person"].type == "object"
+
+        openAPI.components.schemas["Person"].properties
+        openAPI.components.schemas["Person"].properties.size() == 4
+
+        openAPI.components.schemas["Person"].properties["id"]
+        openAPI.components.schemas["Person"].properties["name"]
+        openAPI.components.schemas["Person"].properties["debtValue"]
+        openAPI.components.schemas["Person"].properties["totalGoals"]
+
+        openAPI.components.schemas["Person"].properties["id"].type == "integer"
+        openAPI.components.schemas["Person"].properties["id"].description == "The person's generated id."
+        openAPI.components.schemas["Person"].properties["id"].readOnly
+        !openAPI.components.schemas["Person"].properties["id"].writeOnly
+
+        openAPI.components.schemas["Person"].properties["name"].type == "string"
+        openAPI.components.schemas["Person"].properties["name"].description == "The person full name."
+
+        openAPI.components.schemas["Person"].properties["debtValue"].type == "integer"
+        openAPI.components.schemas["Person"].properties["debtValue"].maximum == 0
+        !openAPI.components.schemas["Person"].properties["debtValue"].exclusiveMaximum
+        openAPI.components.schemas["Person"].properties["debtValue"].description == "The total debt amount."
+
+        openAPI.components.schemas["Person"].properties["totalGoals"].type == "integer"
+        !openAPI.components.schemas["Person"].properties["totalGoals"].exclusiveMinimum
+        openAPI.components.schemas["Person"].properties["totalGoals"].description == "The total number of person's goals."
+    }
+
+    void "test WRITE_ONLY accessMode correctly results in setting writeOnly to true"() {
+
+        when:
+        buildBeanDefinition("test.MyBean", '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.validation.constraints.*;
+
+@Controller
+class PersonController {
+
+    @Operation(
+            summary = "Fetch the person information",
+            description = "Fetch the person name, debt and goals information",
+            parameters = { @Parameter(name = "name", required = true, description = "The person name", in = ParameterIn.PATH) },
+            responses = {
+                    @ApiResponse(description = "The person information",
+                        content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema( implementation = Person.class )
+                    ))
+            }
+    )
+    @Get("/person/{name}")
+    HttpResponse<Person> get(@NotBlank String name) {
+        return HttpResponse.ok();
+    }
+}
+
+/**
+ * The person information.
+ */
+@Introspected
+class Person {
+
+    @Schema(accessMode = Schema.AccessMode.WRITE_ONLY)
+    private Integer id;
+
+    @NotBlank
+    private String name;
+
+    @NegativeOrZero
+    private Integer debtValue;
+
+    @PositiveOrZero
+    private Integer totalGoals;
+
+    public Person(Integer id,
+                  @NotBlank String name,
+                  @NegativeOrZero Integer debtValue,
+                  @PositiveOrZero Integer totalGoals) {
+
+        this.id = id;
+        this.name = name;
+        this.debtValue = debtValue;
+        this.totalGoals = totalGoals;
+    }
+    
+    /**
+     * The person's generated id.
+     *
+     * @return The id
+     */
+    public Integer getId() {
+        return id;
+    }
+
+     /**
+     * The person full name.
+     *
+     * @return The name
+     */
+    public String getName() {
+        return name;
+    }
+
+     /**
+     * The total debt amount.
+     *
+     * @return The debtValue
+     */
+    public Integer getDebtValue() {
+        return debtValue;
+    }
+
+     /**
+     * The total number of person's goals.
+     *
+     * @return The totalGoals
+     */
+    public Integer getTotalGoals() {
+        return totalGoals;
+    }
+    
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDebtValue(Integer debtValue) {
+        this.debtValue = debtValue;
+    }
+
+    public void setTotalGoals(Integer totalGoals) {
+        this.totalGoals = totalGoals;
+    }
+}
+
+@javax.inject.Singleton
+public class MyBean {}
+
+''')
+
+        then:
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        openAPI?.paths?.get("/person/{name}")?.get
+        openAPI.components.schemas["Person"]
+        openAPI.components.schemas["Person"].type == "object"
+
+        openAPI.components.schemas["Person"].properties
+        openAPI.components.schemas["Person"].properties.size() == 4
+
+        openAPI.components.schemas["Person"].properties["id"]
+        openAPI.components.schemas["Person"].properties["name"]
+        openAPI.components.schemas["Person"].properties["debtValue"]
+        openAPI.components.schemas["Person"].properties["totalGoals"]
+
+        openAPI.components.schemas["Person"].properties["id"].type == "integer"
+        openAPI.components.schemas["Person"].properties["id"].description == "The person's generated id."
+        !openAPI.components.schemas["Person"].properties["id"].readOnly
+        openAPI.components.schemas["Person"].properties["id"].writeOnly
+
+        openAPI.components.schemas["Person"].properties["name"].type == "string"
+        openAPI.components.schemas["Person"].properties["name"].description == "The person full name."
+
+        openAPI.components.schemas["Person"].properties["debtValue"].type == "integer"
+        openAPI.components.schemas["Person"].properties["debtValue"].maximum == 0
+        !openAPI.components.schemas["Person"].properties["debtValue"].exclusiveMaximum
+        openAPI.components.schemas["Person"].properties["debtValue"].description == "The total debt amount."
+
+        openAPI.components.schemas["Person"].properties["totalGoals"].type == "integer"
+        !openAPI.components.schemas["Person"].properties["totalGoals"].exclusiveMinimum
+        openAPI.components.schemas["Person"].properties["totalGoals"].description == "The total number of person's goals."
+    }
+
 }


### PR DESCRIPTION
This PR fixes issue #363. I added support for READ_ONLY and WRITE_ONLY accessModes in the Schema annotation.

Setting accessMode to READ_ONLY sets the schema's readOnly attribute to true.
Setting accessMode to WRITE_ONLY sets the schema's writeOnly attribute to true. 