### PR TITLE
Fixed copying swagger-ui theme files

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
@@ -241,7 +241,7 @@ final class SwaggerUIConfig extends AbstractViewConfig implements Renderer {
         template = OpenApiViewConfig.replacePlaceHolder(template, PREFIX_SWAGGER_UI + ".js.url", jsUrl, "");
         template = OpenApiViewConfig.replacePlaceHolder(template, PREFIX_SWAGGER_UI + ".attributes", toOptions(), "");
         template = template.replace("{{" + PREFIX_SWAGGER_UI + ".theme}}", theme == null || Theme.CLASSIC == theme ? "" :
-            "<link rel='stylesheet' type='text/css' href='" + OpenApiViewConfig.THEMES_DIR + '/' + theme.getCss() + ".css' />");
+            "<link rel='stylesheet' type='text/css' href='" + OpenApiViewConfig.RESOURCE_DIR + '/' + theme.getCss() + ".css' />");
         template = template.replace("{{" + PREFIX_SWAGGER_UI + DOT + OPTION_OAUTH2 + "}}", hasOauth2Option(options) ? toOauth2Options() : "");
         return template;
     }

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiOperationViewRenderSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiOperationViewRenderSpec.groovy
@@ -45,7 +45,7 @@ class OpenApiOperationViewRenderSpec extends Specification {
         Files.exists(outputDir.resolve("swagger-ui").resolve("res").resolve("swagger-ui-bundle.js"))
         Files.exists(outputDir.resolve("swagger-ui").resolve("res").resolve("swagger-ui-standalone-preset.js"))
         Files.exists(outputDir.resolve("swagger-ui").resolve("res").resolve("rapipdf-min.js"))
-        Files.exists(outputDir.resolve("swagger-ui").resolve("theme").resolve("flattop.css"))
+        Files.exists(outputDir.resolve("swagger-ui").resolve("res").resolve("flattop.css"))
 
         outputDir.resolve("redoc").resolve("index.html").toFile().getText(StandardCharsets.UTF_8.name()).contains("https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js")
 


### PR DESCRIPTION
@graemerocher Sorry, found the same problem with copying theme swagger-ui files. But is fix not crittical, this only affects the use of custom themes in swagger. You can release it with version 4.5.2 when you decide it's time