### PR TITLE
Smarter processing of javadoc comments into OpenAPI documentation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@ managed-swagger = "2.2.1"
 # Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
 managed-swagger-compat = "2.2.1"
 
-kotlintest-runner-junit5 = "3.4.2"
+javadoc-parser = "0.2.0"
+html2md-converter = "0.62.2"
 kotlin = "1.7.10"
 
 [libraries]
@@ -13,6 +14,9 @@ managed-swagger = { module = "io.swagger.core.v3:swagger-core", version.ref = "m
 managed-swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "managed-swagger" }
 managed-swagger-core = { module = "io.swagger.core.v3:swagger-core", version.ref = "managed-swagger" }
 managed-swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "managed-swagger" }
+
+javadoc-parser = { module = "com.github.chhorz:javadoc-parser", version.ref = "javadoc-parser" }
+html2md-converter = {module = "com.vladsch.flexmark:flexmark-html2md-converter", version.ref = "html2md-converter" }
 
 # Versions from BOM
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/openapi/build.gradle
+++ b/openapi/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation(mn.micronaut.http)
     implementation(mn.micronaut.http.server)
     implementation(libs.reactor.core)
+    implementation(libs.javadoc.parser)
+    implementation(libs.html2md.converter)
 
     api(libs.managed.swagger.core)
     api(libs.managed.swagger.models)

