### PR TITLE
Do not duplicate parameters when defined twice

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -447,6 +447,9 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                 case PATCH:
                     pathItem.getPatch().addParametersItem(parameter);
                     break;
+                default:
+                    // do nothing
+                    break;
             }
         }
     }


### PR DESCRIPTION
Follow up on #416

If a parameter is added at method level using `@Parameter` annotation
and also declared as method argument it can't be added twice. The one
declared in the `@Parameter` annotation takes precedences over the one
declared as method argument.
