### PR TITLE
update server-context documentation

### DIFF
--- a/src/main/docs/guide/serverContext.adoc
+++ b/src/main/docs/guide/serverContext.adoc
@@ -1,60 +1,10 @@
-In micronaut configuration file you can define a server context path (with `micronaut.server.context-path`) which serves as a base path for all routes.
-Since the yaml specification file and the views are generated at compile time, these resources are not aware of this runtime setting.
+In the micronaut configuration file you can define a server context path (with `micronaut.server.context-path`) which serves as a base path for all routes.
+Since the yaml specification file and the views are generated at compile time, these resources are not aware of changes during runtime (e.g. context-path is determined by a reverse proxy).
 
 It is still possible for the views to work in case a context path is defined:
 
-* Set `micronaut.openapi.server.context.path` property for compile time resolution.
+* Set `micronaut.openapi.server.context.path` property for compile time resolution, or
 * Use a `HttpServerFilter` that will add a cookie, or
 * Add a parameter to the url.
 
 The view will first look for the cookie and if not present for the parameter.
-
-=== Compile Time Resolution
-
-Either set `micronaut.openapi.server.context.path` as a System Property or in `openapi.properties`, then all paths will be prepend with the
-specified value at compile time.
-
-If you want the resolution of the context path at runtime use one of the following methods:
-
-=== HttpServerFilter
-
-Create a `HttpServerFilter` that will add a cookie with name `contextPath`.
-
-.HttpServerFilter for context-path
-[source,java]
-----
-import java.time.Duration;
-
-import org.reactivestreams.Publisher;
-
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
-import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.http.HttpMethod;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.annotation.Filter;
-import io.micronaut.http.cookie.Cookie;
-import io.micronaut.http.filter.HttpServerFilter;
-import io.micronaut.http.filter.ServerFilterChain;
-
-@Requires(property = "micronaut.server.context-path")
-@Filter(methods = {HttpMethod.GET, HttpMethod.HEAD}, patterns = {"/**/rapidoc*", "/**/redoc*", "/**/swagger-ui*"})
-public class OpenApiViewCookieContextPathFilter implements HttpServerFilter {
-    private final Cookie contextPathCookie;
-
-    OpenApiViewCookieContextPathFilter(@Value("${micronaut.server.context-path}") String contextPath) {
-        this.contextPathCookie = Cookie.of("contextPath", contextPath).maxAge(Duration.ofMinutes(2L));
-    }
-
-    @Override
-    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
-        return Publishers.map(chain.proceed(request), response -> response.cookie(contextPathCookie));
-    }
-
-}
-----
-
-=== URL Parameter
-
-Just add a parameter to the view url. For instance if the context path is set to `/context/path` you will access your view with `http://localhost:8080/context/path/swagger-ui?contextPath=%2Fcontext%2Fpath`.

--- a/src/main/docs/guide/serverContext/compileResolution.adoc
+++ b/src/main/docs/guide/serverContext/compileResolution.adoc
@@ -1,0 +1,3 @@
+Either set `micronaut.openapi.server.context.path` as a System Property or in `openapi.properties`, then all paths will be prepend with the specified value at compile time.
+
+If you want the resolution of the context path at runtime use one of the following methods:

--- a/src/main/docs/guide/serverContext/serverFilter.adoc
+++ b/src/main/docs/guide/serverContext/serverFilter.adoc
@@ -1,0 +1,94 @@
+Use a `HttpServerFilter` to add a cookie which contains the context-path. This can be done in two ways:
+
+* Set the context-path from a static property (has to be set during compile time), or
+* Parse the context path from the request headers. This is particularly useful if your application runs behind a reverse proxy, which strips the context-path before forwarding the request to the application. Most reverse proxies should provide the possibility to set the stripped context-path as a header (e.g. X-Forwarded-Prefix in the case of traefik).
+
+=== Static Property
+
+Create a `HttpServerFilter` that will add a cookie with name `contextPath`.
+
+.HttpServerFilter for static context-path
+[source,java]
+----
+import java.time.Duration;
+
+import org.reactivestreams.Publisher;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+
+@Requires(property = "micronaut.server.context-path")
+@Filter(methods = {HttpMethod.GET, HttpMethod.HEAD}, patterns = {"/**/rapidoc*", "/**/redoc*", "/**/swagger-ui*"})
+public class OpenApiViewCookieContextPathFilter implements HttpServerFilter {
+    private final Cookie contextPathCookie;
+
+    OpenApiViewCookieContextPathFilter(@Value("${micronaut.server.context-path}") String contextPath) {
+        this.contextPathCookie = Cookie.of("contextPath", contextPath).maxAge(Duration.ofMinutes(2L));
+    }
+
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        return Publishers.map(chain.proceed(request), response -> response.cookie(contextPathCookie));
+    }
+
+}
+----
+
+=== From HTTP Header
+
+The `HttpServerFilter` looks very similar to the one above. The main difference is that it parses the `context-path` value from the request headers.
+
+.HttpServerFilter from request headers
+[source,java]
+----
+import java.time.Duration;
+
+import org.reactivestreams.Publisher;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+
+
+@Filter(
+	methods = {HttpMethod.GET, HttpMethod.HEAD},
+	patterns = {"/**/rapidoc*", "/**/redoc*", "/**/swagger-ui*"}
+)
+@Requires(property = "micronaut.server.context-path-header")
+public class OpenApiContextPathFilter implements HttpServerFilter {
+
+	private final String contextPathHeader;
+
+	OpenApiContextPathFilter(@Value("${micronaut.server.context-path-header}") String contextPathHeader) {
+		this.contextPathHeader = contextPathHeader;
+	}
+
+	@Override
+	public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+		final String contextPath = request.getHeaders().get(contextPathHeader);
+
+		if (contextPath != null) {
+			Cookie contextPathCookie = Cookie.of("contextPath", contextPath).maxAge(Duration.ofMinutes(2L));
+			return Publishers.map(chain.proceed(request), response -> response.cookie(contextPathCookie));
+		} else {
+			return chain.proceed(request);
+		}
+	}
+
+}
+----

--- a/src/main/docs/guide/serverContext/urlParameter.adoc
+++ b/src/main/docs/guide/serverContext/urlParameter.adoc
@@ -1,0 +1,1 @@
+Just add a parameter to the view url. For instance if the context path is set to `/context/path` you will access your view with `http://localhost:8080/context/path/swagger-ui?contextPath=%2Fcontext%2Fpath`.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -43,6 +43,10 @@ openApiViews:
   redoc: Redoc
   rapidoc: RapiDoc
   rapipdf: RapiPdf
-serverContext: Server Context
+serverContext:
+  title: Server Context
+  compileResolution: Compile Time Resolution
+  serverFilter: HttpServerFilter
+  urlParameter: URL Parameter
 repository: Repository
 breaks: Breaking Changes


### PR DESCRIPTION
As suggested in micronaut-projects/micronaut-core#6905 I have updated the documentation to include a way to handle dynamic context-paths at runtime.
This is very useful if the same build artifact is intended to run behind multiple reverse proxies (e.g. on different stages) which serve the application on different context-paths.

The idea is to parse the context-path from the request headers. This assumes that the reverse proxy is configured to set the header accordingly.

Unfortunately, I could not test if the docs still compile correctly. If there is an easy way to test that, I'm happy to do so. Just let me know.