### PR TITLE
Removed hard dependency on the micronaut-management library. Fixes for groovy and endpoints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectGroup=io.micronaut.openapi
 
 micronautDocsVersion=2.0.0
 micronautVersion=3.6.3
-micronautTestVersion=3.5.0
+micronautTestVersion=3.6.0
 groovyVersion=3.0.12
 spockVersion=2.2-groovy-3.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ projectGroup=io.micronaut.openapi
 
 micronautDocsVersion=2.0.0
 micronautVersion=3.6.3
-micronautTestVersion=3.6.0
-groovyVersion=3.0.12
+micronautTestVersion=3.6.2
+groovyVersion=3.0.13
 spockVersion=2.2-groovy-3.0
 
 title=OpenAPI/Swagger Support

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 managed-swagger = "2.2.2"
 # Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
 managed-swagger-compat = "2.2.2"
-managed-javadoc-parser = "0.2.0"
+managed-javadoc-parser = "0.3.1"
 
 # Versions beyond 0.62.2 require Java 11
 managed-html2md-converter = "0.62.2"

--- a/openapi/src/main/java/io/micronaut/openapi/annotation/mappers/OpenAPIManagementAnnotationMapper.java
+++ b/openapi/src/main/java/io/micronaut/openapi/annotation/mappers/OpenAPIManagementAnnotationMapper.java
@@ -15,23 +15,14 @@
  */
 package io.micronaut.openapi.annotation.mappers;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.TypedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.management.endpoint.beans.BeansEndpoint;
-import io.micronaut.management.endpoint.env.EnvironmentEndpoint;
-import io.micronaut.management.endpoint.health.HealthEndpoint;
-import io.micronaut.management.endpoint.info.InfoEndpoint;
-import io.micronaut.management.endpoint.loggers.LoggersEndpoint;
-import io.micronaut.management.endpoint.refresh.RefreshEndpoint;
-import io.micronaut.management.endpoint.routes.RoutesEndpoint;
-import io.micronaut.management.endpoint.stop.ServerStopEndpoint;
-import io.micronaut.management.endpoint.threads.ThreadDumpEndpoint;
 import io.micronaut.openapi.annotation.OpenAPIInclude;
 import io.micronaut.openapi.annotation.OpenAPIManagement;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Mapper for management endpoints.
@@ -46,22 +37,21 @@ public class OpenAPIManagementAnnotationMapper implements TypedAnnotationMapper<
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<OpenAPIManagement> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue
-                        .builder(OpenAPIInclude.class)
-                        .values(
-                                HealthEndpoint.class,
-                                BeansEndpoint.class,
-                                EnvironmentEndpoint.class,
-                                InfoEndpoint.class,
-                                LoggersEndpoint.class,
-                                RefreshEndpoint.class,
-                                RoutesEndpoint.class,
-                                ServerStopEndpoint.class,
-                                ThreadDumpEndpoint.class
-                        )
-                        .member("tags", annotation.getAnnotations("tags").toArray(new AnnotationValue[0]))
-                        .member("security", annotation.getAnnotations("security").toArray(new AnnotationValue[0]))
-                        .build()
+            AnnotationValue.builder(OpenAPIInclude.class)
+                .values(
+                    "io.micronaut.management.endpoint.beans.BeansEndpoint",
+                    "io.micronaut.management.endpoint.env.EnvironmentEndpoint",
+                    "io.micronaut.management.endpoint.health.HealthEndpoint",
+                    "io.micronaut.management.endpoint.info.InfoEndpoint",
+                    "io.micronaut.management.endpoint.loggers.LoggersEndpoint",
+                    "io.micronaut.management.endpoint.refresh.RefreshEndpoint",
+                    "io.micronaut.management.endpoint.routes.RoutesEndpoint",
+                    "io.micronaut.management.endpoint.stop.ServerStopEndpoint",
+                    "io.micronaut.management.endpoint.threads.ThreadDumpEndpoint"
+                )
+                .member("tags", annotation.getAnnotations("tags").toArray(new AnnotationValue[0]))
+                .member("security", annotation.getAnnotations("security").toArray(new AnnotationValue[0]))
+                .build()
         );
     }
 }

