### PR TITLE
Bump build plugin version to 4.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.2.1"
-    }
-}
-
 subprojects { Project subproject ->
     group "io.micronaut.openapi"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,14 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id 'io.micronaut.build.shared.settings' version '4.2.2'
+}
+
 rootProject.name="openapi-root"
 
 include "openapi"


### PR DESCRIPTION
This updates the build plugins to 4.2.2, which will also enable build scans.