--- a/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocDescription.java
+++ b/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocDescription.java
@@ -28,14 +28,32 @@ import java.util.Map;
  */
 public class JavadocDescription {
 
+    private String methodSummary;
     private String methodDescription;
-    private Map<CharSequence, CharSequence> parameters = new HashMap<>(4);
+    private Map<String, String> parameters = new HashMap<>(4);
     private String returnDescription;
+
+    /**
+     * @return method summary
+     */
+    public String getMethodSummary() {
+        return methodSummary;
+    }
+
+    /**
+     * Sets the method summary.
+     *
+     * @param methodSummary The method summary
+     */
+    public void setMethodSummary(String methodSummary) {
+        this.methodSummary = methodSummary;
+    }
 
     /**
      * @return The description
      */
-    @Nullable public String getMethodDescription() {
+    @Nullable
+    public String getMethodDescription() {
         return methodDescription;
     }
 
@@ -51,7 +69,7 @@ public class JavadocDescription {
     /**
      * @return The parameter descriptions
      */
-    public Map<CharSequence, CharSequence> getParameters() {
+    public Map<String, String> getParameters() {
         return parameters;
     }
 
@@ -59,7 +77,8 @@ public class JavadocDescription {
      * The return description.
      * @return The return description
      */
-    @Nullable public String getReturnDescription() {
+    @Nullable
+    public String getReturnDescription() {
         return returnDescription;
     }
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -587,9 +587,9 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                 propertySchema.setNullable(true);
             }
             if (javadocDescription != null && StringUtils.isEmpty(propertySchema.getDescription())) {
-                CharSequence doc = javadocDescription.getParameters().get(parameter.getName());
+                String doc = javadocDescription.getParameters().get(parameter.getName());
                 if (doc != null) {
-                    propertySchema.setDescription(doc.toString());
+                    propertySchema.setDescription(doc);
                 }
             }
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -15,9 +15,22 @@
  */
 package io.micronaut.openapi.visitor;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -28,6 +41,7 @@ import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.DefaultConversionService;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -55,7 +69,6 @@ import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.openapi.javadoc.JavadocDescription;
-import io.micronaut.openapi.javadoc.JavadocParser;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,6 +76,7 @@ import io.swagger.v3.oas.annotations.callbacks.Callback;
 import io.swagger.v3.oas.annotations.callbacks.Callbacks;
 import io.swagger.v3.oas.annotations.enums.Explode;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.ParameterStyle;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import io.swagger.v3.oas.models.Components;
@@ -83,19 +97,9 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
 
-import java.io.IOException;
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A {@link io.micronaut.inject.visitor.TypeElementVisitor} the builds the Swagger model from Micronaut controllers at compile time.
@@ -110,6 +114,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
 
     private static final TypeReference<Map<CharSequence, Object>> MAP_TYPE = new TypeReference<Map<CharSequence, Object>>() {
     };
+    private static final int MAX_SUMMARY_LENGTH = 200;
+    private static final String THREE_DOTS = "...";
 
     protected List<io.swagger.v3.oas.models.tags.Tag> classTags;
     protected io.swagger.v3.oas.models.ExternalDocumentation classExternalDocs;
@@ -481,6 +487,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             paramAnn.booleanValue("allowReserved").ifPresent(parameter::allowReserved);
             paramAnn.stringValue("example").ifPresent(parameter::example);
             paramAnn.stringValue("ref").ifPresent(parameter::$ref);
+            paramAnn.enumValue("style", ParameterStyle.class).ifPresent(style -> parameter.setStyle(paramStyle(style)));
 
             PathItem pathItem = openAPI.getPaths().get(matchTemplate.toPathString());
             switch (httpMethod) {
@@ -554,7 +561,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
 
         Schema schema = newParameter.getSchema();
         if (schema == null) {
-            schema = resolveSchema(openAPI, parameter, parameterType, context, consumesMediaTypes);
+            schema = resolveSchema(openAPI, parameter, parameterType, context, consumesMediaTypes, null);
         }
 
         if (schema != null) {
@@ -566,7 +573,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
     private void processBodyParameter(VisitorContext context, OpenAPI openAPI, JavadocDescription javadocDescription,
                                       MediaType mediaType, Schema schema, TypedElement parameter) {
         Schema propertySchema = resolveSchema(openAPI, parameter, parameter.getType(), context,
-                Collections.singletonList(mediaType));
+                Collections.singletonList(mediaType), null);
         if (propertySchema != null) {
 
             Optional<String> description = parameter.getValue(io.swagger.v3.oas.annotations.Parameter.class,
@@ -660,7 +667,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                 }
 
                 Map<CharSequence, Object> paramValues = toValueMap(paramAnn.getValues(), context);
-                normalizeEnumValues(paramValues, Collections.singletonMap("in", ParameterIn.class));
+                Utils.normalizeEnumValues(paramValues, Collections.singletonMap("in", ParameterIn.class));
                 if (parameter.isAnnotationPresent(Header.class)) {
                     paramValues.put("in", ParameterIn.HEADER.toString());
                 } else if (parameter.isAnnotationPresent(CookieValue.class)) {
@@ -879,13 +886,23 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         String descr = description(element);
         if (StringUtils.isNotEmpty(descr) && StringUtils.isEmpty(swaggerOperation.getDescription())) {
             swaggerOperation.setDescription(descr);
-            swaggerOperation.setSummary(descr);
+            String summary = descr.substring(0, descr.indexOf('.') + 1);
+            if (summary.length() > MAX_SUMMARY_LENGTH) {
+                summary = summary.substring(0, MAX_SUMMARY_LENGTH) + THREE_DOTS;
+            }
+            swaggerOperation.setSummary(summary);
         }
-        JavadocDescription javadocDescription = element.getDocumentation().map(s -> new JavadocParser().parse(s))
+        JavadocDescription javadocDescription = element.getDocumentation()
+                .map(javadocParser::parse)
                 .orElse(null);
-        if (javadocDescription != null && StringUtils.isEmpty(swaggerOperation.getDescription())) {
-            swaggerOperation.setDescription(javadocDescription.getMethodDescription());
-            swaggerOperation.setSummary(javadocDescription.getMethodDescription());
+
+        if (javadocDescription != null) {
+            if (StringUtils.isEmpty(swaggerOperation.getDescription())) {
+                swaggerOperation.setDescription(javadocDescription.getMethodDescription());
+            }
+            if (StringUtils.isEmpty(swaggerOperation.getSummary())) {
+                swaggerOperation.setSummary(javadocDescription.getMethodSummary());
+            }
         }
         return javadocDescription;
     }
@@ -896,10 +913,103 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                 .flatMap(o -> toValue(o.getValues(), context, io.swagger.v3.oas.models.Operation.class))
                 .orElse(new io.swagger.v3.oas.models.Operation());
 
+        if (CollectionUtils.isNotEmpty(swaggerOperation.getParameters())) {
+            swaggerOperation.getParameters().removeIf(Objects::isNull);
+        }
+
+        ParameterElement[] methodParams = element.getParameters();
+        if (ArrayUtils.isNotEmpty(methodParams) && operationAnnotation.isPresent()) {
+            Optional<List<io.swagger.v3.oas.annotations.Parameter>> params = operationAnnotation.get().get("parameters", Argument.listOf(io.swagger.v3.oas.annotations.Parameter.class));
+            if (params.isPresent()) {
+                for (ParameterElement methodParam : methodParams) {
+                    io.swagger.v3.oas.annotations.Parameter paramAnn = null;
+                    for (io.swagger.v3.oas.annotations.Parameter param : params.get()) {
+                        if (methodParam.getName().equals(param.name())) {
+                            paramAnn = param;
+                            break;
+                        }
+                    }
+                    if (paramAnn != null && !paramAnn.hidden()) {
+                        Parameter swaggerParam = null;
+                        if (CollectionUtils.isNotEmpty(swaggerOperation.getParameters())) {
+                            for (Parameter createdParameter : swaggerOperation.getParameters()) {
+                                if (createdParameter.getName().equals(paramAnn.name())) {
+                                    swaggerParam = createdParameter;
+                                    break;
+                                }
+                            }
+                        }
+                        if (swaggerParam == null) {
+                            if (swaggerOperation.getParameters() == null) {
+                                swaggerOperation.setParameters(new ArrayList<>());
+                            }
+                            swaggerParam = new Parameter();
+                            swaggerOperation.getParameters().add(swaggerParam);
+                        }
+                        swaggerParam.setName(paramAnn.name());
+                        swaggerParam.setDescription(paramAnn.description());
+                        swaggerParam.setRequired(paramAnn.required());
+                        swaggerParam.setDeprecated(paramAnn.deprecated());
+                        swaggerParam.setAllowEmptyValue(paramAnn.allowEmptyValue());
+                        swaggerParam.setAllowReserved(paramAnn.allowReserved());
+                        swaggerParam.setExample(paramAnn.example());
+                        swaggerParam.setStyle(paramStyle(paramAnn.style()));
+                        swaggerParam.$ref(paramAnn.ref());
+                        if (paramAnn.in() == null || paramAnn.in() == ParameterIn.DEFAULT) {
+                            swaggerParam.setIn(calcIn(methodParam));
+                        } else {
+                            swaggerParam.setIn(paramAnn.in().toString());
+                        }
+                    }
+                }
+            }
+        }
+
         if (StringUtils.isEmpty(swaggerOperation.getOperationId())) {
             swaggerOperation.setOperationId(element.getName());
         }
         return swaggerOperation;
+    }
+
+    private String calcIn(ParameterElement methodParam) {
+        Set<String> paramAnnNames = methodParam.getAnnotationNames();
+        if (CollectionUtils.isNotEmpty(paramAnnNames)) {
+            if (paramAnnNames.contains(QueryValue.class.getName())) {
+                return ParameterIn.QUERY.toString();
+            } else if (paramAnnNames.contains(PathVariable.class.getName())) {
+                return ParameterIn.PATH.toString();
+            } else if (paramAnnNames.contains(Header.class.getName())) {
+                return ParameterIn.HEADER.toString();
+            } else if (paramAnnNames.contains(CookieValue.class.getName())) {
+                return ParameterIn.COOKIE.toString();
+            }
+        }
+        return null;
+    }
+
+    private Parameter.StyleEnum paramStyle(ParameterStyle paramAnnStyle) {
+        if (paramAnnStyle == null) {
+            return null;
+        }
+        switch (paramAnnStyle) {
+            case MATRIX:
+                return Parameter.StyleEnum.MATRIX;
+            case LABEL:
+                return Parameter.StyleEnum.LABEL;
+            case FORM:
+                return Parameter.StyleEnum.FORM;
+            case SPACEDELIMITED:
+                return Parameter.StyleEnum.SPACEDELIMITED;
+            case PIPEDELIMITED:
+                return Parameter.StyleEnum.PIPEDELIMITED;
+            case DEEPOBJECT:
+                return Parameter.StyleEnum.DEEPOBJECT;
+            case SIMPLE:
+                return Parameter.StyleEnum.SIMPLE;
+            case DEFAULT:
+            default:
+                return null;
+        }
     }
 
     private io.swagger.v3.oas.models.ExternalDocumentation readExternalDocs(MethodElement element, VisitorContext context) {
@@ -1233,7 +1343,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         Content content = new Content();
         mediaTypes.forEach(mediaType -> {
             io.swagger.v3.oas.models.media.MediaType mt = new io.swagger.v3.oas.models.media.MediaType();
-            mt.setSchema(resolveSchema(openAPI, definingElement, type, context, Collections.singletonList(mediaType)));
+            mt.setSchema(resolveSchema(openAPI, definingElement, type, context, Collections.singletonList(mediaType), null));
             content.addMediaType(mediaType.toString(), mt);
 
         });

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -330,7 +330,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
                         List<io.swagger.v3.oas.models.security.SecurityRequirement> securityRequirements =
                                 o.getAnnotations("security", SecurityRequirement.class)
                                 .stream()
-                                .map(this::mapToSecurityRequirement)
+                                .map(Utils::mapToSecurityRequirement)
                                 .collect(Collectors.toList());
                         openAPI.setSecurity(securityRequirements);
                     });

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
@@ -35,8 +35,13 @@ import org.reactivestreams.Publisher;
 
 /**
  * Some util methods.
+ *
+ * @since 4.4.0
  */
-public class Utils {
+public final class Utils {
+
+    private Utils() {
+    }
 
     public static boolean isContainerType(ClassElement type) {
         return CollectionUtils.setOf(

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.visitor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+
+/**
+ * Some util methods
+ */
+public class Utils {
+
+    /**
+     * Normalizes enum values stored in the map.
+     *
+     * @param paramValues The values
+     * @param enumTypes The enum types.
+     */
+    public static void normalizeEnumValues(Map<CharSequence, Object> paramValues, Map<String, Class<? extends Enum>> enumTypes) {
+        for (Map.Entry<String, Class<? extends Enum>> entry : enumTypes.entrySet()) {
+            final String name = entry.getKey();
+            final Class<? extends Enum> enumType = entry.getValue();
+            Object in = paramValues.get(name);
+            if (in != null) {
+                try {
+                    final Enum enumInstance = Enum.valueOf(enumType, in.toString());
+                    paramValues.put(name, enumInstance.toString());
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+
+        }
+    }
+
+    /**
+     * Maps annotation value to {@link io.swagger.v3.oas.annotations.security.SecurityRequirement}.
+     * Correct format is:
+     * custom_name:
+     * - custom_scope1
+     * - custom_scope2
+     *
+     * @param r The value of {@link SecurityRequirement}.
+     *
+     * @return converted object.
+     */
+    public static SecurityRequirement mapToSecurityRequirement(AnnotationValue<io.swagger.v3.oas.annotations.security.SecurityRequirement> r) {
+        String name = r.getRequiredValue("name", String.class);
+        List<String> scopes = r.get("scopes", String[].class).map(Arrays::asList).orElse(Collections.emptyList());
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList(name, scopes);
+        return securityRequirement;
+    }
+}

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
@@ -15,18 +15,51 @@
  */
 package io.micronaut.openapi.visitor;
 
+import java.io.File;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Future;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.server.types.files.FileCustomizableResponseType;
+import io.micronaut.inject.ast.ClassElement;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 
+import org.reactivestreams.Publisher;
+
 /**
- * Some util methods
+ * Some util methods.
  */
 public class Utils {
+
+    public static boolean isContainerType(ClassElement type) {
+        return CollectionUtils.setOf(
+            Optional.class.getName(),
+            Future.class.getName(),
+            Publisher.class.getName(),
+            "io.reactivex.Single",
+            "io.reactivex.Observable",
+            "io.reactivex.Maybe",
+            "io.reactivex.rxjava3.core.Single",
+            "io.reactivex.rxjava3.core.Observable",
+            "io.reactivex.rxjava3.core.Maybe"
+        ).stream().anyMatch(type::isAssignable);
+    }
+
+    public static boolean isReturnTypeFile(ClassElement type) {
+        return CollectionUtils.setOf(
+            FileCustomizableResponseType.class.getName(),
+            File.class.getName(),
+            InputStream.class.getName(),
+            ByteBuffer.class.getName()
+        ).stream().anyMatch(type::isAssignable);
+    }
 
     /**
      * Normalizes enum values stored in the map.

--- a/openapi/src/test/groovy/io/micronaut/openapi/javadoc/JavadocParserSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/javadoc/JavadocParserSpec.groovy
@@ -9,7 +9,7 @@ class JavadocParserSpec extends Specification {
         given:
         JavadocParser parser = new JavadocParser()
         JavadocDescription desc = parser.parse('''
-This is a description with <b>bold</b> and {@code some code}
+This is a summary text. This is a description with <b>bold</b> and {@code some code}
 
 @since 1.0
 @param foo The foo param
@@ -19,12 +19,21 @@ This is a description with <b>bold</b> and {@code some code}
 
 
         expect:
+        desc.methodSummary
         desc.methodDescription
         desc.returnDescription
         desc.parameters.size() == 2
-        desc.methodDescription == 'This is a description with bold and some code'
-        desc.returnDescription == 'The return value'
+        desc.methodSummary == 'This is a summary text.'
+        desc.methodDescription == 'This is a summary text. This is a description with **bold** and `some code`'
+        desc.returnDescription == '''The
+
+```
+return
+```
+
+value'''
         desc.parameters['foo'] == 'The foo param'
+        desc.parameters['bar'] == 'The `bar` param'
 
     }
 
@@ -45,14 +54,22 @@ And more stuff.
 
 
         expect:
+        desc.methodSummary
         desc.methodDescription
         desc.returnDescription
         desc.parameters.size() == 2
-        desc.methodDescription == '''This is a description with bold and some code.
-
+        desc.methodSummary == 'This is a description with **bold** and `some code`.'
+        desc.methodDescription == '''This is a description with **bold** and `some code`.
 And more stuff.'''
-        desc.returnDescription == 'The return value'
+        desc.returnDescription == '''The
+
+```
+return
+```
+
+value'''
         desc.parameters['foo'] == 'The foo param'
+        desc.parameters['bar'] == 'The `bar` param'
     }
 
     void 'test parse multiline return value javadoc'() {
@@ -75,19 +92,22 @@ as it is multiline
 ''')
 
         expect:
+        desc.methodSummary
         desc.methodDescription
         desc.returnDescription
         desc.parameters.size() == 2
-        desc.parameters['foo'] == '''The foo param
-With more foo param desctiption'''
-        desc.methodDescription == '''This is a description with bold and some code.
-
+        desc.parameters['foo'] == '''The foo param With more foo param desctiption'''
+        desc.parameters['bar'] == 'The `bar` param'
+        desc.methodSummary == 'This is a description with **bold** and `some code`.'
+        desc.methodDescription == '''This is a description with **bold** and `some code`.
 And more stuff.'''
-        desc.returnDescription == '''The return value
-with more return description
+        desc.returnDescription == '''The
 
-as it is multiline'''
+```
+return
+```
 
+value with more return description as it is multiline'''
     }
 
     void 'test parse multiline javadoc param'() {
@@ -111,5 +131,72 @@ Check if the given user has access to RabbitMQ.
         desc.parameters.size() == 2
         desc.parameters['username'] == 'The username to check.'
         desc.parameters['password'] == 'The password to check.'
+    }
+
+    void 'test parse javadoc with summary tag'() {
+
+        given:
+        JavadocParser parser = new JavadocParser()
+        JavadocDescription desc = parser.parse('''
+{@summary This is a summary text.} This is a description with <b>bold</b> and {@code some code}
+
+@since 1.0
+@param foo The foo param
+@param bar The {@code bar} param
+@return The {@value return} value
+''')
+
+
+        expect:
+        desc.methodSummary
+        desc.methodDescription
+        desc.returnDescription
+        desc.parameters.size() == 2
+        desc.methodSummary == 'This is a summary text.'
+        desc.methodDescription == 'This is a summary text. This is a description with **bold** and `some code`'
+        desc.returnDescription == '''The
+
+```
+return
+```
+
+value'''
+        desc.parameters['foo'] == 'The foo param'
+        desc.parameters['bar'] == 'The `bar` param'
+
+    }
+
+    void 'test parse javadoc with complex javadoc'() {
+
+        given:
+        JavadocParser parser = new JavadocParser()
+        JavadocDescription desc = parser.parse('''
+Values separated with commas ",". In case of iterables, the values are converted to {@link String} and joined
+with comma delimiter. In case of {@link Map} or a POJO {@link Object} the keys and values are alternating and all
+delimited with commas.
+<table border="1">
+    <caption>Examples</caption>
+    <tr> <th><b> Type </b></th>      <th><b> Example value </b></th>                     <th><b> Example representation </b></th> </tr>
+    <tr> <td> Iterable &emsp; </td>   <td> param=["Mike", "Adam", "Kate"] </td>           <td> "param=Mike,Adam,Kate" </td></tr>
+    <tr> <td> Map </td>              <td> param=["name": "Mike", "age": "30"] &emsp;</td> <td> "param=name,Mike,age,30" </td> </tr>
+    <tr> <td> Object </td>           <td> param={name: "Mike", age: 30} </td>            <td> "param=name,Mike,age,30" </td> </tr>
+</table>
+Note that ambiguity may arise when the values contain commas themselves after being converted to String.
+''')
+
+        expect:
+        desc.methodSummary
+        desc.methodDescription
+        desc.methodSummary == 'Values separated with commas ",".'
+        desc.methodDescription == '''Values separated with commas ",". In case of iterables, the values are converted to String and joined with comma delimiter. In case of Map or a POJO Object the keys and values are alternating and all delimited with commas.
+
+|  **Type**  |            **Example value**            | **Example representation** |
+|------------|-----------------------------------------|----------------------------|
+| Iterable   | param=\\["Mike", "Adam", "Kate"\\]        | "param=Mike,Adam,Kate"     |
+| Map        | param=\\["name": "Mike", "age": "30"\\]   | "param=name,Mike,age,30"   |
+| Object     | param={name: "Mike", age: 30}           | "param=name,Mike,age,30"   |
+[Examples]
+
+Note that ambiguity may arise when the values contain commas themselves after being converted to String.'''
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationWithjavadocSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationWithjavadocSpec.groovy
@@ -1,0 +1,239 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.parameters.Parameter
+import spock.lang.Ignore
+
+class OpenApiOperationWithjavadocSpec extends AbstractOpenApiTypeElementSpec {
+
+    void "test javadoc description, summary and parameters"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.QueryValue;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+
+@Controller
+class MyController {
+
+    /**
+     * Description and summary here
+     * @param id UUID of test
+     */
+    @Delete("/")
+    public void deleteObj(@QueryValue int id) {
+
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths?.get("/")?.delete
+
+        expect:
+        operation
+        operation.summary == 'Description and summary here'
+        operation.description == 'Description and summary here'
+
+        operation.parameters
+        operation.parameters.size() == 1
+        operation.parameters[0].name == 'id'
+        operation.parameters[0].description == 'UUID of test'
+    }
+
+    void "test Operation description, summary and parameters"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.QueryValue;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+
+@Controller
+class MyController {
+
+    @Delete("/")
+    @Operation(
+        summary = "Delete a thing",
+        description = "description test",
+        parameters = @Parameter(name = "id", description = "id description", style = ParameterStyle.LABEL)
+    )
+    @Parameter(name = "param1", description = "my desc", style = ParameterStyle.DEEPOBJECT)
+    public void deleteObj(@QueryValue int id, @QueryValue int param1) {
+
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths?.get("/")?.delete
+
+        expect:
+        operation
+        operation.summary == 'Delete a thing'
+        operation.description == 'description test'
+
+        operation.parameters
+        operation.parameters.size() == 2
+        operation.parameters[0].name == 'id'
+        operation.parameters[0].description == 'id description'
+        operation.parameters[0].style == Parameter.StyleEnum.LABEL
+        operation.parameters[1].name == 'param1'
+        operation.parameters[1].description == 'my desc'
+        operation.parameters[1].style == Parameter.StyleEnum.DEEPOBJECT
+    }
+
+    void "test Operation empty description and not empty summary"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.QueryValue;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+
+@Controller
+class MyController {
+
+    /**
+     * @param id UUID of test
+     */
+    @Delete("/")
+    @Operation(
+        summary = "Delete a thing",
+        description = ""
+    )
+    public void deleteObj(@QueryValue int id) {
+    }
+
+    /**
+     * @param id UUID of test
+     */
+    @Delete("/del2")
+    @Operation(
+        summary = "Delete a thing"
+    )
+    public void deleteObj2(@QueryValue int id) {
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+        Operation operation = openAPI.paths?.get("/")?.delete
+        Operation operation2 = openAPI.paths?.get("/del2")?.delete
+
+        expect:
+        operation
+        operation.summary == 'Delete a thing'
+        operation.description == ''
+
+        operation.parameters
+        operation.parameters.size() == 1
+        operation.parameters[0].name == 'id'
+        operation.parameters[0].description == 'UUID of test'
+
+        operation2
+        operation2.summary == 'Delete a thing'
+        operation2.description == ''
+
+        operation2.parameters
+        operation2.parameters.size() == 1
+        operation2.parameters[0].name == 'id'
+        operation2.parameters[0].description == 'UUID of test'
+    }
+
+    @Ignore("Need to fix problem with reading javadoc from class level (see this: https://github.com/micronaut-projects/micronaut-core/pull/7662)")
+    void "test read javadoc from class level for records"() {
+        given:
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+import io.micronaut.http.annotation.*;
+
+@Controller
+class PersonController {
+
+    @Get("/person")
+    Person getPerson() {
+        return new Person();
+    }
+}
+
+/**
+ * The Person class description
+*/
+class Person {
+    /**
+     * This is name description
+     */
+    @Nullable
+    private String name;
+    /**
+     * This is age description
+     */
+    private Integer age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        AbstractOpenApiVisitor.testReference != null
+
+        when:
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:
+        openAPI.components.schemas
+        openAPI.components.schemas.size() == 1
+
+        Schema personSchema = openAPI.components.schemas['Person']
+        personSchema.name == 'Person'
+        personSchema.type == 'object'
+        personSchema.description == 'The Person class description'
+        personSchema.properties.name.type == 'string'
+        personSchema.properties.name.description == 'This is name description'
+        personSchema.properties.age.type == 'integer'
+        personSchema.properties.age.description == 'This is age description'
+    }
+
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRecordsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRecordsSpec.groovy
@@ -2,6 +2,8 @@ package io.micronaut.openapi.visitor
 
 import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -90,5 +92,60 @@ class MyBean {}
         openAPI.components.schemas['Person'].required
         openAPI.components.schemas['Person'].required.size() == 1
         openAPI.components.schemas['Person'].required.contains('age')
+    }
+
+    @Ignore("Need to fix problem with reading javadoc from class level (see this: https://github.com/micronaut-projects/micronaut-core/pull/7662)")
+    void "test read javadoc from class level for records"() {
+        given:
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+import io.micronaut.http.annotation.*;
+
+@Controller
+class PersonController {
+
+    @Get("/person")
+    Person getPerson() {
+        return new Person("John", 42);
+    }
+}
+
+/**
+ * The Person class description
+ *
+ * @param name this is persons name
+ * @param age this is persons age
+ *
+ * @return new instance of Person class
+*/
+record Person(@Nullable String name, Integer age) {}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        AbstractOpenApiVisitor.testReference != null
+
+        when:
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:
+        openAPI.components.schemas
+        openAPI.components.schemas.size() == 1
+
+        Schema personSchema = openAPI.components.schemas['Person']
+        personSchema.name == 'Person'
+        personSchema.type == 'object'
+        personSchema.description == 'The Person class description'
+        personSchema.properties.name.type == 'string'
+        personSchema.properties.name.description == 'this is persons name'
+        personSchema.properties.age.type == 'integer'
+        personSchema.properties.age.description == 'this is persons age'
+        personSchema.required
+        personSchema.required.size() == 1
+        personSchema.required.contains('age')
     }
 }


### PR DESCRIPTION
 - Refactor JavadocParser. 
 - Add support summary and description blocks in method javadoc.
 - Add support html tags which will be convert to markdown

 - Add support Operation internal parameters field.
 - Fix problem with set style for parameter
 - Add read class level javadoc (need to records, kotlin data classes and enums)

Fixes #265