--- a/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocParser.java
+++ b/openapi/src/main/java/io/micronaut/openapi/javadoc/JavadocParser.java
@@ -24,6 +24,7 @@ import com.github.chhorz.javadoc.JavaDocParser;
 import com.github.chhorz.javadoc.JavaDocParserBuilder;
 import com.github.chhorz.javadoc.OutputType;
 import com.github.chhorz.javadoc.tags.ParamTag;
+import com.github.chhorz.javadoc.tags.PropertyTag;
 import com.github.chhorz.javadoc.tags.ReturnTag;
 import com.github.chhorz.javadoc.tags.Tag;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
@@ -53,7 +54,7 @@ public class JavadocParser {
         }
 
         JavaDocParser javaDocParser = JavaDocParserBuilder
-            .withBasicTags()
+            .withAllKnownTags()
             .withOutputType(OutputType.HTML)
             .build();
 
@@ -76,6 +77,10 @@ public class JavadocParser {
                     ParamTag paramTag = (ParamTag) tag;
                     String paramDesc = htmlToMarkdownConverter.convert(paramTag.getParamDescription()).trim();
                     javadocDescription.getParameters().put(paramTag.getParamName(), paramDesc);
+                } else if (tag instanceof PropertyTag) {
+                    PropertyTag propertyTag = (PropertyTag) tag;
+                    String paramDesc = htmlToMarkdownConverter.convert(propertyTag.getParamDescription()).trim();
+                    javadocDescription.getParameters().put(propertyTag.getPropertyName(), paramDesc);
                 }
             }
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanMap;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -108,7 +107,6 @@ import static io.micronaut.openapi.visitor.Utils.DEFAULT_MEDIA_TYPES;
  * @author graemerocher
  * @since 1.0
  */
