### PR TITLE
Expose libraries required for Groovy projects

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ title=OpenAPI/Swagger Support
 projectDesc=Configuration to integrate Micronaut and OpenAPI/Swagger
 projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-openapi
-developers=Puneet Behl,√Ålvaro S√°nchez-Mariscal,Iv√°n L√≥pez
+developers=Puneet Behl,¡lvaro S·nchez-Mariscal,Iv·n LÛpez
 
 githubCoreBranch=3.6.x
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,11 @@
 managed-swagger = "2.2.2"
 # Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
 managed-swagger-compat = "2.2.2"
+managed-javadoc-parser = "0.2.0"
 
-javadoc-parser = "0.2.0"
-html2md-converter = "0.62.2"
+# Versions beyond 0.62.2 require Java 11
+managed-html2md-converter = "0.62.2"
+
 kotlin = "1.7.10"
 
 [libraries]
@@ -15,8 +17,8 @@ managed-swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations
 managed-swagger-core = { module = "io.swagger.core.v3:swagger-core", version.ref = "managed-swagger" }
 managed-swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "managed-swagger" }
 
-javadoc-parser = { module = "com.github.chhorz:javadoc-parser", version.ref = "javadoc-parser" }
-html2md-converter = {module = "com.vladsch.flexmark:flexmark-html2md-converter", version.ref = "html2md-converter" }
+managed-javadoc-parser = { module = "com.github.chhorz:javadoc-parser", version.ref = "managed-javadoc-parser" }
+managed-html2md-converter = {module = "com.vladsch.flexmark:flexmark-html2md-converter", version.ref = "managed-html2md-converter" }
 
 # Versions from BOM
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/openapi/build.gradle
+++ b/openapi/build.gradle
@@ -9,12 +9,12 @@ dependencies {
     implementation(mn.micronaut.http)
     implementation(mn.micronaut.http.server)
     implementation(libs.reactor.core)
-    implementation(libs.javadoc.parser)
-    implementation(libs.html2md.converter)
 
     api(libs.managed.swagger.core)
     api(libs.managed.swagger.models)
     api(libs.managed.swagger.annotations)
+    api(libs.managed.javadoc.parser)
+    api(libs.managed.html2md.converter)
 
     testImplementation(mn.micronaut.runtime)
     testImplementation(mn.micronaut.security)


### PR DESCRIPTION
Groovy projects need `io.micronaut.openapi:micronaut-openapi` in the
compile classpath for the AST transformations to work (unlike Java/Kotlin,
which have it on the annotation processor scope only).

Fixes #781