### PR TITLE
Upgrade Kotlin to 1.5.30

### DIFF
--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.5.21"
+    id "org.jetbrains.kotlin.jvm" version "1.5.30"
     id "org.jetbrains.kotlin.kapt" version "1.5.21"
 }
 

--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.5.30"
-    id "org.jetbrains.kotlin.kapt" version "1.5.21"
+    id "org.jetbrains.kotlin.kapt" version "1.5.30"
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ bomProperties=swaggerVersion
 
 rxJava2Version=2.2.21
 swaggerVersion=2.1.10
-kotlinVersion=1.5.21
+kotlinVersion=1.5.30
 junitVersion=5.7.2


### PR DESCRIPTION
Bumps org.jetbrains.kotlin.jvm from 1.5.21 to 1.5.30.

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin.jvm
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>- Bump org.jetbrains.kotlin.jvm from 1.5.21 to 1.5.30
- Bump org.jetbrains.kotlin.kapt from 1.5.21 to 1.5.30
- Upgrade Kotlin to 1.5.30