-@Experimental
 public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisitor {
 
     public static final String COMPONENTS_CALLBACKS_PREFIX = "#/components/callbacks/";
@@ -839,8 +837,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         return element.isNullable()
             || element.getType().isOptional()
             || element.hasStereotype(Nullable.class)
-            || element.hasStereotype(jakarta.annotation.Nullable.class)
-            || element.hasStereotype(org.jetbrains.annotations.Nullable.class);
+            || element.hasStereotype("jakarta.annotation.Nullable")
+            || element.hasStereotype("org.jetbrains.annotations.Nullable");
     }
 
     private void processBody(VisitorContext context, OpenAPI openAPI,

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -932,7 +932,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         }
         if (response == null && !withMethodResponses) {
             response = new ApiResponse();
-            if (javadocDescription == null) {
+            if (javadocDescription == null || StringUtils.isEmpty(javadocDescription.getReturnDescription())) {
                 response.setDescription(swaggerOperation.getOperationId() + " " + responseCode + " response");
             } else {
                 response.setDescription(javadocDescription.getReturnDescription());
@@ -998,10 +998,10 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             .orElse(null);
 
         if (javadocDescription != null) {
-            if (StringUtils.isEmpty(swaggerOperation.getDescription())) {
+            if (StringUtils.isEmpty(swaggerOperation.getDescription()) && StringUtils.hasText(javadocDescription.getMethodDescription())) {
                 swaggerOperation.setDescription(javadocDescription.getMethodDescription());
             }
-            if (StringUtils.isEmpty(swaggerOperation.getSummary())) {
+            if (StringUtils.isEmpty(swaggerOperation.getSummary()) && StringUtils.hasText(javadocDescription.getMethodSummary())) {
                 swaggerOperation.setSummary(javadocDescription.getMethodSummary());
             }
         }
@@ -1110,6 +1110,10 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             swaggerOperation.setOperationId(prefix + element.getName() + suffix);
         } else if (addAlways) {
             swaggerOperation.setOperationId(prefix + swaggerOperation.getOperationId() + suffix);
+        }
+
+        if (swaggerOperation.getDescription() != null && swaggerOperation.getDescription().isEmpty()) {
+            swaggerOperation.setDescription(null);
         }
         return swaggerOperation;
     }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/EndpointsConfiguration.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/EndpointsConfiguration.java
@@ -15,15 +15,6 @@
  */
 package io.micronaut.openapi.visitor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micronaut.core.util.StringUtils;
-import io.micronaut.inject.visitor.VisitorContext;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.tags.Tag;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +22,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * Endpoints configuration.
@@ -60,14 +60,15 @@ class EndpointsConfiguration {
      * @param properties The properties to process.
      */
     EndpointsConfiguration(VisitorContext context, Properties properties) {
-        enabled = Boolean.parseBoolean(properties.getProperty(ENDPOINTS_ENABLED, Boolean.FALSE.toString()));
+        String enabledStr = OpenApiApplicationVisitor.getConfigurationProperty(ENDPOINTS_ENABLED, context);
+        enabled = StringUtils.hasText(enabledStr) && Boolean.parseBoolean(enabledStr);
         if (!enabled) {
             return;
         }
-        path = parsePath(properties.getProperty(ENDPOINTS_PATH, ""));
-        tags = parseTags(properties.getProperty(ENDPOINTS_TAGS, "").split(","));
-        servers = parseServers(properties.getProperty(ENDPOINTS_SERVERS, ""), context);
-        securityRequirements = parseSecurityRequirements(properties.getProperty(ENDPOINTS_SECURITY_REQUIREMENTS, ""), context);
+        path = parsePath(OpenApiApplicationVisitor.getConfigurationProperty(ENDPOINTS_PATH, context));
+        tags = parseTags(OpenApiApplicationVisitor.getConfigurationProperty(ENDPOINTS_TAGS, context));
+        servers = parseServers(OpenApiApplicationVisitor.getConfigurationProperty(ENDPOINTS_SERVERS, context), context);
+        securityRequirements = parseSecurityRequirements(OpenApiApplicationVisitor.getConfigurationProperty(ENDPOINTS_SECURITY_REQUIREMENTS, context), context);
         endpoints = new LinkedHashMap<>();
         Map<String, String> map = new HashMap<>(properties.size());
         properties.forEach((key, value) -> map.put((String) key, (String) value));
@@ -75,7 +76,7 @@ class EndpointsConfiguration {
                 .filter(EndpointsConfiguration::validEntry)
                 .forEach(entry -> {
                     int idx = entry.getKey().lastIndexOf('.');
-                    if (idx <= 0 || idx == entry.getKey().length() || entry.getValue() == null) {
+                    if (idx <= 0 || idx == entry.getKey().length() - 1 || entry.getValue() == null) {
                         return;
                     }
                     String entryType = entry.getKey().substring(idx + 1);
@@ -88,7 +89,7 @@ class EndpointsConfiguration {
                         endpoint.setServers(parseServers(entry.getValue(), context));
                     } else if ("tags".equals(entryType)) {
                         Endpoint endpoint = endpoints.computeIfAbsent(name, key -> new Endpoint());
-                        endpoint.setTags(parseTags(entry.getValue().split(",")));
+                        endpoint.setTags(parseTags(entry.getValue()));
                     } else if ("class".equals(entryType)) {
                         Endpoint endpoint = endpoints.computeIfAbsent(name, key -> new Endpoint());
                         endpoint.setClassElement(context.getClassElement(entry.getValue()));
@@ -159,12 +160,11 @@ class EndpointsConfiguration {
     }
 
     private static <T> List<T> parseModel(String s, VisitorContext context, TypeReference<List<T>> typeReference)  {
-        if (s == null || s.isEmpty() || (! s.startsWith("[") && ! s.endsWith("]"))) {
+        if (StringUtils.isEmpty(s) || (!s.startsWith("[") && !s.endsWith("]"))) {
             return Collections.emptyList();
         }
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.readValue(s, typeReference);
+            return ConvertUtils.getConvertJsonMapper().readValue(s, typeReference);
         } catch (JsonProcessingException e) {
             context.warn("Fail to parse " + typeReference.getType().toString() + ": " + s + " - " + e.getMessage(), null);
         }
@@ -180,7 +180,12 @@ class EndpointsConfiguration {
         && !entry.getKey().equals(ENDPOINTS_PATH);
     }
 
-    private static List<Tag> parseTags(String... stringTags) {
+    private static List<Tag> parseTags(String stringTagsStr) {
+
+        if (StringUtils.isEmpty(stringTagsStr)) {
+            return Collections.emptyList();
+        }
+        String[] stringTags = stringTagsStr.split(",");
         if (stringTags.length == 0) {
             return Collections.emptyList();
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -28,6 +28,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -101,6 +102,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 
 })
 public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements TypeElementVisitor<OpenAPIDefinition, Object> {
+
     /**
      * System property that enables setting the open api config file.
      */
@@ -257,14 +259,6 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
 
     @Nullable
     public static Environment getEnv(VisitorContext context) {
-        String isEnabledStr = System.getProperty(MICRONAUT_ENVIRONMENT_ENABLED, readOpenApiConfigFile(context).getProperty(MICRONAUT_ENVIRONMENT_ENABLED));
-        boolean isEnabled = true;
-        if (StringUtils.isNotEmpty(isEnabledStr)) {
-            isEnabled = Boolean.parseBoolean(isEnabledStr);
-        }
-        if (!isEnabled) {
-            return null;
-        }
         Environment existedEnvironment = context.get(MICRONAUT_ENVIRONMENT, Environment.class).orElse(null);
         Boolean envCreated = context.get(MICRONAUT_ENVIRONMENT_CREATED, Boolean.class).orElse(null);
         if (envCreated != null && envCreated) {
@@ -279,6 +273,17 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     }
 
     public static List<String> getActiveEnvs(VisitorContext context) {
+
+        String isEnabledStr = System.getProperty(MICRONAUT_ENVIRONMENT_ENABLED, readOpenApiConfigFile(context).getProperty(MICRONAUT_ENVIRONMENT_ENABLED));
+        boolean isEnabled = true;
+        if (StringUtils.isNotEmpty(isEnabledStr)) {
+            isEnabled = Boolean.parseBoolean(isEnabledStr);
+        }
+        context.put(MICRONAUT_ENVIRONMENT_ENABLED, isEnabled);
+        if (!isEnabled) {
+            return Collections.emptyList();
+        }
+
         String activeEnvStr = System.getProperty(MICRONAUT_OPENAPI_ENVIRONMENTS, readOpenApiConfigFile(context).getProperty(MICRONAUT_OPENAPI_ENVIRONMENTS));
         List<String> activeEnvs;
         if (StringUtils.isNotEmpty(activeEnvStr)) {
@@ -368,7 +373,9 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
 
     /**
      * Returns the EndpointsConfiguration.
+     *
      * @param context The context.
+     *
      * @return The EndpointsConfiguration.
      */
     static EndpointsConfiguration endPointsConfiguration(VisitorContext context) {
@@ -761,9 +768,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
 
     private void processEndpoints(VisitorContext visitorContext) {
         EndpointsConfiguration endpointsCfg = endPointsConfiguration(visitorContext);
-        if ("io.micronaut.annotation.processing.visitor.JavaVisitorContext".equals(visitorContext.getClass().getName())
-                && endpointsCfg.isEnabled()
-                && !endpointsCfg.getEndpoints().isEmpty()) {
+        if (endpointsCfg.isEnabled() && !endpointsCfg.getEndpoints().isEmpty()) {
             OpenApiEndpointVisitor visitor = new OpenApiEndpointVisitor(true);
             endpointsCfg.getEndpoints().values().stream()
             .filter(endpoint -> endpoint.getClassElement().isPresent())
@@ -783,6 +788,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     }
 
     static class LowerCamelCasePropertyNamingStrategy extends PropertyNamingStrategies.NamingBase {
+
         private static final long serialVersionUID = -2750503285679998670L;
 
         @Override
@@ -791,5 +797,4 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         }
 
     }
-
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -47,7 +47,6 @@ import javax.annotation.processing.SupportedOptions;
 import io.micronaut.context.ApplicationContextConfiguration;
 import io.micronaut.context.DefaultApplicationContextBuilder;
 import io.micronaut.context.env.Environment;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
@@ -88,7 +87,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
  * @author graemerocher
  * @since 1.0
  */
-@Experimental
 @SupportedOptions({
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY,

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -31,7 +31,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpMethod;
@@ -63,7 +62,6 @@ import static io.micronaut.openapi.visitor.Utils.DEFAULT_MEDIA_TYPES;
  * @author graemerocher
  * @since 1.0
  */
-@Experimental
 public class OpenApiControllerVisitor extends AbstractOpenApiEndpointVisitor implements TypeElementVisitor<Object, HttpMethodMapping> {
 
     private final String customUri;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
@@ -15,8 +15,15 @@
  */
 package io.micronaut.openapi.visitor;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.HttpMethod;
@@ -27,24 +34,11 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.management.endpoint.annotation.Delete;
-import io.micronaut.management.endpoint.annotation.Endpoint;
-import io.micronaut.management.endpoint.annotation.Read;
-import io.micronaut.management.endpoint.annotation.Selector;
-import io.micronaut.management.endpoint.annotation.Write;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
-
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 
@@ -57,8 +51,8 @@ import static io.micronaut.openapi.visitor.Utils.DEFAULT_MEDIA_TYPES;
  * @author croudet
  * @since 1.4
  */
-@Experimental
-public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor implements TypeElementVisitor<Endpoint, Object> {
+public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor implements TypeElementVisitor<Object, Object> {
+
     private String id;
     private HttpMethodDesciption methodDescription;
 
@@ -140,8 +134,8 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
         if (!enabled) {
             return true;
         }
-        if (element.isAnnotationPresent(Endpoint.class)) {
-            AnnotationValue<Endpoint> ann = element.getAnnotation(Endpoint.class);
+        if (element.isAnnotationPresent("io.micronaut.management.endpoint.annotation.Endpoint")) {
+            AnnotationValue<?> ann = element.getAnnotation("io.micronaut.management.endpoint.annotation.Endpoint");
             id = path + ann.stringValue("id").orElse(NameUtils.hyphenate(element.getSimpleName()));
             if (id.charAt(0) != '/') {
                 id = '/' + id;
@@ -178,7 +172,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     protected List<UriMatchTemplate> uriMatchTemplates(MethodElement element, VisitorContext context) {
         UriMatchTemplate uriTemplate = UriMatchTemplate.of(id);
         for (ParameterElement param : element.getParameters()) {
-            if (param.hasAnnotation(Selector.class)) {
+            if (param.hasAnnotation("io.micronaut.management.endpoint.annotation.Selector")) {
                 uriTemplate = uriTemplate.nest("/{" + param.getName() + "}");
             }
         }
@@ -204,7 +198,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     protected List<Tag> classTags(ClassElement element, VisitorContext context) {
         List<Tag> allTags = new ArrayList<>(tags);
         allTags.addAll(context.get(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENDPOINT_CLASS_TAGS, List.class,
-                Collections.emptyList()));
+            Collections.emptyList()));
         return allTags;
     }
 
@@ -212,7 +206,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     protected List<Server> methodServers(MethodElement element, VisitorContext context) {
         List<Server> servers = new ArrayList<>(this.servers);
         servers.addAll(context.get(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENDPOINT_SERVERS, List.class,
-                Collections.emptyList()));
+            Collections.emptyList()));
         return servers;
     }
 
@@ -220,7 +214,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     protected List<SecurityRequirement> methodSecurityRequirements(MethodElement element, VisitorContext context) {
         List<SecurityRequirement> securityRequirements = new ArrayList<>(this.securityRequirements);
         securityRequirements.addAll(context.get(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENDPOINT_SECURITY_REQUIREMENTS, List.class,
-                Collections.emptyList()));
+            Collections.emptyList()));
         return securityRequirements;
     }
 
@@ -232,23 +226,23 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     }
 
     private static HttpMethodDesciption httpMethodDescription(MethodElement element) {
-        HttpMethodDesciption httpMethodDescription = methodDescription(element, Write.class, HttpMethod.POST);
+        HttpMethodDesciption httpMethodDescription = methodDescription(element, "io.micronaut.management.endpoint.annotation.Write", HttpMethod.POST);
         if (httpMethodDescription != null) {
             return httpMethodDescription;
         }
-        httpMethodDescription = methodDescription(element, Read.class, HttpMethod.GET);
+        httpMethodDescription = methodDescription(element, "io.micronaut.management.endpoint.annotation.Read", HttpMethod.GET);
         if (httpMethodDescription != null) {
             return httpMethodDescription;
         }
-        return methodDescription(element, Delete.class, HttpMethod.DELETE);
+        return methodDescription(element, "io.micronaut.management.endpoint.annotation.Delete", HttpMethod.DELETE);
     }
 
-    private static HttpMethodDesciption methodDescription(MethodElement element, Class<? extends Annotation> ann, HttpMethod httpMethod) {
-        Optional<Class<? extends Annotation>> httpMethodOpt = element.getAnnotationTypeByStereotype(ann);
+    private static HttpMethodDesciption methodDescription(MethodElement element, String endpointManagementAnnName, HttpMethod httpMethod) {
+        Optional<Class<? extends Annotation>> httpMethodOpt = element.getAnnotationTypeByStereotype(endpointManagementAnnName);
         if (httpMethodOpt.isPresent()) {
-            AnnotationValue<?> annotation = element.getAnnotation(ann);
+            AnnotationValue<?> annotation = element.getAnnotation(endpointManagementAnnName);
             return new HttpMethodDesciption(httpMethod, annotation.stringValue("description").orElse(null),
-                    annotation.stringValues("produces"), annotation.stringValues("consumes"));
+                annotation.stringValues("produces"), annotation.stringValues("consumes"));
         }
         return null;
     }
@@ -259,6 +253,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
      * @author croudet
      */
     private static class HttpMethodDesciption {
+
         HttpMethod httpMethod;
         String description;
         String[] produces;
@@ -274,7 +269,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
         @Override
         public String toString() {
             return "HttpMethodDesciption [httpMethod=" + httpMethod + ", description=" + description + ", produces="
-                    + Arrays.toString(produces) + ", consumes=" + Arrays.toString(consumes) + "]";
+                + Arrays.toString(produces) + ", consumes=" + Arrays.toString(consumes) + "]";
         }
     }
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
@@ -15,12 +15,10 @@
  */
 package io.micronaut.openapi.visitor;
 
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.micronaut.core.annotation.AnnotationValue;
@@ -136,9 +134,13 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
         }
         if (element.isAnnotationPresent("io.micronaut.management.endpoint.annotation.Endpoint")) {
             AnnotationValue<?> ann = element.getAnnotation("io.micronaut.management.endpoint.annotation.Endpoint");
-            id = path + ann.stringValue("id").orElse(NameUtils.hyphenate(element.getSimpleName()));
-            if (id.charAt(0) != '/') {
-                id = '/' + id;
+            String idAnn = ann.stringValue("id").orElse(NameUtils.hyphenate(element.getSimpleName()));
+            if (idAnn.isEmpty()) {
+                idAnn = ann.stringValue("value").orElse(idAnn);
+            }
+            id = path + idAnn;
+            if (id.isEmpty() || id.charAt(0) != '/') {
+                id = "/" + id;
             }
             return false;
         }
@@ -238,8 +240,7 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     }
 
     private static HttpMethodDesciption methodDescription(MethodElement element, String endpointManagementAnnName, HttpMethod httpMethod) {
-        Optional<Class<? extends Annotation>> httpMethodOpt = element.getAnnotationTypeByStereotype(endpointManagementAnnName);
-        if (httpMethodOpt.isPresent()) {
+        if (element.isAnnotationPresent(endpointManagementAnnName)) {
             AnnotationValue<?> annotation = element.getAnnotation(endpointManagementAnnName);
             return new HttpMethodDesciption(httpMethod, annotation.stringValue("description").orElse(null),
                 annotation.stringValues("produces"), annotation.stringValues("consumes"));

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiIncludeVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiIncludeVisitor.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.openapi.visitor;
 
+import java.util.List;
+import java.util.Optional;
+
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.inject.ast.ClassElement;
@@ -24,21 +26,16 @@ import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.openapi.annotation.OpenAPIInclude;
 import io.micronaut.openapi.annotation.OpenAPIIncludes;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link TypeElementVisitor} that builds the Swagger model from Micronaut controllers included by @{@link OpenAPIInclude} at the compile time.
  *
  * @author Denis Stepanov
  */
-@Experimental
 public class OpenApiIncludeVisitor implements TypeElementVisitor<OpenAPIIncludes, Object> {
 
     @Override
@@ -57,7 +54,7 @@ public class OpenApiIncludeVisitor implements TypeElementVisitor<OpenAPIIncludes
                             .ifPresent(ce -> {
                                 if (ce.isAnnotationPresent(Controller.class)) {
                                     visit(controllerVisitor, visitorContext, ce);
-                                } else if (ce.isAnnotationPresent(Endpoint.class)) {
+                                } else if (ce.isAnnotationPresent("io.micronaut.management.endpoint.annotation.Endpoint")) {
                                     visit(endpointVisitor, visitorContext, ce);
                                 }
                             });

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiJacksonVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiJacksonVisitor.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.openapi.visitor;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
@@ -28,10 +30,8 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * A {@link TypeElementVisitor} that builds appropriate {@link Schema} annotation for the parent class of a hierarchy
@@ -40,7 +40,6 @@ import java.util.Set;
  * @author Iván López
  * @since 3.0.0
  */
-@Experimental
 public class OpenApiJacksonVisitor implements TypeElementVisitor<Object, Object> {
 
     @Override

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationWithjavadocSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationWithjavadocSpec.groovy
@@ -28,8 +28,26 @@ class MyController {
      * @param id UUID of test
      */
     @Delete("/")
-    public void deleteObj(@QueryValue int id) {
+    public MyDto deleteObj(@QueryValue int id) {
+        return null;
+    }
+}
 
+/**
+* My dto description
+*
+* @property test property desc
+*/
+class MyDto {
+
+    private String test;
+
+    public String getTest() {
+        return test;
+    }
+
+    public void setTest(String test) {
+        this.test = test;
     }
 }
 
@@ -39,6 +57,7 @@ class MyBean {}
 
         OpenAPI openAPI = Utils.testReference
         Operation operation = openAPI.paths?.get("/")?.delete
+        Schema schema = openAPI.components.schemas.MyDto
 
         expect:
         operation
@@ -49,6 +68,11 @@ class MyBean {}
         operation.parameters.size() == 1
         operation.parameters[0].name == 'id'
         operation.parameters[0].description == 'UUID of test'
+
+        schema
+        schema.properties.test
+        schema.properties.test.description == 'property desc'
+
     }
 
     void "test Operation description, summary and parameters"() {
@@ -148,7 +172,7 @@ class MyBean {}
         expect:
         operation
         operation.summary == 'Delete a thing'
-        operation.description == ''
+        operation.description == null
 
         operation.parameters
         operation.parameters.size() == 1
@@ -157,7 +181,7 @@ class MyBean {}
 
         operation2
         operation2.summary == 'Delete a thing'
-        operation2.description == ''
+        operation2.description == null
 
         operation2.parameters
         operation2.parameters.size() == 1

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPropsFromEnvSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPropsFromEnvSpec.groovy
@@ -66,6 +66,7 @@ class MyBean {}
         given:
         System.setProperty(OpenApiApplicationVisitor.MICRONAUT_ENVIRONMENT_ENABLED, "false")
         System.setProperty(Environment.ENVIRONMENTS_PROPERTY, "local")
+        System.setProperty("props-from-env-test.paths.my-controller.get", "myGet")
 
         buildBeanDefinition('test.MyBean', '''
 package test;
@@ -105,12 +106,14 @@ class MyBean {}
         paths.size() == 3
         paths.'/${props-from-env-test.paths.my-controller.post}'
         paths.'/${props-from-env-test.paths.my-controller.post}'.post
-        paths.'/${props-from-env-test.paths.my-controller.get}'
-        paths.'/${props-from-env-test.paths.my-controller.get}'.get
+        !paths.'/${props-from-env-test.paths.my-controller.get}'
+        paths.'/myGet'
+        paths.'/myGet'.get
         paths.'/${props-from-env-test.paths.my-controller.put}'
         paths.'/${props-from-env-test.paths.my-controller.put}'.put
 
         cleanup:
+        System.clearProperty("props-from-env-test.paths.my-controller.get")
         System.clearProperty(Environment.ENVIRONMENTS_PROPERTY)
         System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_ENVIRONMENT_ENABLED)
     }


### PR DESCRIPTION
 - Removed hard dependency on the micronaut-management library.
 - Removed Experimental annotations.
 - Micronaut test 3.6.2
 - fixed endpoints annotation processing for endpoints. Fixed different behavior endpoints processing for groovy and java.
 - Bug with check endpoints paths. Fix work with groovy (Fixed #602)
 - Remove empty operation description from final yaml
 - Add support kdoc `@property` tag for javadoc-parser
 - Allow system properties when micronaut environments disabled

@graemerocher When testing on a real project, I tried to use the OpenAPIDecorator annotation. As a result, I got an error that micronaut-management was not added as a dependency, because there is a use of classes from this library.This PR fixes this issue and minor bugs also.

Along the way, I found 2 bugs in the core:

https://github.com/micronaut-projects/micronaut-core/issues/8033
https://github.com/micronaut-projects/micronaut-core/pull/8028