### PR TITLE
Fixed lost tags block in openAPI, when tags described on operation level

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -293,7 +293,7 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
 
         io.swagger.v3.oas.models.Operation swaggerOperation = readOperation(element, context);
 
-        readTags(element, swaggerOperation, classTags == null ? Collections.emptyList() : classTags);
+        readTags(element, context, swaggerOperation, classTags == null ? Collections.emptyList() : classTags, openAPI);
 
         readSecurityRequirements(element, context, swaggerOperation);
 
@@ -1073,8 +1073,42 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
         }
     }
 
-    private void readTags(MethodElement element, io.swagger.v3.oas.models.Operation swaggerOperation, List<io.swagger.v3.oas.models.tags.Tag> classTags) {
+    private void readTags(MethodElement element, VisitorContext context, io.swagger.v3.oas.models.Operation swaggerOperation, List<io.swagger.v3.oas.models.tags.Tag> classTags, OpenAPI openAPI) {
         element.getAnnotationValuesByType(Tag.class).forEach(av -> av.get("name", String.class).ifPresent(swaggerOperation::addTagsItem));
+
+        List<io.swagger.v3.oas.models.tags.Tag> operationTags = processOpenApiAnnotation(element, context, Tag.class, io.swagger.v3.oas.models.tags.Tag.class, openAPI.getTags());
+        // find not simple tags (tags with description or other information), such fields need to be described at the openAPI level.
+        List<io.swagger.v3.oas.models.tags.Tag> complexTags = null;
+        if (CollectionUtils.isNotEmpty(operationTags)) {
+            complexTags = new ArrayList<>();
+            for (io.swagger.v3.oas.models.tags.Tag operationTag : operationTags) {
+                if (StringUtils.hasText(operationTag.getDescription())
+                        || CollectionUtils.isNotEmpty(operationTag.getExtensions())
+                        || operationTag.getExternalDocs() != null) {
+                    complexTags.add(operationTag);
+                }
+            }
+        }
+        if (CollectionUtils.isNotEmpty(complexTags)) {
+            if (CollectionUtils.isEmpty(openAPI.getTags())) {
+                openAPI.setTags(complexTags);
+            } else {
+                for (io.swagger.v3.oas.models.tags.Tag operationTag : complexTags) {
+                    // skip all existed tags
+                    boolean alreadyExists = false;
+                    for (io.swagger.v3.oas.models.tags.Tag apiTag : openAPI.getTags()) {
+                        if (apiTag.getName().equals(operationTag.getName())) {
+                            alreadyExists = true;
+                            break;
+                        }
+                    }
+                    if (!alreadyExists) {
+                        openAPI.getTags().add(operationTag);
+                    }
+                }
+            }
+        }
+
         // only way to get inherited tags
         element.getValues(Tags.class, AnnotationValue.class).forEach((k, v) -> v.get("name", String.class).ifPresent(name -> addTagIfNotPresent((String) name, swaggerOperation)));
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/AnnotationRetentionPolicyTransformerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/AnnotationRetentionPolicyTransformerSpec.groovy
@@ -101,8 +101,9 @@ class HelloWorldController implements HelloWorldApi {
         openAPI.info.license.name == 'Apache 2.0'
         openAPI.info.contact.name == 'Fred'
         openAPI.tags.size() == 3
-        openAPI.tags.first().name == 'Tag 1'
-        openAPI.tags.first().description == 'desc 1'
+        Tag tag = openAPI.tags.find { it -> (it.name == 'Tag 1') }
+        tag
+        tag.description == 'desc 1'
         openAPI.externalDocs.description == 'definition docs desc'
         openAPI.security.size() == 2
         openAPI.security[0] == ["req 1":["a", "b"]]

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.openapi.visitor
 import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.tags.Tag
 
 class OpenApiApplicationVisitorSpec extends AbstractOpenApiTypeElementSpec {
 
@@ -121,8 +122,9 @@ class MyBean {}
         openAPI.info.license.name == 'Apache 2.0'
         openAPI.info.contact.name == 'Fred'
         openAPI.tags.size() == 3
-        openAPI.tags.first().name == 'Tag 1'
-        openAPI.tags.first().description == 'desc 1'
+        Tag tag = openAPI.tags.find { it -> (it.name == 'Tag 1') }
+        tag
+        tag.description == 'desc 1'
         openAPI.externalDocs.description == 'definition docs desc'
         openAPI.security.size() == 2
         openAPI.security[0] == ["req 1":["a", "b"]]

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiIncludeVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiIncludeVisitorSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.oas.models.tags.Tag
 import spock.lang.Issue
 
 class OpenApiIncludeVisitorSpec extends AbstractOpenApiTypeElementSpec {
@@ -216,8 +217,9 @@ class MyBean {}
             openAPI.info.license.name == 'Apache 2.0'
             openAPI.info.contact.name == 'Fred'
             openAPI.tags.size() == 3
-            openAPI.tags.first().name == 'Tag 1'
-            openAPI.tags.first().description == 'desc 1'
+            Tag tag = openAPI.tags.find { it -> (it.name == 'Tag 1') }
+            tag
+            tag.description == 'desc 1'
             openAPI.externalDocs.description == 'definition docs desc'
             openAPI.security.size() == 2
             openAPI.security[0] == ["req 1": ["a", "b"]]

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationTagsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationTagsSpec.groovy
@@ -1,0 +1,485 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+
+class OpenApiOperationTagsSpec extends AbstractOpenApiTypeElementSpec {
+
+
+    void "test build OpenAPI operation with @Tags"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+@Controller("/path")
+class OpenApiController {
+
+    @Get(uri = "/200")
+    @Tags({
+            @Tag(
+                    name = "Tag 0",
+                    description = "desc 0",
+                    externalDocs = @ExternalDocumentation(
+                            description = "docs desc0",
+                            url = "http://externaldoc.com",
+                            extensions = {
+                                    @Extension(
+                                            name = "extdocs.custom1",
+                                            properties = {
+                                                    @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                                    @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                            }
+                                    ),
+                                    @Extension(
+                                            name = "extdocs.custom2",
+                                            properties = {
+                                                    @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                                    @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                            }
+                                    )
+                            }
+                    ),
+                    extensions = {
+                            @Extension(
+                                    name = "tag.custom1",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                            @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                    }
+                            ),
+                            @Extension(
+                                    name = "tag.custom2",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                            @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                    }
+                            )
+                    }
+            ),
+            @Tag(name = "Tag 1", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc")),
+            @Tag(name = "Tag 2", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2")),
+            @Tag(name = "Tag 3")
+    })
+    public String processSync() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths.get("/path/200").get
+
+        then:
+        operation
+        operation.tags
+        operation.tags.size() == 4
+        operation.tags.get(0) == "Tag 0"
+        operation.tags.get(1) == "Tag 1"
+        operation.tags.get(2) == "Tag 2"
+        operation.tags.get(3) == "Tag 3"
+
+        openAPI.tags
+        openAPI.tags.size() == 3
+        openAPI.tags.get(0).name == "Tag 0"
+        openAPI.tags.get(0).description == 'desc 0'
+        openAPI.tags.get(0).externalDocs
+        openAPI.tags.get(0).externalDocs.description == "docs desc0"
+        openAPI.tags.get(0).externalDocs.url == "http://externaldoc.com"
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop22' == 'prop22Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop22' == 'prop22Val'
+
+        openAPI.tags.get(1).name == "Tag 1"
+        openAPI.tags.get(1).description == 'desc 1'
+        openAPI.tags.get(1).externalDocs
+        openAPI.tags.get(1).externalDocs.description == "docs desc"
+
+        openAPI.tags.get(2).name == "Tag 2"
+        openAPI.tags.get(2).description == 'desc 2'
+        openAPI.tags.get(2).externalDocs
+        openAPI.tags.get(2).externalDocs.description == "docs desc 2"
+    }
+
+    void "test build OpenAPI operation with @Tag repeated"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+@Controller("/path")
+class OpenApiController {
+
+    @Get(uri = "/200")
+    @Tag(
+            name = "Tag 0",
+            description = "desc 0",
+            externalDocs = @ExternalDocumentation(
+                    description = "docs desc0",
+                    url = "http://externaldoc.com",
+                    extensions = {
+                            @Extension(
+                                    name = "extdocs.custom1",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                            @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                    }
+                            ),
+                            @Extension(
+                                    name = "extdocs.custom2",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                            @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                    }
+                            )
+                    }
+            ),
+            extensions = {
+                    @Extension(
+                            name = "tag.custom1",
+                            properties = {
+                                    @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                    @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                            }
+                    ),
+                    @Extension(
+                            name = "tag.custom2",
+                            properties = {
+                                    @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                    @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                            }
+                    )
+            }
+    )
+    @Tag(name = "Tag 1", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc"))
+    @Tag(name = "Tag 2", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2"))
+    @Tag(name = "Tag 3")
+    public String processSync() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths.get("/path/200").get
+
+        then:
+        operation
+        operation.tags
+        operation.tags.size() == 4
+        operation.tags.get(0) == "Tag 0"
+        operation.tags.get(1) == "Tag 1"
+        operation.tags.get(2) == "Tag 2"
+        operation.tags.get(3) == "Tag 3"
+
+        openAPI.tags
+        openAPI.tags.size() == 3
+        openAPI.tags.get(0).name == "Tag 0"
+        openAPI.tags.get(0).description == 'desc 0'
+        openAPI.tags.get(0).externalDocs
+        openAPI.tags.get(0).externalDocs.description == "docs desc0"
+        openAPI.tags.get(0).externalDocs.url == "http://externaldoc.com"
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop22' == 'prop22Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop22' == 'prop22Val'
+
+        openAPI.tags.get(1).name == "Tag 1"
+        openAPI.tags.get(1).description == 'desc 1'
+        openAPI.tags.get(1).externalDocs
+        openAPI.tags.get(1).externalDocs.description == "docs desc"
+
+        openAPI.tags.get(2).name == "Tag 2"
+        openAPI.tags.get(2).description == 'desc 2'
+        openAPI.tags.get(2).externalDocs
+        openAPI.tags.get(2).externalDocs.description == "docs desc 2"
+    }
+
+    void "test build OpenAPI operation with class tags"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+@Tags({
+        @Tag(
+                name = "Tag 01",
+                description = "desc 0",
+                externalDocs = @ExternalDocumentation(
+                        description = "docs desc0",
+                        url = "http://externaldoc.com",
+                        extensions = {
+                                @Extension(
+                                        name = "extdocs.custom1",
+                                        properties = {
+                                                @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                                @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                        }
+                                ),
+                                @Extension(
+                                        name = "extdocs.custom2",
+                                        properties = {
+                                                @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                                @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                        }
+                                )
+                        }
+                ),
+                extensions = {
+                        @Extension(
+                                name = "tag.custom1",
+                                properties = {
+                                        @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                        @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                }
+                        ),
+                        @Extension(
+                                name = "tag.custom2",
+                                properties = {
+                                        @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                        @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                }
+                        )
+                }
+        ),
+        @Tag(name = "Tag 11", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc")),
+        @Tag(name = "Tag 21", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2")),
+        @Tag(name = "Tag 31")
+})
+@Controller("/path")
+class OpenApiController {
+
+    @Get(uri = "/200")
+    @Tags({
+            @Tag(
+                    name = "Tag 0",
+                    description = "desc 0",
+                    externalDocs = @ExternalDocumentation(
+                            description = "docs desc0",
+                            url = "http://externaldoc.com",
+                            extensions = {
+                                    @Extension(
+                                            name = "extdocs.custom1",
+                                            properties = {
+                                                    @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                                    @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                            }
+                                    ),
+                                    @Extension(
+                                            name = "extdocs.custom2",
+                                            properties = {
+                                                    @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                                    @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                            }
+                                    )
+                            }
+                    ),
+                    extensions = {
+                            @Extension(
+                                    name = "tag.custom1",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop11", value = "prop11Val"),
+                                            @ExtensionProperty(name = "prop12", value = "prop12Val"),
+                                    }
+                            ),
+                            @Extension(
+                                    name = "tag.custom2",
+                                    properties = {
+                                            @ExtensionProperty(name = "prop21", value = "prop21Val"),
+                                            @ExtensionProperty(name = "prop22", value = "prop22Val"),
+                                    }
+                            )
+                    }
+            ),
+            @Tag(name = "Tag 1", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc")),
+            @Tag(name = "Tag 2", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2")),
+            @Tag(name = "Tag 3")
+    })
+    public String processSync() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths.get("/path/200").get
+
+        then:
+        operation
+        operation.tags
+        operation.tags.size() == 8
+        operation.tags.get(0) == "Tag 0"
+        operation.tags.get(1) == "Tag 1"
+        operation.tags.get(2) == "Tag 2"
+        operation.tags.get(3) == "Tag 3"
+        operation.tags.get(4) == "Tag 01"
+        operation.tags.get(5) == "Tag 11"
+        operation.tags.get(6) == "Tag 21"
+        operation.tags.get(7) == "Tag 31"
+
+        openAPI.tags
+        openAPI.tags.size() == 6
+        openAPI.tags.get(0).name == "Tag 0"
+        openAPI.tags.get(0).description == 'desc 0'
+        openAPI.tags.get(0).externalDocs
+        openAPI.tags.get(0).externalDocs.description == "docs desc0"
+        openAPI.tags.get(0).externalDocs.url == "http://externaldoc.com"
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).externalDocs.extensions.'x-extdocs.custom2'.'prop22' == 'prop22Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(0).extensions.'x-tag.custom2'.'prop22' == 'prop22Val'
+
+        openAPI.tags.get(1).name == "Tag 1"
+        openAPI.tags.get(1).description == 'desc 1'
+        openAPI.tags.get(1).externalDocs
+        openAPI.tags.get(1).externalDocs.description == "docs desc"
+
+        openAPI.tags.get(2).name == "Tag 2"
+        openAPI.tags.get(2).description == 'desc 2'
+        openAPI.tags.get(2).externalDocs
+        openAPI.tags.get(2).externalDocs.description == "docs desc 2"
+
+        openAPI.tags.get(3).name == "Tag 01"
+        openAPI.tags.get(3).description == 'desc 0'
+        openAPI.tags.get(3).externalDocs
+        openAPI.tags.get(3).externalDocs.description == "docs desc0"
+        openAPI.tags.get(3).externalDocs.url == "http://externaldoc.com"
+        openAPI.tags.get(3).externalDocs.extensions.'x-extdocs.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(3).externalDocs.extensions.'x-extdocs.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(3).externalDocs.extensions.'x-extdocs.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(3).externalDocs.extensions.'x-extdocs.custom2'.'prop22' == 'prop22Val'
+        openAPI.tags.get(3).extensions.'x-tag.custom1'.'prop11' == 'prop11Val'
+        openAPI.tags.get(3).extensions.'x-tag.custom1'.'prop12' == 'prop12Val'
+        openAPI.tags.get(3).extensions.'x-tag.custom2'.'prop21' == 'prop21Val'
+        openAPI.tags.get(3).extensions.'x-tag.custom2'.'prop22' == 'prop22Val'
+
+        openAPI.tags.get(4).name == "Tag 11"
+        openAPI.tags.get(4).description == 'desc 1'
+        openAPI.tags.get(4).externalDocs
+        openAPI.tags.get(4).externalDocs.description == "docs desc"
+
+        openAPI.tags.get(5).name == "Tag 21"
+        openAPI.tags.get(5).description == 'desc 2'
+        openAPI.tags.get(5).externalDocs
+        openAPI.tags.get(5).externalDocs.description == "docs desc 2"
+    }
+
+    void "test build OpenAPI operation with simple tags"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+@Controller("/path")
+class OpenApiController {
+
+    @Get(uri = "/200")
+    @Tags({
+            @Tag(name = "Tag 0"),
+            @Tag(name = "Complex tag", description = "this is description"),
+            @Tag(name = "Tag 2"),
+            @Tag(name = "Tag 3")
+    })
+    public String processSync() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths.get("/path/200").get
+
+        then:
+        operation
+        operation.tags
+        operation.tags.size() == 4
+        operation.tags.get(0) == "Tag 0"
+        operation.tags.get(1) == "Complex tag"
+        operation.tags.get(2) == "Tag 2"
+        operation.tags.get(3) == "Tag 3"
+
+        openAPI.tags
+        openAPI.tags.size() == 1
+        openAPI.tags.get(0).name == "Complex tag"
+        openAPI.tags.get(0).description == "this is description"
+    }
+
+}


### PR DESCRIPTION
Now if you describe your tags inside controller (see tests), and tags not described on OpenAPI level, they are not added to the general list of tags. On the left is what the official swagger plugin generates, on the right - micronaut-openapi. This is the case when tags are described at the operation level (see test)

![изображение](https://user-images.githubusercontent.com/48474279/171998755-b586be7a-bcd7-4fb4-96cb-84256dab8ed9.png)