### PR TITLE
Fix swagger-annotations version to latest 2.1.9

### DIFF
--- a/src/main/docs/guide/swaggerAnnotations.adoc
+++ b/src/main/docs/guide/swaggerAnnotations.adoc
@@ -2,7 +2,7 @@ You can take full control by augmenting your definition with https://github.com/
 
 Add the Swagger annotations to the compile classpath
 
-dependency:swagger-annotations[scope="implementation", version="{version}", groupId="io.swagger.core.v3"]
+dependency:swagger-annotations[scope="implementation", version="2.1.9", groupId="io.swagger.core.v3"]
 
 and then annotate your controllers:
 


### PR DESCRIPTION
Dependency swagger-annotations version of io.swagger.core.v3 isn't the same version as Micronaut. 
If you select version 2.5.0 in the docs, for example, there's no 2.5.0 of swagger-annotations in the maven repository.