### PR TITLE
Support inheritance for request and response body with Jackson

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/postprocessors/JacksonDiscriminatorPostProcessor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/postprocessors/JacksonDiscriminatorPostProcessor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.postprocessors;
+
+import io.micronaut.core.annotation.NonNull;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to add missing "discriminator" property when using Jackson {@link com.fasterxml.jackson.annotation.JsonTypeInfo}
+ * and {@link com.fasterxml.jackson.annotation.JsonSubTypes}.
+ *
+ * @author Iván López
+ * @since 3.0.0
+ */
+public class JacksonDiscriminatorPostProcessor {
+
+    /**
+     * Add the missing discriminator property to the schemas related to another schema referencing them.
+     *
+     * @param openAPI The OpenAPI object
+     */
+    public void addMissingDiscriminatorType(OpenAPI openAPI) {
+        if ((openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null)) {
+            return;
+        }
+
+        for (Schema<?> schema : openAPI.getComponents().getSchemas().values()) {
+            if (schema.getDiscriminator() != null && schema.getDiscriminator().getMapping() != null) {
+                String discriminatorProperty = schema.getDiscriminator().getPropertyName();
+                List<String> schemasToUpdate = new ArrayList<>(schema.getDiscriminator().getMapping().values());
+                addDiscriminatorProperty(openAPI, schemasToUpdate, discriminatorProperty);
+            }
+        }
+    }
+
+    private void addDiscriminatorProperty(OpenAPI openAPI, List<String> schemasToUpdate, @NonNull String discriminatorProperty) {
+        for (String s : schemasToUpdate) {
+            Schema<?> schema = openAPI.getComponents().getSchemas().get(extractComponentSchemaName(s));
+            if (schema.getProperties() != null && !schema.getProperties().containsKey(discriminatorProperty)) {
+                schema.addProperties(discriminatorProperty, new StringSchema());
+            }
+        }
+    }
+
+    private String extractComponentSchemaName(@NonNull String mapping) {
+        return mapping.replace("#/components/schemas/", "");
+    }
+}

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -29,6 +29,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.GeneratedFile;
+import io.micronaut.openapi.postprocessors.JacksonDiscriminatorPostProcessor;
 import io.micronaut.openapi.postprocessors.OpenApiOperationsPostProcessor;
 import io.micronaut.openapi.view.OpenApiViewConfig;
 import io.swagger.v3.core.util.Yaml;
@@ -498,6 +499,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         openAPI = resolvePropertyPlaceHolders(openAPI, visitorContext);
         sortOpenAPI(openAPI);
         // Process after sorting so order is stable
+        new JacksonDiscriminatorPostProcessor().addMissingDiscriminatorType(openAPI);
         new OpenApiOperationsPostProcessor().processOperations(openAPI);
         String fileName = "swagger.yml";
         String documentTitle = "OpenAPI";

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiJacksonVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiJacksonVisitor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.visitor;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@link TypeElementVisitor} that builds appropriate {@link Schema} annotation for the parent class of a hierarchy
+ * when using Jackson {@link JsonTypeInfo} and {@link JsonSubTypes}.
+ *
+ * @author Iván López
+ * @since 3.0.0
+ */
+@Experimental
+public class OpenApiJacksonVisitor implements TypeElementVisitor<Object, Object> {
+
+    @Override
+    @NonNull
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return CollectionUtils.setOf(
+                "com.fasterxml.jackson.annotation.JsonSubTypes",
+                "com.fasterxml.jackson.annotation.JsonTypeInfo"
+        );
+    }
+
+    @Override
+    public int getOrder() {
+        return -10;
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext visitorContext) {
+        AnnotationValue<JsonSubTypes> jsonSubTypesDecAnn = element.getDeclaredAnnotation(JsonSubTypes.class);
+        AnnotationValue<JsonTypeInfo> jsonTypeInfoDecAnn = element.getDeclaredAnnotation(JsonTypeInfo.class);
+        AnnotationValue<Schema> schemaAnn = element.getDeclaredAnnotation(Schema.class);
+
+        /*
+        Given the following annotations:
+            @JsonSubTypes({
+                @JsonSubTypes.Type(name = "CAT", value = Cat.class),
+                @JsonSubTypes.Type(name = "DOG", value = Dog.class)
+            })
+            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+
+        This visitor will add the following @Schema (if no previous @Schema already exists):
+            @Schema(
+                oneOf = {Cat.class, Dog.class},
+                discriminatorMapping = {
+                    @DiscriminatorMapping(value = "CAT", schema = Cat.class),
+                    @DiscriminatorMapping(value = "DOG", schema = Dog.class)
+                },
+                discriminatorProperty = "type"
+            )
+         */
+        if (jsonTypeInfoDecAnn != null && jsonSubTypesDecAnn != null && schemaAnn == null) {
+            JsonTypeInfo.Id use = jsonTypeInfoDecAnn.enumValue("use", JsonTypeInfo.Id.class).orElse(null);
+            String discriminatorProp = jsonTypeInfoDecAnn.stringValue("property").orElse(null);
+            if (use != JsonTypeInfo.Id.NAME || discriminatorProp == null) {
+                return;
+            }
+
+            List<AnnotationClassValue<?>> discriminatorClasses = new ArrayList<>();
+            List<AnnotationValue<DiscriminatorMapping>> discriminatorMappings = new ArrayList<>();
+            for (AnnotationValue<Annotation> av : jsonSubTypesDecAnn.getAnnotations("value")) {
+                AnnotationClassValue<?> mappingClass = av.annotationClassValue("value").orElse(null);
+                String subTypeName = av.stringValue("name").orElse(null);
+                if (mappingClass != null && subTypeName != null) {
+                    AnnotationValue<DiscriminatorMapping> discriminatorMapping = AnnotationValue.builder(DiscriminatorMapping.class)
+                            .member("value", subTypeName)
+                            .member("schema", mappingClass)
+                            .build();
+                    discriminatorMappings.add(discriminatorMapping);
+                    discriminatorClasses.add(mappingClass);
+                }
+            }
+
+            element.annotate(Schema.class, builder -> {
+                builder.member("oneOf", discriminatorClasses.toArray(new AnnotationClassValue[0]));
+                builder.member("discriminatorProperty", discriminatorProp);
+                builder.member("discriminatorMapping", discriminatorMappings.toArray(new AnnotationValue<?>[0]));
+            });
+        }
+    }
+}

