### PR TITLE
Refer to the openapi generator in docs

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,3 +1,5 @@
 Micronaut includes support for producing https://www.openapis.org[OpenAPI] (Swagger) YAML at compilation time. Micronaut will at compile time produce a OpenAPI 3.x compliant YAML file just based on the regular Micronaut annotations and the javadoc comments within your code.
 
 You can customize the generated Swagger using the standard <<swaggerAnnotations, Swagger Annotations>>.
+
+If you wish to generate Micronaut projects from OpenAPI definition files, utilize the https://openapi-generator.tech/[OpenAPI Generator]'s Micronaut support. Refer to the https://guides.micronaut.io/latest/micronaut-openapi-generator-server["Micronaut server genreation with OpenAPI" guide] or the https://guides.micronaut.io/latest/micronaut-openapi-generator-client["Micronaut Client generation with OpenAPI" guide] for details.


### PR DESCRIPTION
Since users who want to convert OpenAPI definition files to code templates are likely to see this documentation page, it makes sense to add a reference to the OpenAPI generator in the page.