### PR TITLE
Process @Requires annotation with conditions env and notEnv

### DIFF
--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     testImplementation(mn.micronaut.hibernate.validator)
     testImplementation(libs.kotlin.stdlib.jdk8)
     testImplementation(libs.kotlin.reflect)
-    testImplementation(libs.kotlintest.runner.junit5)
 
     testRuntimeOnly(libs.logback.classic)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ rxjava2 = { module = "io.reactivex.rxjava2:rxjava" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava" }
 testcontainers-spock = { module = "org.testcontainers:spock" }
 
-kotlintest-runner-junit5 = { module = "io.kotlintest:kotlintest-runner-junit5", version.ref = "kotlintest-runner-junit5" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -74,6 +74,7 @@ import java.util.stream.Collectors;
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_VIEWS_SPEC,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_JSON_FORMAT,
+    OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_TARGET_FILE,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ADDITIONAL_FILES,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE,
@@ -108,22 +109,18 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
      * System property that specifies the location of additional swagger YAML and JSON files to read from.
      */
     public static final String MICRONAUT_OPENAPI_ADDITIONAL_FILES = "micronaut.openapi.additional.files";
-
     /**
      * Default openapi config file.
      */
     public static final String OPENAPI_CONFIG_FILE = "openapi.properties";
-
     /**
      * The name of the entry for Endpoint class tags in the context.
      */
     public static final String MICRONAUT_OPENAPI_ENDPOINT_CLASS_TAGS = "micronaut.openapi.endpoint.class.tags";
-
     /**
      * The name of the entry for Endpoint servers in the context.
      */
     public static final String MICRONAUT_OPENAPI_ENDPOINT_SERVERS = "micronaut.openapi.endpoint.servers";
-
     /**
      * The name of the entry for Endpoint security requirements in the context.
      */
@@ -132,6 +129,10 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
      * Is this property true, output file format will be JSON, otherwise YAML.
      */
     public static final String MICRONAUT_OPENAPI_JSON_FORMAT = "micronaut.openapi.json.format";
+    /**
+     * Active micronaut environments which will be used for @Requires annotations.
+     */
+    public static final String MICRONAUT_OPENAPI_ENVIRONMENTS = "micronaut.openapi.environments";
 
     private static final String MICRONAUT_OPENAPI_PROPERTIES = "micronaut.openapi.properties";
     private static final String MICRONAUT_OPENAPI_ENDPOINTS = "micronaut.openapi.endpoints";

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerRequiresVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerRequiresVisitorSpec.groovy
@@ -1,0 +1,350 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.Paths
+
+class OpenApiControllerRequiresVisitorSpec extends AbstractOpenApiTypeElementSpec {
+
+    void "test requires env for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(env = {"env3"})
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env = {"env1"})
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 1
+        paths."/c2"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+
+    void "test requires not env for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(notEnv="env3")
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(notEnv="env1")
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 1
+        paths."/c1"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+
+    void "test requires not env and env for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(env="env1",notEnv="env3")
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env="env2",notEnv="env1")
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 1
+        paths."/c1"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+
+    void "test requires multiple env for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(env={"env1","env2"})
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env={"env2","env3"})
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env={"env3","env4"})
+@Controller
+class Controller3 {
+
+    @Post("/c3")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 2
+        paths."/c1"
+        paths."/c2"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+
+    void "test requires multiple notenv for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(notEnv={"env1","env2"})
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(notEnv={"env3"})
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 1
+        paths."/c2"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+
+    void "test requires multiple annotations with env for controller"() {
+
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS, "env1,env2")
+
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.*;
+import java.util.List;
+
+@Requires(env="env1")
+@Requires(env={"env2","env3"})
+@Requires(env={"env3","env4"})
+@Controller
+class Controller1 {
+
+    @Post("/c1")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env={"env1"})
+@Requires(env={"env2"})
+@Controller
+class Controller2 {
+
+    @Post("/c2")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@Requires(env={"env1"})
+@Requires(env={"env3"})
+@Controller
+class Controller3 {
+
+    @Post("/c3")
+    public HttpResponse<String> publicEnpoint() {
+        return null;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        when:
+        Paths paths = AbstractOpenApiVisitor.testReference?.paths
+
+        then:
+        paths
+        paths.size() == 1
+        paths."/c2"
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS)
+    }
+}


### PR DESCRIPTION
Add system property (micronaut.openapi.environments) to set active environments for correct process simple @Requires annotations with condition env={...} and notEnv={...}

Fixes #584