### PR TITLE
All not nullable parameters in a constructor are required in OpenAPI

### DIFF
--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
@@ -819,9 +819,10 @@ public class MyBean {}
         openAPI.components.schemas["Person"].properties["xyz"].additionalProperties == null
         openAPI.components.schemas["Person"].properties["xyz"].format == "email"
 
-        openAPI.components.schemas["Person"].required.size() == 2
+        openAPI.components.schemas["Person"].required.size() == 3
         openAPI.components.schemas["Person"].required.contains("name")
         openAPI.components.schemas["Person"].required.contains("debt_value")
+        openAPI.components.schemas["Person"].required.contains("total_goals")
     }
 
     void "test READ_ONLY accessMode correctly results in setting readOnly to true"() {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
@@ -1,16 +1,15 @@
 package io.micronaut.openapi.visitor
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.inject.BeanDefinition
 
 class OpenApiOutputYamlSpec extends AbstractTypeElementSpec {
 
     void "test paths and schemas for OpenAPI are sorted"() {
         given:"An API definition"
-            System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
 
         when:
-            BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean', '''
+        buildBeanDefinition('test.MyBean', '''
 package test;
 
 import io.micronaut.management.endpoint.annotation.Endpoint;
@@ -131,11 +130,10 @@ class Person3 {
 class MyBean {}
 ''')
         then:"the yaml is written"
-            AbstractOpenApiVisitor.testYamlReference != null
-        println(AbstractOpenApiVisitor.testYamlReference)
+        AbstractOpenApiVisitor.testYamlReference != null
 
         then:"paths are sorted and schemas are sorted"
-            AbstractOpenApiEndpointVisitor.testYamlReference.contains('''\
+        AbstractOpenApiEndpointVisitor.testYamlReference.contains('''\
 paths:
   /endpoint1:
     get:
@@ -239,6 +237,10 @@ paths:
 components:
   schemas:
     Person1:
+      required:
+      - debtValue
+      - name
+      - totalGoals
       type: object
       properties:
         name:
@@ -250,11 +252,15 @@ components:
           type: integer
           format: int32
     Person2:
+      required:
+      - name
       type: object
       properties:
         name:
           type: string
     Person3:
+      required:
+      - name
       type: object
       properties:
         name:

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.openapi.visitor
 
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
 
 class OpenApiOutputYamlSpec extends AbstractOpenApiTypeElementSpec {
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerSpec.groovy
@@ -9,10 +9,15 @@ import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.MapSchema
 import io.swagger.v3.oas.models.media.Schema
+import spock.lang.Issue
 
 class OpenApiPojoControllerSpec extends AbstractTypeElementSpec {
     def setup() {
         System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+    }
+
+    def cleanup() {
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "")
     }
 
     void "test build OpenAPI for List"() {
@@ -1622,5 +1627,111 @@ class MyBean {}
         operation.requestBody.content.size() == 2
         operation.requestBody.content['application/json'].schema
         operation.requestBody.content['application/x-www-form-urlencoded'].schema
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-openapi/issues/490")
+    void "test build OpenAPI for Controller with POJO with mandatory/optional fields"() {
+        given:"An API definition"
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.reactivex.*;
+import io.micronaut.core.annotation.*;
+import io.micronaut.http.annotation.*;
+import io.swagger.v3.oas.annotations.media.*;
+
+import java.util.List;
+
+@Controller("/example")
+class ExampleController {
+
+    @Get("/")
+    ExampleData getExampleData() {
+        return new ExampleData("name", true, new ExampleAdditionalData("hello"), 2, 0.456f, 1.2F);
+    }
+}
+
+class ExampleData {
+    private String name;
+    @Schema(required = false)
+    private Boolean active;
+    private ExampleAdditionalData additionalData;
+    private Integer age;
+    private Float battingAverage;
+    private float anotherFloat;
+
+    ExampleData(String name, Boolean active, ExampleAdditionalData additionalData, Integer age, @Nullable Float battingAverage, float anotherFloat) {
+        this.name = name;
+        this.active = active;
+        this.additionalData = additionalData;
+        this.age = age;
+        this.battingAverage = battingAverage;
+        this.anotherFloat = anotherFloat;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public Boolean isActive() {
+        return this.active;
+    }
+
+    public ExampleAdditionalData getAdditionalData() {
+        return this.additionalData;
+    }
+
+    public Integer getAge() {
+        return this.age;
+    }
+
+    public Float getBattingAverage() {
+        return this.battingAverage;
+    }
+
+    public float getAnotherFloat() {
+        return this.anotherFloat;
+    }
+}
+
+class ExampleAdditionalData {
+    private String something;
+
+    ExampleAdditionalData(String something) {
+        this.something = something;
+    }
+
+    String getSomething() {
+        return this.something;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Schema schema = openAPI.components.schemas['ExampleData']
+
+        then: "the components are valid"
+        schema.properties.size() == 6
+        schema.type == 'object'
+        schema.required
+
+        and: 'all params without annotations are required'
+        schema.required.contains('name')
+        schema.required.contains('additionalData')
+        schema.required.contains('age')
+        schema.required.contains('anotherFloat')
+
+        and: 'active is not required because it is annotated with @Schema(required = false)'
+        !schema.required.contains('active')
+
+        and: 'battingAverage is not required because it is annotated with @Nullable in the constructor'
+        !schema.required.contains('battingAverage')
     }
 }


### PR DESCRIPTION
Fixes #409

It turns out that at the end this is not a breaking change. As you can see in the modified tests I only needed to make some minor adjustments, so I think this fix can go in a patch release.


---

According to https://swagger.io/docs/specification/data-models/data-types/#required
all object properties are optional by default, so if a fields is not
nullable, it should be declared as "required" in the OpenAPI spec file.

In case the `@Schema` annotation exists on the field, it takes
precendece because the user decided to use it. It's up to the user to
make sure that the annotations in the field and in the constructor are
the same so they make sense.
