### PR TITLE
Use getDeclaredAnnotation when retrieving @Schema

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -1168,7 +1168,7 @@ abstract class AbstractOpenApiVisitor  {
             ClassElement type,
             @Nullable Element definingElement,
             List<MediaType> mediaTypes) {
-        AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaValue = definingElement == null ? null : definingElement.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaValue = definingElement == null ? null : definingElement.getDeclaredAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
         if (schemaValue == null) {
             schemaValue = type.getDeclaredAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
         }


### PR DESCRIPTION
Fixes #555
Fixes #564

This was changed in https://github.com/micronaut-projects/micronaut-openapi/pull/540/files#diff-70483a9ff868dce418c3a545df1929d1c33a917d15e9bcc650b3e5185166b909L1120 and led to this issue. Now the change is reverted and I've added a test for it.