### PR TITLE
Change nullable handling

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -978,7 +978,7 @@ abstract class AbstractOpenApiVisitor  {
         }
         // @Schema annotation takes priority over nullability annotations
         Boolean isSchemaNullable = element.booleanValue(io.swagger.v3.oas.annotations.media.Schema.class, "nullable").orElse(null);
-        boolean isNullable = (isSchemaNullable == null && element.isNullable())
+        boolean isNullable = (isSchemaNullable == null && (element.isNullable() || isTypeNullable(elementType)))
             || Boolean.TRUE.equals(isSchemaNullable);
         if (isNullable) {
             topLevelSchema.setNullable(true);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -145,6 +145,7 @@ abstract class AbstractOpenApiVisitor  {
     private static final Lock VISITED_ELEMENTS_LOCK = new ReentrantLock();
     private static final String ATTR_VISITED_ELEMENTS = "io.micronaut.OPENAPI.visited.elements";
     private static final Schema<?> EMPTY_SCHEMA = new Schema<>();
+    private static final ComposedSchema EMPTY_COMPOSED_SCHEMA = new ComposedSchema();
 
     /**
      * The JSON mapper.
@@ -957,26 +958,54 @@ abstract class AbstractOpenApiVisitor  {
             element.getValue(Part.class, String.class).ifPresent(finalSchemaToBind::setName);
         }
 
-        setSchemaDocumentation(element, schemaToBind);
+        final ComposedSchema composedSchema;
+        final Schema<?> topLevelSchema;
+        if (originalSchema.get$ref() != null) {
+            composedSchema = new ComposedSchema();
+            topLevelSchema = composedSchema;
+        } else {
+            composedSchema = null;
+            topLevelSchema = schemaToBind;
+        }
+
+        setSchemaDocumentation(element, topLevelSchema);
         if (element.isAnnotationPresent(Deprecated.class)) {
-            schemaToBind.setDeprecated(true);
+            topLevelSchema.setDeprecated(true);
         }
         final String defaultValue = element.getValue(Bindable.class, "defaultValue", String.class).orElse(null);
         if (defaultValue != null && schemaToBind.getDefault() == null) {
-            schemaToBind.setDefault(defaultValue);
+            topLevelSchema.setDefault(defaultValue);
         }
         // @Schema annotation takes priority over nullability annotations
         Boolean isSchemaNullable = element.booleanValue(io.swagger.v3.oas.annotations.media.Schema.class, "nullable").orElse(null);
-        if ((isSchemaNullable == null && element.isNullable()) || Boolean.TRUE.equals(isSchemaNullable)) {
-            schemaToBind.setNullable(true);
+        boolean isNullable = (isSchemaNullable == null && element.isNullable())
+            || Boolean.TRUE.equals(isSchemaNullable);
+        if (isNullable) {
+            topLevelSchema.setNullable(true);
         }
         final String defaultJacksonValue = element.stringValue(JsonProperty.class, "defaultValue").orElse(null);
         if (defaultJacksonValue != null && schemaToBind.getDefault() == null) {
-            schemaToBind.setDefault(defaultJacksonValue);
+            topLevelSchema.setDefault(defaultJacksonValue);
         }
-        return originalSchema.get$ref() != null && !schemaToBind.equals(EMPTY_SCHEMA)
-                ? new ComposedSchema().addAllOfItem(originalSchema).addAllOfItem(schemaToBind)
-                : originalSchema;
+
+        if (composedSchema != null) {
+            boolean addSchemaToBind = !schemaToBind.equals(EMPTY_SCHEMA);
+
+            if (addSchemaToBind) {
+                composedSchema.addAllOfItem(originalSchema);
+            } else if (isNullable && (composedSchema.getAllOf() == null || composedSchema.getAllOf().isEmpty())) {
+                composedSchema.addOneOfItem(originalSchema);
+            }
+            if (addSchemaToBind) {
+                composedSchema.addAllOfItem(schemaToBind);
+            }
+
+            if (!composedSchema.equals(EMPTY_COMPOSED_SCHEMA)) {
+                return composedSchema;
+            }
+        }
+
+        return originalSchema;
     }
 
     private void setSchemaDocumentation(Element element, Schema schemaToBind) {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
@@ -79,7 +79,9 @@ class PetController {
         petSchema.properties.size() == 2
 
         petSchema.properties["age"].type == "integer"
+        petSchema.properties["age"].nullable
         petSchema.properties["name"].type == "string"
+        petSchema.properties["name"].nullable
     }
 
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
@@ -82,4 +82,83 @@ class PetController {
         petSchema.properties["name"].type == "string"
     }
 
+
+    void "test build OpenAPI for nullable fields"() {
+        when:
+        buildBeanDefinition('test.PetController','''
+package test;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
+
+import java.util.List;
+import java.util.Optional;
+
+class Pet {
+    private String name;
+    private Pet mother;
+
+    public void setName(String n) {
+        name = n;
+    }
+
+    /**
+     * The Pet Name
+     *
+     * @return The Pet Name
+     */
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public void setMother(Pet mother) {
+        this.mother = mother;
+    }
+
+    /**
+     * The Pet Mother
+     *
+     * @return The Pet Mother
+     */
+    @Nullable
+    public Pet getMother() {
+        return mother;
+    }
+}
+
+@Controller
+class PetController {
+
+    @Get("/pet/{name}")
+    HttpResponse<Pet> get(String name) {
+        return HttpResponse.ok();
+    }
+    
+    @Post("/pet/")
+    HttpResponse<Pet> post(Pet p) {
+       return HttpResponse.ok();
+    }
+}
+
+''')
+        then:"the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then:"the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 2
+
+        petSchema.properties["name"].nullable
+        petSchema.properties["mother"].nullable
+    }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRecursionSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRecursionSpec.groovy
@@ -249,10 +249,10 @@ class MyBean {}
             Schema testImpl1 = schemas.get("TestImpl1")
             Schema woopsieProperty = testImpl1.getProperties()["woopsie"]
             woopsieProperty instanceof ComposedSchema
-            ((ComposedSchema) woopsieProperty).allOf[0].$ref == "#/components/schemas/TestInterface"
-            ((ComposedSchema) woopsieProperty).allOf[1].deprecated
-            ((ComposedSchema) woopsieProperty).allOf[1].description == "Some docs"
-            ((ComposedSchema) woopsieProperty).allOf[1].nullable
+            ((ComposedSchema) woopsieProperty).deprecated
+            ((ComposedSchema) woopsieProperty).description == "Some docs"
+            ((ComposedSchema) woopsieProperty).nullable
+            ((ComposedSchema) woopsieProperty).oneOf[0].$ref == "#/components/schemas/TestInterface"
     }
 
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
@@ -426,10 +426,10 @@ class MyBean {}
             Schema owner = schemas["Owner"]
             Schema vehicleProperty = owner.getProperties()["vehicle"]
             vehicleProperty instanceof ComposedSchema
-            ((ComposedSchema) vehicleProperty).allOf[0].$ref == "#/components/schemas/Vehicle"
-            ((ComposedSchema) vehicleProperty).allOf[1].deprecated
-            ((ComposedSchema) vehicleProperty).allOf[1].description == "Some docs"
-            ((ComposedSchema) vehicleProperty).allOf[1].nullable
+            ((ComposedSchema) vehicleProperty).deprecated
+            ((ComposedSchema) vehicleProperty).description == "Some docs"
+            ((ComposedSchema) vehicleProperty).nullable
+            ((ComposedSchema) vehicleProperty).oneOf[0].$ref == "#/components/schemas/Vehicle"
             Schema vehicle = schemas["Vehicle"]
             vehicle instanceof ComposedSchema
             ((ComposedSchema) vehicle).oneOf[0].$ref == '#/components/schemas/Car'
@@ -547,16 +547,16 @@ class MyBean {}
         emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto instanceof ComposedSchema
         ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).allOf[0].$ref == "#/components/schemas/EmailSendProtocolDto"
         ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).allOf[1].description == "Protocol used for the connection"
-        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).allOf[1].nullable
-        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).allOf[1].required
+        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).nullable
+        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailOutputLocationDto).required
 
         schemas["ReadEmailSettingsDto"].required.containsAll(["protocol", "active", "hostname", "port", "senderEmail", "username", "plaintextPassword"])
         Schema emailSendProtocolDtoSchemaFromReadEmailSettingsDto = schemas["ReadEmailSettingsDto"].getProperties()["protocol"]
         emailSendProtocolDtoSchemaFromReadEmailSettingsDto instanceof ComposedSchema
         ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).allOf[0].$ref == "#/components/schemas/EmailSendProtocolDto"
         ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).allOf[1].description == "Protocol used for the connection or null if email sending is disabled"
-        ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).allOf[1].nullable
-        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).allOf[1].required
+        ((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).nullable
+        !((ComposedSchema) emailSendProtocolDtoSchemaFromReadEmailSettingsDto).required
     }
 
 }


### PR DESCRIPTION
First commit changes the output for `@Nullable` properties as per OAS 3.0:
```
ParentSchema:
  type: object
  properties:
    child:
      nullable: true
      oneOf:
        - $ref: '#/components/schemas/ChildSchema'
```

Second commit sets `nullable: true` for `Optional<>` fields. I felt like this was desirable, but I can strip that commit if not.

I believe both commits are breaking changes.

Fixes #605 