### PR TITLE
Remove generating empty parameters array

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -28,6 +28,7 @@ import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.DefaultConversionService;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.PropertyResolver;
@@ -389,6 +390,9 @@ abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
                                    Map<String, UriMatchVariable> pathVariables,
                                    List<MediaType> consumesMediaTypes,
                                    List<TypedElement> extraBodyParameters) {
+        if (ArrayUtils.isEmpty(element.getParameters())) {
+            return;
+        }
         List<Parameter> swaggerParameters = swaggerOperation.getParameters();
         if (CollectionUtils.isEmpty(swaggerParameters)) {
             swaggerParameters = new ArrayList<>();

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/AnnotationRetentionPolicyTransformerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/AnnotationRetentionPolicyTransformerSpec.groovy
@@ -121,7 +121,7 @@ class HelloWorldController implements HelloWorldApi {
         then:
         operation != null
         operation.operationId == 'helloWorld'
-        operation.parameters.size() == 0
+        !operation.parameters
         operation.tags
         operation.tags.size() == 3
         operation.tags.contains("Controller")

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
@@ -52,7 +52,7 @@ class MyBean {}
         then:
         operation != null
         operation.operationId == 'helloWorld'
-        operation.parameters.size() == 0
+        !operation.parameters
         operation.tags
         operation.tags.size() == 2
         operation.tags.contains("HelloWorld")

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOutputYamlSpec.groovy
@@ -135,7 +135,6 @@ paths:
   /endpoint1:
     get:
       operationId: getPath
-      parameters: []
       responses:
         "200":
           description: getPath 200 response
@@ -146,7 +145,6 @@ paths:
   /endpoint1/path1:
     get:
       operationId: path1
-      parameters: []
       responses:
         "200":
           description: path1 200 response
@@ -157,7 +155,6 @@ paths:
   /endpoint1/path2:
     get:
       operationId: path2
-      parameters: []
       responses:
         "200":
           description: path2 200 response
@@ -168,7 +165,6 @@ paths:
   /endpoint2:
     get:
       operationId: path
-      parameters: []
       responses:
         "200":
           description: path 200 response
@@ -179,7 +175,6 @@ paths:
   /endpoint2/path1:
     get:
       operationId: path1_1
-      parameters: []
       responses:
         "200":
           description: path1_1 200 response
@@ -190,7 +185,6 @@ paths:
   /endpoint2/path2:
     get:
       operationId: path2_1
-      parameters: []
       responses:
         "200":
           description: path2_1 200 response
@@ -201,7 +195,6 @@ paths:
   /endpoint3:
     get:
       operationId: path_1
-      parameters: []
       responses:
         "200":
           description: path_1 200 response
@@ -212,7 +205,6 @@ paths:
   /endpoint3/path1:
     get:
       operationId: path1_2
-      parameters: []
       responses:
         "200":
           description: path1_2 200 response
@@ -223,7 +215,6 @@ paths:
   /endpoint3/path2:
     get:
       operationId: path2_2
-      parameters: []
       responses:
         "200":
           description: path2_2 200 response


### PR DESCRIPTION
No need to add line `parameters: []` to swagger yaml when operation without parameters