--- a/openapi/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/openapi/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -2,3 +2,4 @@ io.micronaut.openapi.visitor.OpenApiApplicationVisitor
 io.micronaut.openapi.visitor.OpenApiControllerVisitor
 io.micronaut.openapi.visitor.OpenApiEndpointVisitor
 io.micronaut.openapi.visitor.OpenApiIncludeVisitor
+io.micronaut.openapi.visitor.OpenApiJacksonVisitor

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
@@ -636,7 +636,7 @@ class MyBean {}
         petSchema != null
         dogSchema != null
         catSchema != null
-        !(petSchema instanceof ComposedSchema)
+        petSchema instanceof ComposedSchema
         catSchema instanceof ComposedSchema
         dogSchema instanceof ComposedSchema
         catSchema.type == null

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiJacksonInheritanceSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiJacksonInheritanceSpec.groovy
@@ -1,0 +1,129 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.ComposedSchema
+import io.swagger.v3.oas.models.media.Schema
+import spock.lang.Issue
+
+class OpenApiJacksonInheritanceSpec extends AbstractOpenApiTypeElementSpec {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-openapi/issues/508")
+    void "test render OpenAPI with @JsonSubTypes and @JsonTypeInfo"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.*;
+import io.swagger.v3.oas.annotations.media.*;
+
+@Controller("/pets")
+class PetController {
+    @Get
+    Pet[] getPets() {
+        return null;
+    }
+
+    @Post
+    String createPet(Pet pet) {
+        return null;
+    }
+}
+
+@Introspected
+@JsonSubTypes({
+        @JsonSubTypes.Type(name = "CAT", value = Cat.class),
+        @JsonSubTypes.Type(name = "DOG", value = Dog.class)
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+interface Pet {
+    Integer getId();
+}
+
+@Introspected
+class Cat implements Pet {
+    private final Integer id;
+    private final String name;
+
+    public Cat(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+    public String getName() {
+        return this.name;
+    }
+}
+
+@Introspected
+class Dog implements Pet {
+    private final Integer id;
+    private final Boolean barking;
+
+    public Dog(Integer id, Boolean barking) {
+        this.id = id;
+        this.barking = barking;
+    }
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+    public Boolean isBarking() {
+        return barking;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        expect:
+        openAPI
+        openAPI.paths.get("/pets")
+
+        and:
+        Schema catSchema = openAPI.components.schemas['Cat']
+        catSchema instanceof Schema
+        catSchema.name == 'Cat'
+        catSchema.type == 'object'
+        catSchema.properties.size() == 3
+        catSchema.properties['id'].type == 'integer'
+        catSchema.properties['name'].type == 'string'
+        catSchema.properties['type'].type == 'string'
+
+        and:
+        Schema dogSchema = openAPI.components.schemas['Dog']
+        catSchema instanceof Schema
+        dogSchema.name == 'Dog'
+        dogSchema.type == 'object'
+        dogSchema.properties.size() == 3
+        dogSchema.properties['id'].type == 'integer'
+        dogSchema.properties['barking'].type == 'boolean'
+        dogSchema.properties['type'].type == 'string'
+
+        and:
+        Schema petSchema = openAPI.components.schemas['Pet']
+        petSchema instanceof ComposedSchema
+        ComposedSchema composedPetSchema = (ComposedSchema) openAPI.components.schemas['Pet']
+
+        composedPetSchema.name == 'Pet'
+        composedPetSchema.type == 'object'
+        composedPetSchema.properties.size() == 1
+        composedPetSchema.properties['id'].type == 'integer'
+        composedPetSchema.oneOf.size() == 2
+        composedPetSchema.oneOf[0].$ref == '#/components/schemas/Cat'
+        composedPetSchema.oneOf[1].$ref == '#/components/schemas/Dog'
+        composedPetSchema.discriminator.propertyName == 'type'
+        composedPetSchema.discriminator.mapping['CAT'] == '#/components/schemas/Cat'
+        composedPetSchema.discriminator.mapping['DOG'] == '#/components/schemas/Dog'
+    }
+}


### PR DESCRIPTION
Fixes #508


This PR fixes the generated openapi to handle properly Jackson `@JsonTypeInfo` and `@JsonSubTypes` with inheritance when no `@Schema` annotations are used.

Before this PR, using the sample application code provided in the issue, the openapi rendered with ReDoc looked like:

![image](https://user-images.githubusercontent.com/559192/128531077-f178de83-cd20-4f0d-bd2a-e50d402c6787.png)

Only the `id` from the `Pet` interface was used but no the specific fields from children `Dog` and `Cat`.

Now with this PR when selecting a Cat/Dog the right properties are displayed. Also the discriminator `type` is there.

![image](https://user-images.githubusercontent.com/559192/128531398-d2c04768-2714-42d7-818f-eb28544d71da.png)
