### PR TITLE
Add ability to customize classes schemas in properties.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-projectVersion=4.6.1-SNAPSHOT
+projectVersion=4.7.0-SNAPSHOT
 projectGroup=io.micronaut.openapi
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.7.2
+micronautVersion=3.7.3
 micronautTestVersion=3.7.0
 groovyVersion=3.0.13
 spockVersion=2.3-groovy-3.0
@@ -13,7 +13,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-openapi
 developers=Puneet Behl,Álvaro Sánchez-Mariscal,Iván López
 
-githubCoreBranch=3.7.x
+githubCoreBranch=3.8.x
 
 bomProperty=micronautOpenapiVersion
 bomProperties=swaggerVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ managed-slf4j = "1.7.36"
 # Versions beyond 0.62.2 require Java 11
 managed-html2md-converter = "0.62.2"
 
-kotlin = "1.7.10"
+kotlin = "1.7.21"
 
 [libraries]
 # Duplicated to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -9,7 +9,7 @@ license {
         java   = 'SLASHSTAR_STYLE'
         groovy = 'SLASHSTAR_STYLE'
     }
-    ext.year = '2017-2020'
+    ext.year = '2017-2022'
 
     exclude "**/transaction/**"
     exclude '**/*.txt'

--- a/openapi/openapi-custom-schema-for-class.properties
+++ b/openapi/openapi-custom-schema-for-class.properties
@@ -1,0 +1,4 @@
+micronaut.openapi.schema.io.micronaut.openapi.ObjectId=java.lang.String
+micronaut.openapi.schema.io.micronaut.openapi.JAXBElement=io.micronaut.openapi.MyJaxbElement
+micronaut.openapi.schema.io.micronaut.openapi.JAXBElement<test.XmlElement2>=io.micronaut.openapi.MyJaxbElement2
+micronaut.openapi.schema.io.micronaut.openapi.JAXBElement<test.XmlElement3>=io.micronaut.openapi.MyJaxbElement3

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -73,6 +73,7 @@ import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.EnumConstantElement;
 import io.micronaut.inject.ast.EnumElement;
 import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.TypedElement;
@@ -122,7 +123,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static io.micronaut.openapi.visitor.ConvertUtils.normalizeValue;
 import static io.micronaut.openapi.visitor.ConvertUtils.resolveExtensions;
 import static io.micronaut.openapi.visitor.OpenApiApplicationVisitor.expandProperties;
 import static io.micronaut.openapi.visitor.OpenApiApplicationVisitor.getExpandableProperties;
@@ -766,10 +766,13 @@ abstract class AbstractOpenApiVisitor {
             }
         }
 
+        ClassElement componentType = type.getFirstTypeArgument().orElse(null);
+        Map<String, ClassElement> typeArgs = type.getTypeArguments();
+
         Schema schema = null;
 
         if (type instanceof EnumElement) {
-            schema = getSchemaDefinition(openAPI, context, type, definingElement, mediaTypes);
+            schema = getSchemaDefinition(openAPI, context, type, typeArgs, definingElement, mediaTypes);
         } else {
 
             boolean isPublisher = false;
@@ -780,15 +783,28 @@ abstract class AbstractOpenApiVisitor {
             if (!type.isAssignable("io.micronaut.http.multipart.StreamingFileUpload") && Utils.isContainerType(type)) {
                 isPublisher = type.isAssignable("org.reactivestreams.Publisher") && !type.isAssignable("reactor.core.publisher.Mono");
                 isObservable = type.isAssignable("io.reactivex.Observable") && !type.isAssignable("reactor.core.publisher.Mono");
-                type = type.getFirstTypeArgument().orElse(null);
+                type = componentType;
+                if (componentType != null) {
+                    typeArgs = componentType.getTypeArguments();
+                    componentType = componentType.getFirstTypeArgument().orElse(null);
+                }
             } else if (isTypeNullable(type)) {
                 isNullable = true;
-                type = type.getFirstTypeArgument().orElse(null);
+                type = componentType;
+                if (componentType != null) {
+                    typeArgs = componentType.getTypeArguments();
+                    componentType = componentType.getFirstTypeArgument().orElse(null);
+                }
             }
 
             if (type != null) {
 
                 String typeName = type.getName();
+                ClassElement customTypeSchema = OpenApiApplicationVisitor.getCustomSchema(typeName, typeArgs, context);
+                if (customTypeSchema != null) {
+                    type = customTypeSchema;
+                }
+
                 // File upload case
                 if ("io.micronaut.http.multipart.StreamingFileUpload".equals(typeName) ||
                     "io.micronaut.http.multipart.CompletedFileUpload".equals(typeName) ||
@@ -805,10 +821,10 @@ abstract class AbstractOpenApiVisitor {
                     schema = primitiveType.createProperty();
                 } else if (type.isAssignable(Map.class.getName())) {
                     schema = new MapSchema();
-                    if (type.getTypeArguments().isEmpty()) {
+                    if (typeArgs.isEmpty()) {
                         schema.setAdditionalProperties(true);
                     } else {
-                        ClassElement valueType = type.getTypeArguments().get("V");
+                        ClassElement valueType = typeArgs.get("V");
                         if (valueType.getName().equals(Object.class.getName())) {
                             schema.setAdditionalProperties(true);
                         } else {
@@ -822,9 +838,8 @@ abstract class AbstractOpenApiVisitor {
                             schema = SchemaUtils.arraySchema(schema);
                         }
                     } else {
-                        Optional<ClassElement> componentType = type.getFirstTypeArgument();
-                        if (componentType.isPresent()) {
-                            schema = resolveSchema(openAPI, type, componentType.get(), context, mediaTypes, null, classJavadoc);
+                        if (componentType != null) {
+                            schema = resolveSchema(openAPI, type, componentType, context, mediaTypes, null, classJavadoc);
                         } else {
                             schema = getPrimitiveType(Object.class.getName());
                         }
@@ -832,7 +847,7 @@ abstract class AbstractOpenApiVisitor {
                         if (schema != null && fields.isEmpty()) {
                             schema = SchemaUtils.arraySchema(schema);
                         } else {
-                            schema = getSchemaDefinition(openAPI, context, type, definingElement, mediaTypes);
+                            schema = getSchemaDefinition(openAPI, context, type, typeArgs, definingElement, mediaTypes);
                         }
                     }
                 } else if (Utils.isReturnTypeFile(type)) {
@@ -877,7 +892,7 @@ abstract class AbstractOpenApiVisitor {
                 } else if (type.isAssignable(Number.class)) {
                     schema = PrimitiveType.NUMBER.createProperty();
                 } else {
-                    schema = getSchemaDefinition(openAPI, context, type, definingElement, mediaTypes);
+                    schema = getSchemaDefinition(openAPI, context, type, typeArgs, definingElement, mediaTypes);
                 }
             }
 
@@ -916,7 +931,9 @@ abstract class AbstractOpenApiVisitor {
 
     private void handleUnwrapped(VisitorContext context, Element element, ClassElement elementType, Schema parentSchema, AnnotationValue<JsonUnwrapped> uw) {
         Map<String, Schema> schemas = SchemaUtils.resolveSchemas(Utils.resolveOpenAPI(context));
-        String schemaName = element.stringValue(io.swagger.v3.oas.annotations.media.Schema.class, "name").orElse(computeDefaultSchemaName(null, elementType));
+        ClassElement customElementType = OpenApiApplicationVisitor.getCustomSchema(elementType.getName(), elementType.getTypeArguments(), context);
+        String schemaName = element.stringValue(io.swagger.v3.oas.annotations.media.Schema.class, "name")
+            .orElse(computeDefaultSchemaName(null, customElementType != null ? customElementType : elementType, elementType.getTypeArguments(), context));
         Schema wrappedPropertySchema = schemas.get(schemaName);
         Map<String, Schema> properties = wrappedPropertySchema.getProperties();
         if (properties == null || properties.isEmpty()) {
@@ -1744,6 +1761,7 @@ abstract class AbstractOpenApiVisitor {
         OpenAPI openAPI,
         VisitorContext context,
         ClassElement type,
+        Map<String, ClassElement> typeArgs,
         @Nullable Element definingElement,
         List<MediaType> mediaTypes) {
         AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaValue = definingElement == null ? null : definingElement.getDeclaredAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
@@ -1761,7 +1779,7 @@ abstract class AbstractOpenApiVisitor {
                 primitiveType = null;
             }
             if (primitiveType == null) {
-                String schemaName = computeDefaultSchemaName(definingElement, type);
+                String schemaName = computeDefaultSchemaName(definingElement, type, typeArgs, context);
                 schema = schemas.get(schemaName);
                 JavadocDescription javadoc = Utils.getJavadocParser().parse(type.getDocumentation().orElse(null));
                 if (schema == null) {
@@ -1801,7 +1819,12 @@ abstract class AbstractOpenApiVisitor {
                                 schema = new ComposedSchema();
                                 for (ClassElement sType : superTypes) {
                                     if (!type.isRecord()) {
-                                        readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, sType, schemas);
+                                        Map<String, ClassElement> sTypeArgs = sType.getTypeArguments();
+                                        ClassElement customStype = OpenApiApplicationVisitor.getCustomSchema(sType.getName(), sTypeArgs, context);
+                                        if (customStype != null) {
+                                            sType = customStype;
+                                        }
+                                        readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, sType, schemas, sTypeArgs);
                                     }
                                 }
                             } else {
@@ -1817,7 +1840,7 @@ abstract class AbstractOpenApiVisitor {
                         }
                         schemas.put(schemaName, schema);
 
-                        populateSchemaProperties(openAPI, context, type, schema, mediaTypes, javadoc);
+                        populateSchemaProperties(openAPI, context, type, typeArgs, schema, mediaTypes, javadoc);
                         checkAllOf(schema);
                     }
                 }
@@ -1825,7 +1848,7 @@ abstract class AbstractOpenApiVisitor {
                 return primitiveType.createProperty();
             }
         } else {
-            String schemaName = schemaValue.stringValue("name").orElse(computeDefaultSchemaName(definingElement, type));
+            String schemaName = schemaValue.stringValue("name").orElse(computeDefaultSchemaName(definingElement, type, typeArgs, context));
             schema = schemas.get(schemaName);
             if (schema == null) {
                 if (inProgressSchemas.contains(schemaName)) {
@@ -1834,10 +1857,10 @@ abstract class AbstractOpenApiVisitor {
                 }
                 inProgressSchemas.add(schemaName);
                 try {
-                    schema = readSchema(schemaValue, openAPI, context, type, mediaTypes);
+                    schema = readSchema(schemaValue, openAPI, context, type, typeArgs, mediaTypes);
                     AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> typeSchema = type.getDeclaredAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
                     if (typeSchema != null) {
-                        Schema originalTypeSchema = readSchema(typeSchema, openAPI, context, type, mediaTypes);
+                        Schema originalTypeSchema = readSchema(typeSchema, openAPI, context, type, typeArgs, mediaTypes);
                         if (originalTypeSchema != null && schema != null) {
                             if (StringUtils.isNotEmpty(originalTypeSchema.getDescription())) {
                                 schema.setDescription(originalTypeSchema.getDescription());
@@ -1866,7 +1889,8 @@ abstract class AbstractOpenApiVisitor {
                             schema1.addAllOfItem(schema);
 
                             for (ClassElement sType : superTypes) {
-                                String schemaName2 = computeDefaultSchemaName(definingElement, sType);
+                                ClassElement customStype = OpenApiApplicationVisitor.getCustomSchema(sType.getName(), sType.getTypeArguments(), context);
+                                String schemaName2 = computeDefaultSchemaName(definingElement, customStype != null ? customStype : sType, sType.getTypeArguments(), context);
                                 Schema parentSchema = new Schema();
                                 parentSchema.set$ref(SchemaUtils.schemaRef(schemaName2));
                                 schema1.addAllOfItem(parentSchema);
@@ -1906,10 +1930,10 @@ abstract class AbstractOpenApiVisitor {
     }
 
     private void readAllInterfaces(OpenAPI openAPI, VisitorContext context, @Nullable Element definingElement, List<MediaType> mediaTypes,
-                                   Schema schema, ClassElement superType, Map<String, Schema> schemas) {
-        String parentSchemaName = computeDefaultSchemaName(definingElement, superType);
+                                   Schema schema, ClassElement superType, Map<String, Schema> schemas, Map<String, ClassElement> superTypeArgs) {
+        String parentSchemaName = computeDefaultSchemaName(definingElement, superType, superTypeArgs, context);
         if (schemas.get(parentSchemaName) != null
-            || getSchemaDefinition(openAPI, context, superType, null, mediaTypes) != null) {
+            || getSchemaDefinition(openAPI, context, superType, superTypeArgs, null, mediaTypes) != null) {
             Schema parentSchema = new Schema();
             parentSchema.set$ref(SchemaUtils.schemaRef(parentSchemaName));
             schema.addAllOfItem(parentSchema);
@@ -1920,10 +1944,23 @@ abstract class AbstractOpenApiVisitor {
                     || interfaceElement.getBeanProperties().isEmpty()) {
                     continue;
                 }
-                readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, interfaceElement, schemas);
+
+                Map<String, ClassElement> interfaceTypeArgs = interfaceElement.getTypeArguments();
+                ClassElement customInterfaceType = OpenApiApplicationVisitor.getCustomSchema(interfaceElement.getName(), interfaceTypeArgs, context);
+                if (customInterfaceType != null) {
+                    interfaceElement = customInterfaceType;
+                }
+
+                readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, interfaceElement, schemas, interfaceTypeArgs);
             }
         } else if (superType.getSuperType().isPresent()) {
-            readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, superType.getSuperType().get(), schemas);
+            ClassElement superSuperType = superType.getSuperType().get();
+            Map<String, ClassElement> superSuperTypeArgs = superSuperType.getTypeArguments();
+            ClassElement customSuperSuperType = OpenApiApplicationVisitor.getCustomSchema(superSuperType.getName(), superSuperTypeArgs, context);
+            if (customSuperSuperType != null) {
+                superSuperType = customSuperSuperType;
+            }
+            readAllInterfaces(openAPI, context, definingElement, mediaTypes, schema, superSuperType, schemas, superSuperTypeArgs);
         }
     }
 
@@ -1933,14 +1970,15 @@ abstract class AbstractOpenApiVisitor {
      * @param schemaValue annotation value
      * @param openAPI The OpenApi
      * @param context The VisitorContext
-     * @param type The element
+     * @param type type element
+     * @param typeArgs type arguments
      * @param mediaTypes The media types of schema
      *
      * @return New schema instance
      *
      * @throws JsonProcessingException when Json parsing fails
      */
-    protected Schema readSchema(AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaValue, OpenAPI openAPI, VisitorContext context, @Nullable Element type, List<MediaType> mediaTypes) throws JsonProcessingException {
+    protected Schema readSchema(AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaValue, OpenAPI openAPI, VisitorContext context, @Nullable Element type, Map<String, ClassElement> typeArgs, List<MediaType> mediaTypes) throws JsonProcessingException {
         Map<CharSequence, Object> values = schemaValue.getValues()
             .entrySet()
             .stream()
@@ -2023,7 +2061,7 @@ abstract class AbstractOpenApiVisitor {
             }
         } else {
             JavadocDescription javadoc = Utils.getJavadocParser().parse(type.getDescription());
-            populateSchemaProperties(openAPI, context, type, schema, mediaTypes, javadoc);
+            populateSchemaProperties(openAPI, context, type, typeArgs, schema, mediaTypes, javadoc);
             checkAllOf(composedSchema);
         }
         return schema;
@@ -2060,9 +2098,15 @@ abstract class AbstractOpenApiVisitor {
     private List<Schema<?>> namesToSchemas(OpenAPI openAPI, VisitorContext context, AnnotationClassValue<?>[] names, List<MediaType> mediaTypes) {
         return Arrays.stream(names)
             .flatMap((Function<AnnotationClassValue<?>, Stream<Schema<?>>>) classAnn -> {
-                final Optional<ClassElement> classElement = context.getClassElement(classAnn.getName());
-                if (classElement.isPresent()) {
-                    final Schema<?> schemaDefinition = getSchemaDefinition(openAPI, context, classElement.get(), null, mediaTypes);
+                final Optional<ClassElement> classElementOpt = context.getClassElement(classAnn.getName());
+                if (classElementOpt.isPresent()) {
+                    ClassElement classElement = classElementOpt.get();
+                    Map<String, ClassElement> classElementTypeArgs = classElement.getTypeArguments();
+                    ClassElement customClassElement = OpenApiApplicationVisitor.getCustomSchema(classElement.getName(), classElementTypeArgs, context);
+                    if (customClassElement != null) {
+                        classElement = customClassElement;
+                    }
+                    final Schema<?> schemaDefinition = getSchemaDefinition(openAPI, context, classElement, classElementTypeArgs, null, mediaTypes);
                     if (schemaDefinition != null) {
                         return Stream.of(schemaDefinition);
                     }
@@ -2072,38 +2116,48 @@ abstract class AbstractOpenApiVisitor {
             }).collect(Collectors.toList());
     }
 
-    private String computeDefaultSchemaName(Element definingElement, Element type) {
+    private String computeDefaultSchemaName(Element definingElement, Element type, Map<String, ClassElement> typeArgs, VisitorContext context) {
         final String metaAnnName = definingElement == null ? null : definingElement.getAnnotationNameByStereotype(io.swagger.v3.oas.annotations.media.Schema.class).orElse(null);
         if (metaAnnName != null && !io.swagger.v3.oas.annotations.media.Schema.class.getName().equals(metaAnnName)) {
             return NameUtils.getSimpleName(metaAnnName);
         }
         String javaName;
         if (type instanceof TypedElement) {
-            javaName = computeNameWithGenerics(((TypedElement) type).getType());
+            ClassElement typeType = ((TypedElement) type).getType();
+            if (CollectionUtils.isNotEmpty(typeType.getTypeArguments())) {
+                javaName = computeNameWithGenerics(typeType, typeArgs, context);
+            } else {
+                javaName = computeNameWithGenerics(typeType, Collections.emptyMap(), context);
+            }
         } else {
             javaName = type.getSimpleName();
         }
         return javaName.replace("$", ".");
     }
 
-    private String computeNameWithGenerics(ClassElement classElement) {
+    private String computeNameWithGenerics(ClassElement classElement, Map<String, ClassElement> typeArgs, VisitorContext context) {
         StringBuilder builder = new StringBuilder(classElement.getSimpleName());
-        computeNameWithGenerics(classElement, builder, new HashSet<>());
+        computeNameWithGenerics(classElement, builder, new HashSet<>(), typeArgs, context);
         return builder.toString();
     }
 
-    private void computeNameWithGenerics(ClassElement classElement, StringBuilder builder, Set<String> computed) {
+    private void computeNameWithGenerics(ClassElement classElement, StringBuilder builder, Set<String> computed, Map<String, ClassElement> typeArgs, VisitorContext context) {
         computed.add(classElement.getName());
-        final Map<String, ClassElement> typeArguments = classElement.getTypeArguments();
+        final Map<String, ClassElement> typeArguments = typeArgs;
         final Iterator<ClassElement> i = typeArguments.values().iterator();
         if (i.hasNext()) {
 
             builder.append('_');
             while (i.hasNext()) {
-                final ClassElement ce = i.next();
+                ClassElement ce = i.next();
                 builder.append(ce.getSimpleName());
+                Map<String, ClassElement> ceTypeArgs = ce.getTypeArguments();
+                ClassElement customElement = OpenApiApplicationVisitor.getCustomSchema(ce.getName(), ceTypeArgs, context);
+                if (customElement != null) {
+                    ce = customElement;
+                }
                 if (!computed.contains(ce.getName())) {
-                    computeNameWithGenerics(ce, builder, computed);
+                    computeNameWithGenerics(ce, builder, computed, ceTypeArgs, context);
                 }
                 if (i.hasNext()) {
                     builder.append('.');
@@ -2127,7 +2181,7 @@ abstract class AbstractOpenApiVisitor {
             "io.micronaut.annotation.processing.visitor.JavaVisitorContext".equals(context.getClass().getName());
     }
 
-    private void populateSchemaProperties(OpenAPI openAPI, VisitorContext context, Element type, Schema schema, List<MediaType> mediaTypes, JavadocDescription classJavadoc) {
+    private void populateSchemaProperties(OpenAPI openAPI, VisitorContext context, Element type, Map<String, ClassElement> typeArgs, Schema schema, List<MediaType> mediaTypes, JavadocDescription classJavadoc) {
         ClassElement classElement = null;
         if (type instanceof ClassElement) {
             classElement = (ClassElement) type;
@@ -2143,15 +2197,15 @@ abstract class AbstractOpenApiVisitor {
                 // Workaround for https://github.com/micronaut-projects/micronaut-openapi/issues/313
                 beanProperties = Collections.emptyList();
             }
-            processPropertyElements(openAPI, context, type, schema, beanProperties, mediaTypes, classJavadoc);
+            processPropertyElements(openAPI, context, type, typeArgs, schema, beanProperties, mediaTypes, classJavadoc);
 
             final List<FieldElement> publicFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.modifiers(mods -> mods.contains(ElementModifier.PUBLIC) && mods.size() == 1));
 
-            processPropertyElements(openAPI, context, type, schema, publicFields, mediaTypes, classJavadoc);
+            processPropertyElements(openAPI, context, type, typeArgs, schema, publicFields, mediaTypes, classJavadoc);
         }
     }
 
-    private void processPropertyElements(OpenAPI openAPI, VisitorContext context, Element type, Schema schema, List<? extends TypedElement> publicFields, List<MediaType> mediaTypes, JavadocDescription classJavadoc) {
+    private void processPropertyElements(OpenAPI openAPI, VisitorContext context, Element type, Map<String, ClassElement> typeArgs, Schema schema, List<? extends TypedElement> publicFields, List<MediaType> mediaTypes, JavadocDescription classJavadoc) {
 
         ClassElement classElement = null;
         if (type instanceof ClassElement) {
@@ -2183,12 +2237,20 @@ abstract class AbstractOpenApiVisitor {
 
             if (publicField instanceof MemberElement && ((MemberElement) publicField).getDeclaringType().getType().getName().equals(type.getName())) {
 
-                Schema propertySchema = resolveSchema(openAPI, publicField, publicField.getType(), context, mediaTypes, fieldJavadoc, classJavadoc);
+                ClassElement fieldType = publicField.getType();
+                if (publicField.getType() instanceof GenericPlaceholderElement) {
+                    ClassElement genericType = typeArgs.get(((GenericPlaceholderElement) publicField.getType()).getVariableName());
+                    if (genericType != null) {
+                        fieldType = genericType;
+                    }
+                }
+
+                Schema propertySchema = resolveSchema(openAPI, publicField, fieldType, context, mediaTypes, fieldJavadoc, classJavadoc);
 
                 processSchemaProperty(
                     context,
                     publicField,
-                    publicField.getType(),
+                    fieldType,
                     type,
                     schema,
                     propertySchema

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -29,6 +29,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,6 +51,7 @@ import io.micronaut.context.DefaultApplicationContextBuilder;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.GenericArgument;
 import io.micronaut.core.util.CollectionUtils;
@@ -98,7 +100,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_TARGET_FILE,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ADDITIONAL_FILES,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE,
-
 })
 public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements TypeElementVisitor<OpenAPIDefinition, Object> {
 
@@ -179,6 +180,24 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     private static final String MICRONAUT_ENVIRONMENT_CREATED = "micronaut.environment.created";
     private static final String MICRONAUT_OPENAPI_PROPERTIES = "micronaut.openapi.properties";
     private static final String MICRONAUT_OPENAPI_ENDPOINTS = "micronaut.openapi.endpoints";
+
+    /**
+     * Properties prefix to set custom schema implementations for selected clases.
+     * For example, if you want to set simple 'java.lang.String' class to some complex 'org.somepackage.MyComplexType' class you need to write:
+     * <p>
+     * micronaut.openapi.schema.org.somepackage.MyComplexType=java.lang.String
+     *
+     * Also, you can set it in your application.yml file like this:
+     * <p>
+     * micronaut:
+     *   openapi:
+     *     schema:
+     *       org.somepackage.MyComplexType: java.lang.String
+     *       org.somepackage.MyComplexType2: java.lang.Integer
+     *       ...
+     */
+    private static final String MICRONAUT_OPENAPI_SCHEMA = "micronaut.openapi.schema";
+    private static final String MICRONAUT_CUSTOM_SCHEMAS = "micronaut.internal.custom.schemas";
     /**
      * Loaded expandable properties. Need to save them to reuse in diffferent places.
      */
@@ -245,6 +264,108 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         }
 
         classElement = element;
+    }
+
+    public static ClassElement getCustomSchema(String className, Map<String, ClassElement> typeArgs, VisitorContext context) {
+
+        Map<String, CustomSchema> customSchemas = (Map<String, CustomSchema>) context.get(MICRONAUT_CUSTOM_SCHEMAS, Map.class).orElse(null);
+        if (customSchemas != null) {
+            String key = getClassNameWithGenerics(className, typeArgs);
+
+            CustomSchema customSchema = customSchemas.get(key);
+            if (customSchema != null) {
+                return customSchema.classElement;
+            }
+            customSchema = customSchemas.get(className);
+
+            return customSchema != null ? customSchema.classElement : null;
+        }
+
+        customSchemas = new HashMap<>();
+
+        // first read system properties
+        Properties sysProps = System.getProperties();
+        readCustomSchemas(sysProps, customSchemas, context);
+
+        // second read openapi.properties file
+        Properties fileProps = readOpenApiConfigFile(context);
+        readCustomSchemas(fileProps, customSchemas, context);
+
+        // third read environments properties
+        Environment environment = getEnv(context);
+        for (Map.Entry<String, Object> entry : environment.getProperties(MICRONAUT_OPENAPI_SCHEMA, StringConvention.RAW).entrySet()) {
+            String configuredClassName = entry.getKey();
+            String targetClassName = (String) entry.getValue();
+            readCustomSchema(configuredClassName, targetClassName, customSchemas, context);
+        }
+
+        context.put(MICRONAUT_CUSTOM_SCHEMAS, customSchemas);
+
+        if (customSchemas.isEmpty()) {
+            return null;
+        }
+
+        String key = getClassNameWithGenerics(className, typeArgs);
+
+        CustomSchema customSchema = customSchemas.get(key);
+        if (customSchema != null) {
+            return customSchema.classElement;
+        }
+        customSchema = customSchemas.get(className);
+
+        return customSchema != null ? customSchema.classElement : null;
+    }
+
+    private static String getClassNameWithGenerics(String className, Map<String, ClassElement> typeArgs) {
+        StringBuilder key = new StringBuilder(className);
+        if (!typeArgs.isEmpty()) {
+            key.append('<');
+            boolean isFirst = true;
+            for (ClassElement typeArg : typeArgs.values()) {
+                if (!isFirst) {
+                    key.append(',');
+                }
+                key.append(typeArg.getName());
+                isFirst = false;
+            }
+            key.append('>');
+        }
+        return key.toString();
+    }
+
+    private static void readCustomSchemas(Properties props, Map<String, CustomSchema> customSchemas, VisitorContext context) {
+
+        for (String prop : props.stringPropertyNames()) {
+            if (!prop.startsWith(MICRONAUT_OPENAPI_SCHEMA)) {
+                continue;
+            }
+            String className = prop.substring(MICRONAUT_OPENAPI_SCHEMA.length() + 1);
+            String targetClassName = props.getProperty(prop);
+            readCustomSchema(className, targetClassName, customSchemas, context);
+        }
+    }
+
+    private static void readCustomSchema(String className, String targetClassName, Map<String, CustomSchema> customSchemas, VisitorContext context) {
+        if (customSchemas.containsKey(className)) {
+            return;
+        }
+        ClassElement targetClassElement = context.getClassElement(targetClassName).orElse(null);
+        if (targetClassElement == null) {
+            context.warn("Can't find class " + targetClassName + " in classpath. Skip it.", null);
+            return;
+        }
+
+        List<String> configuredTypeArgs = null;
+        int genericNameStart = className.indexOf('<');
+        if (genericNameStart > 0) {
+            String[] generics = className.substring(genericNameStart + 1, className.indexOf('>')).split(",");
+            configuredTypeArgs = new ArrayList<>();
+            for (String generic : generics) {
+                configuredTypeArgs.add(generic.trim());
+            }
+        }
+
+        customSchemas.put(className, new CustomSchema(configuredTypeArgs, targetClassElement));
     }
 
     public static String getConfigurationProperty(String key, VisitorContext context) {
@@ -806,5 +927,24 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             return propertyName;
         }
 
+    }
+
+    static final class CustomSchema {
+
+        private final List<String> typeArgs;
+        private final ClassElement classElement;
+
+        private CustomSchema(List<String> typeArgs, ClassElement classElement) {
+            this.typeArgs = typeArgs;
+            this.classElement = classElement;
+        }
+
+        public List<String> getTypeArgs() {
+            return typeArgs;
+        }
+
+        public ClassElement getClassElement() {
+            return classElement;
+        }
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/JAXBElement.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/JAXBElement.java
@@ -1,0 +1,174 @@
+package io.micronaut.openapi;
+
+import java.io.Serializable;
+
+import javax.xml.namespace.QName;
+
+/**
+ * This class is copy of jakarta.xml.bind.api.JAXBElement
+ */
+public class JAXBElement<T> implements Serializable {
+
+    /**
+     * xml element tag name
+     */
+    final protected QName name;
+
+    /**
+     * Java datatype binding for xml element declaration's type.
+     */
+    final protected Class<T> declaredType;
+
+    final protected Class<?> scope;
+
+    /**
+     * xml element value.
+     * Represents content model and attributes of an xml element instance.
+     */
+    protected T value;
+
+    /**
+     * true iff the xml element instance has xsi:nil="true".
+     */
+    protected boolean nil = false;
+
+    /**
+     * Designates global scope for an xml element.
+     */
+    public static final class GlobalScope {
+
+        private GlobalScope() {
+        }
+    }
+
+    /**
+     * <p>Construct an xml element instance.</p>
+     *
+     * @param name Java binding of xml element tag name
+     * @param declaredType Java binding of xml element declaration's type
+     * @param scope Java binding of scope of xml element declaration.
+     *     Passing null is the same as passing {@code GlobalScope.class}
+     * @param value Java instance representing xml element's value.
+     *
+     * @see #getScope()
+     * @see #isTypeSubstituted()
+     */
+    public JAXBElement(QName name,
+                       Class<T> declaredType,
+                       Class<?> scope,
+                       T value) {
+        if (declaredType == null || name == null) {
+            throw new IllegalArgumentException();
+        }
+        this.declaredType = declaredType;
+        if (scope == null) {
+            scope = GlobalScope.class;
+        }
+        this.scope = scope;
+        this.name = name;
+        this.value = value;
+    }
+
+    /**
+     * Construct a xml element instance.
+     * <p>
+     * This is just a convenience method for {@code new JAXBElement(name,declaredType,GlobalScope.class,value)}
+     */
+    public JAXBElement(QName name, Class<T> declaredType, T value) {
+        this(name, declaredType, GlobalScope.class, value);
+    }
+
+    /**
+     * Returns the Java binding of the xml element declaration's type attribute.
+     */
+    public Class<T> getDeclaredType() {
+        return declaredType;
+    }
+
+    /**
+     * Returns the xml element tag name.
+     */
+    public QName getName() {
+        return name;
+    }
+
+    /**
+     * <p>Set the content model and attributes of this xml element.</p>
+     *
+     * <p>When this property is set to {@code null}, {@code isNil()} must by {@code true}.
+     * Details of constraint are described at {@link #isNil()}.</p>
+     *
+     * @see #isTypeSubstituted()
+     */
+    public void setValue(T t) {
+        value = t;
+    }
+
+    /**
+     * <p>Return the content model and attribute values for this element.</p>
+     *
+     * <p>See {@link #isNil()} for a description of a property constraint when
+     * this value is {@code null}</p>
+     */
+    public T getValue() {
+        return value;
+    }
+
+    /**
+     * Returns scope of xml element declaration.
+     *
+     * @return {@code GlobalScope.class} if this element is of global scope.
+     *
+     * @see #isGlobalScope()
+     */
+    public Class<?> getScope() {
+        return scope;
+    }
+
+    /**
+     * <p>Returns {@code true} iff this element instance content model
+     * is nil.</p>
+     *
+     * <p>This property always returns {@code true} when {@link #getValue()} is null.
+     * Note that the converse is not true, when this property is {@code true},
+     * {@link #getValue()} can contain a non-null value for attribute(s). It is
+     * valid for a nil xml element to have attribute(s).</p>
+     */
+    public boolean isNil() {
+        return (value == null) || nil;
+    }
+
+    /**
+     * <p>Set whether this element has nil content.</p>
+     *
+     * @see #isNil()
+     */
+    public void setNil(boolean value) {
+        nil = value;
+    }
+
+    /* Convenience methods
+     * (Not necessary but they do unambiguously conceptualize
+     *  the rationale behind this class' fields.)
+     */
+
+    /**
+     * Returns true iff this xml element declaration is global.
+     */
+    public boolean isGlobalScope() {
+        return scope == GlobalScope.class;
+    }
+
+    /**
+     * Returns true iff this xml element instance's value has a different
+     * type than xml element declaration's declared type.
+     */
+    public boolean isTypeSubstituted() {
+        if (value == null) {
+            return false;
+        }
+        return value.getClass() != declaredType;
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement.java
@@ -1,0 +1,23 @@
+package io.micronaut.openapi;
+
+class MyJaxbElement<T> {
+
+    private String type;
+    private T value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement2.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement2.java
@@ -1,0 +1,25 @@
+package io.micronaut.openapi;
+
+import java.util.List;
+
+class MyJaxbElement2 {
+
+    private String type;
+    private List<String> values;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement3.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/MyJaxbElement3.java
@@ -1,0 +1,23 @@
+package io.micronaut.openapi;
+
+class MyJaxbElement3 {
+
+    private String type;
+    private String value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/ObjectId.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/ObjectId.java
@@ -1,0 +1,380 @@
+package io.micronaut.openapi;
+
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This is copy of MongoDB bson class: org.bson.types.ObjectId
+ * Note: this class has a natural ordering that is inconsistent with equals.
+ */
+public final class ObjectId implements Comparable<ObjectId>, Serializable {
+
+    // unused, as this class uses a proxy for serialization
+    private static final long serialVersionUID = 1L;
+
+    private static final int OBJECT_ID_LENGTH = 12;
+    private static final int LOW_ORDER_THREE_BYTES = 0x00ffffff;
+
+    // Use primitives to represent the 5-byte random value.
+    private static final int RANDOM_VALUE1;
+    private static final short RANDOM_VALUE2;
+
+    private static final AtomicInteger NEXT_COUNTER = new AtomicInteger(new SecureRandom().nextInt());
+
+    private static final char[] HEX_CHARS = new char[]{
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    /**
+     * The timestamp
+     */
+    private final int timestamp;
+    /**
+     * The counter.
+     */
+    private final int counter;
+    /**
+     * the first four bits of randomness.
+     */
+    private final int randomValue1;
+    /**
+     * The last two bits of randomness.
+     */
+    private final short randomValue2;
+
+    /**
+     * Gets a new object id.
+     *
+     * @return the new id
+     */
+    public static ObjectId get() {
+        return new ObjectId();
+    }
+
+    /**
+     * Checks if a string could be an {@code ObjectId}.
+     *
+     * @param hexString a potential ObjectId as a String.
+     * @return whether the string could be an object id
+     * @throws IllegalArgumentException if hexString is null
+     */
+    public static boolean isValid(final String hexString) {
+        if (hexString == null) {
+            throw new IllegalArgumentException();
+        }
+
+        int len = hexString.length();
+        if (len != 24) {
+            return false;
+        }
+
+        for (int i = 0; i < len; i++) {
+            char c = hexString.charAt(i);
+            if (c >= '0' && c <= '9') {
+                continue;
+            }
+            if (c >= 'a' && c <= 'f') {
+                continue;
+            }
+            if (c >= 'A' && c <= 'F') {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Create a new object id.
+     */
+    public ObjectId() {
+        this(new Date());
+    }
+
+    /**
+     * Constructs a new instance using the given date.
+     *
+     * @param date the date
+     */
+    public ObjectId(final Date date) {
+        this(dateToTimestampSeconds(date), NEXT_COUNTER.getAndIncrement() & LOW_ORDER_THREE_BYTES, false);
+    }
+
+    /**
+     * Constructs a new instances using the given date and counter.
+     *
+     * @param date    the date
+     * @param counter the counter
+     * @throws IllegalArgumentException if the high order byte of counter is not zero
+     */
+    public ObjectId(final Date date, final int counter) {
+        this(dateToTimestampSeconds(date), counter, true);
+    }
+
+    /**
+     * Creates an ObjectId using the given time and counter.
+     *
+     * @param timestamp the time in seconds
+     * @param counter   the counter
+     * @throws IllegalArgumentException if the high order byte of counter is not zero
+     */
+    public ObjectId(final int timestamp, final int counter) {
+        this(timestamp, counter, true);
+    }
+
+    private ObjectId(final int timestamp, final int counter, final boolean checkCounter) {
+        this(timestamp, RANDOM_VALUE1, RANDOM_VALUE2, counter, checkCounter);
+    }
+
+    private ObjectId(final int timestamp, final int randomValue1, final short randomValue2, final int counter,
+                     final boolean checkCounter) {
+        if ((randomValue1 & 0xff000000) != 0) {
+            throw new IllegalArgumentException("The random value must be between 0 and 16777215 (it must fit in three bytes).");
+        }
+        if (checkCounter && ((counter & 0xff000000) != 0)) {
+            throw new IllegalArgumentException("The counter must be between 0 and 16777215 (it must fit in three bytes).");
+        }
+        this.timestamp = timestamp;
+        this.counter = counter & LOW_ORDER_THREE_BYTES;
+        this.randomValue1 = randomValue1;
+        this.randomValue2 = randomValue2;
+    }
+
+    /**
+     * Constructs a new instance from a 24-byte hexadecimal string representation.
+     *
+     * @param hexString the string to convert
+     * @throws IllegalArgumentException if the string is not a valid hex string representation of an ObjectId
+     */
+    public ObjectId(final String hexString) {
+        this(parseHexString(hexString));
+    }
+
+    /**
+     * Constructs a new instance from the given byte array
+     *
+     * @param bytes the byte array
+     * @throws IllegalArgumentException if array is null or not of length 12
+     */
+    public ObjectId(final byte[] bytes) {
+        this(ByteBuffer.wrap(bytes));
+    }
+
+    /**
+     * Constructs a new instance from the given ByteBuffer
+     *
+     * @param buffer the ByteBuffer
+     * @throws IllegalArgumentException if the buffer is null or does not have at least 12 bytes remaining
+     * @since 3.4
+     */
+    public ObjectId(final ByteBuffer buffer) {
+        // Note: Cannot use ByteBuffer.getInt because it depends on tbe buffer's byte order
+        // and ObjectId's are always in big-endian order.
+        timestamp = makeInt(buffer.get(), buffer.get(), buffer.get(), buffer.get());
+        randomValue1 = makeInt((byte) 0, buffer.get(), buffer.get(), buffer.get());
+        randomValue2 = makeShort(buffer.get(), buffer.get());
+        counter = makeInt((byte) 0, buffer.get(), buffer.get(), buffer.get());
+    }
+
+    /**
+     * Convert to a byte array.  Note that the numbers are stored in big-endian order.
+     *
+     * @return the byte array
+     */
+    public byte[] toByteArray() {
+        ByteBuffer buffer = ByteBuffer.allocate(OBJECT_ID_LENGTH);
+        putToByteBuffer(buffer);
+        return buffer.array();  // using .allocate ensures there is a backing array that can be returned
+    }
+
+    /**
+     * Convert to bytes and put those bytes to the provided ByteBuffer.
+     * Note that the numbers are stored in big-endian order.
+     *
+     * @param buffer the ByteBuffer
+     * @throws IllegalArgumentException if the buffer is null or does not have at least 12 bytes remaining
+     * @since 3.4
+     */
+    public void putToByteBuffer(final ByteBuffer buffer) {
+        buffer.put(int3(timestamp));
+        buffer.put(int2(timestamp));
+        buffer.put(int1(timestamp));
+        buffer.put(int0(timestamp));
+        buffer.put(int2(randomValue1));
+        buffer.put(int1(randomValue1));
+        buffer.put(int0(randomValue1));
+        buffer.put(short1(randomValue2));
+        buffer.put(short0(randomValue2));
+        buffer.put(int2(counter));
+        buffer.put(int1(counter));
+        buffer.put(int0(counter));
+    }
+
+    /**
+     * Gets the timestamp (number of seconds since the Unix epoch).
+     *
+     * @return the timestamp
+     */
+    public int getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Gets the timestamp as a {@code Date} instance.
+     *
+     * @return the Date
+     */
+    public Date getDate() {
+        return new Date((timestamp & 0xFFFFFFFFL) * 1000L);
+    }
+
+    /**
+     * Converts this instance into a 24-byte hexadecimal string representation.
+     *
+     * @return a string representation of the ObjectId in hexadecimal format
+     */
+    public String toHexString() {
+        char[] chars = new char[OBJECT_ID_LENGTH * 2];
+        int i = 0;
+        for (byte b : toByteArray()) {
+            chars[i++] = HEX_CHARS[b >> 4 & 0xF];
+            chars[i++] = HEX_CHARS[b & 0xF];
+        }
+        return new String(chars);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = timestamp;
+        result = 31 * result + counter;
+        result = 31 * result + randomValue1;
+        result = 31 * result + randomValue2;
+        return result;
+    }
+
+    @Override
+    public int compareTo(final ObjectId other) {
+        if (other == null) {
+            throw new NullPointerException();
+        }
+
+        byte[] byteArray = toByteArray();
+        byte[] otherByteArray = other.toByteArray();
+        for (int i = 0; i < OBJECT_ID_LENGTH; i++) {
+            if (byteArray[i] != otherByteArray[i]) {
+                return ((byteArray[i] & 0xff) < (otherByteArray[i] & 0xff)) ? -1 : 1;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return toHexString();
+    }
+
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ObjectId objectId = (ObjectId) o;
+        return timestamp == objectId.timestamp && counter == objectId.counter && randomValue1 == objectId.randomValue1 && randomValue2 == objectId.randomValue2;
+    }
+
+    private static class SerializationProxy implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final byte[] bytes;
+
+        SerializationProxy(final ObjectId objectId) {
+            bytes = objectId.toByteArray();
+        }
+
+        private Object readResolve() {
+            return new ObjectId(bytes);
+        }
+    }
+
+    static {
+        try {
+            SecureRandom secureRandom = new SecureRandom();
+            RANDOM_VALUE1 = secureRandom.nextInt(0x01000000);
+            RANDOM_VALUE2 = (short) secureRandom.nextInt(0x00008000);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] parseHexString(final String s) {
+        if (!isValid(s)) {
+            throw new IllegalArgumentException("invalid hexadecimal representation of an ObjectId: [" + s + "]");
+        }
+
+        byte[] b = new byte[OBJECT_ID_LENGTH];
+        for (int i = 0; i < b.length; i++) {
+            b[i] = (byte) Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
+        }
+        return b;
+    }
+
+    private static int dateToTimestampSeconds(final Date time) {
+        return (int) (time.getTime() / 1000);
+    }
+
+    // Big-Endian helpers, in this class because all other BSON numbers are little-endian
+
+    private static int makeInt(final byte b3, final byte b2, final byte b1, final byte b0) {
+        // CHECKSTYLE:OFF
+        return (((b3) << 24) |
+            ((b2 & 0xff) << 16) |
+            ((b1 & 0xff) << 8) |
+            ((b0 & 0xff)));
+        // CHECKSTYLE:ON
+    }
+
+    private static short makeShort(final byte b1, final byte b0) {
+        // CHECKSTYLE:OFF
+        return (short) (((b1 & 0xff) << 8) | ((b0 & 0xff)));
+        // CHECKSTYLE:ON
+    }
+
+    private static byte int3(final int x) {
+        return (byte) (x >> 24);
+    }
+
+    private static byte int2(final int x) {
+        return (byte) (x >> 16);
+    }
+
+    private static byte int1(final int x) {
+        return (byte) (x >> 8);
+    }
+
+    private static byte int0(final int x) {
+        return (byte) (x);
+    }
+
+    private static byte short1(final short x) {
+        return (byte) (x >> 8);
+    }
+
+    private static byte short0(final short x) {
+        return (byte) (x);
+    }
+
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenapiCustomSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenapiCustomSchemaSpec.groovy
@@ -1,0 +1,258 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.context.env.Environment
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
+
+class OpenapiCustomSchemaSpec extends AbstractOpenApiTypeElementSpec {
+
+    void "test custom OpenAPI schema for class"() {
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE, "openapi-custom-schema-for-class.properties")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.openapi.JAXBElement;
+import io.micronaut.openapi.ObjectId;
+
+@Controller
+class OpenApiController {
+
+    @Post("/path")
+    public void processSync(@Body MyDto dto) {
+    }
+}
+
+class MyDto {
+
+    private ObjectId id;
+    private JAXBElement<? extends XmlElement> xmlElement;
+    private JAXBElement<? extends XmlElement2> xmlElement2;
+    public JAXBElement<? extends XmlElement3> xmlElement3;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public JAXBElement<? extends XmlElement> getXmlElement() {
+        return xmlElement;
+    }
+
+    public void setXmlElement(JAXBElement<? extends XmlElement> xmlElement) {
+        this.xmlElement = xmlElement;
+    }
+
+    public JAXBElement<? extends XmlElement2> getXmlElement2() {
+        return xmlElement2;
+    }
+
+    public void setXmlElement2(JAXBElement<? extends XmlElement2> xmlElement2) {
+        this.xmlElement2 = xmlElement2;
+    }
+}
+
+class XmlElement {
+
+    private String propStr;
+    private int propNumPrimitive;
+    public Integer propNum;
+
+    public String getPropStr() {
+        return propStr;
+    }
+
+    public void setPropStr(String propStr) {
+        this.propStr = propStr;
+    }
+
+    public int getPropNumPrimitive() {
+        return propNumPrimitive;
+    }
+
+    public void setPropNumPrimitive(int propNumPrimitive) {
+        this.propNumPrimitive = propNumPrimitive;
+    }
+}
+
+class XmlElement2 {
+
+    private String propStr2;
+
+    public String getPropStr2() {
+        return propStr2;
+    }
+
+    public void setPropStr2(String propStr2) {
+        this.propStr2 = propStr2;
+    }
+}
+
+class XmlElement3 {
+
+    private String propStr3;
+
+    public String getPropStr3() {
+        return propStr3;
+    }
+
+    public void setPropStr3(String propStr3) {
+        this.propStr3 = propStr3;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        Utils.testReference != null
+
+        when:
+        OpenAPI openAPI = Utils.testReference
+        Schema myDtoSchema = openAPI.components.schemas.MyDto
+        Schema myJaxbElementSchema = openAPI.components.schemas.MyJaxbElement_XmlElement_
+        Schema myJaxbElement2Schema = openAPI.components.schemas.MyJaxbElement2
+        Schema myJaxbElement3Schema = openAPI.components.schemas.MyJaxbElement3
+        Schema xmlElementSchema = openAPI.components.schemas.XmlElement
+
+        then:
+
+        myDtoSchema
+        myDtoSchema.properties.id
+        myDtoSchema.properties.id.type == 'string'
+        myDtoSchema.properties.xmlElement.$ref == '#/components/schemas/MyJaxbElement_XmlElement_'
+        myDtoSchema.properties.xmlElement2.$ref == '#/components/schemas/MyJaxbElement2'
+        myDtoSchema.properties.xmlElement3.$ref == '#/components/schemas/MyJaxbElement3'
+
+        myJaxbElementSchema
+        myJaxbElementSchema.properties.type.type == 'string'
+        myJaxbElementSchema.properties.value.$ref == '#/components/schemas/XmlElement'
+
+        myJaxbElement2Schema
+        myJaxbElement2Schema.properties.type.type == 'string'
+        myJaxbElement2Schema.properties.values.type == 'array'
+        myJaxbElement2Schema.properties.values.items.type == 'string'
+
+        myJaxbElement3Schema
+        myJaxbElement3Schema.properties.type.type == 'string'
+        myJaxbElement3Schema.properties.value.type == 'string'
+
+        xmlElementSchema
+        xmlElementSchema.properties.propStr.type == 'string'
+        xmlElementSchema.properties.propNumPrimitive.type == 'integer'
+        xmlElementSchema.properties.propNum.type == 'integer'
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE)
+    }
+
+    void "test custom OpenAPI schema for class with env properties"() {
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_CONFIG_FILE_LOCATIONS, "project:/src/test/resources/")
+        System.setProperty(Environment.ENVIRONMENTS_PROPERTY, "schemaforclass")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.openapi.JAXBElement;
+import io.micronaut.openapi.ObjectId;
+
+@Controller
+class OpenApiController {
+
+    @Post("/path")
+    public void processSync(@Body MyDto dto) {
+    }
+}
+
+class MyDto {
+
+    private ObjectId id;
+    private JAXBElement<? extends XmlElement> xmlElement;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public JAXBElement<? extends XmlElement> getXmlElement() {
+        return xmlElement;
+    }
+
+    public void setXmlElement(JAXBElement<? extends XmlElement> xmlElement) {
+        this.xmlElement = xmlElement;
+    }
+}
+
+class XmlElement {
+
+    private String propStr;
+    private int propNumPrimitive;
+    public Integer propNum;
+
+    public String getPropStr() {
+        return propStr;
+    }
+
+    public void setPropStr(String propStr) {
+        this.propStr = propStr;
+    }
+
+    public int getPropNumPrimitive() {
+        return propNumPrimitive;
+    }
+
+    public void setPropNumPrimitive(int propNumPrimitive) {
+        this.propNumPrimitive = propNumPrimitive;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        Utils.testReference != null
+
+        when:
+        OpenAPI openAPI = Utils.testReference
+        Schema myDtoSchema = openAPI.components.schemas.MyDto
+        Schema myJaxbElementSchema = openAPI.components.schemas.MyJaxbElement_XmlElement_
+        Schema xmlElementSchema = openAPI.components.schemas.XmlElement
+
+        then:
+
+        myDtoSchema
+        myDtoSchema.properties.id
+        myDtoSchema.properties.id.type == 'string'
+        myDtoSchema.properties.xmlElement.$ref == '#/components/schemas/MyJaxbElement_XmlElement_'
+
+        myJaxbElementSchema
+        myJaxbElementSchema.properties.type.type == 'string'
+        myJaxbElementSchema.properties.value.$ref == '#/components/schemas/XmlElement'
+
+        xmlElementSchema
+        xmlElementSchema.properties.propStr.type == 'string'
+        xmlElementSchema.properties.propNumPrimitive.type == 'integer'
+        xmlElementSchema.properties.propNum.type == 'integer'
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_CONFIG_FILE_LOCATIONS)
+        System.clearProperty(Environment.ENVIRONMENTS_PROPERTY)
+    }
+}

--- a/openapi/src/test/resources/application-schemaforclass.yml
+++ b/openapi/src/test/resources/application-schemaforclass.yml
@@ -1,0 +1,5 @@
+micronaut:
+  openapi:
+    schema:
+      io.micronaut.openapi.ObjectId: java.lang.String
+      io.micronaut.openapi.JAXBElement: io.micronaut.openapi.MyJaxbElement

--- a/src/main/docs/guide/customSerializers.adoc
+++ b/src/main/docs/guide/customSerializers.adoc
@@ -1,0 +1,85 @@
+You can set custom classes to create different open api schemas for selected classes:
+
+```yaml
+micronaut:
+  openapi:
+  schema:
+    org.somepackage.MyComplexType: java.lang.String
+    org.somepackage.MyComplexType2: java.lang.Integer
+```
+
+or by system properties:
+
+```
+-Dmicronaut.opemapi.schema.org.somepackage.MyComplexType=java.lang.String -Dmicronaut.opemapi.schema.org.somepackage.MyComplexType2=java.lang.Integer
+```
+
+or by openapi.properties
+
+```properties
+micronaut.opemapi.schema.org.somepackage.MyComplexType=java.lang.String
+micronaut.opemapi.schema.org.somepackage.MyComplexType2=java.lang.Integer
+```
+
+Also, it can be used for replace classes schema with generics, for example, if you use jaxb generated classes and have custom serializer for JAXBElement class.
+And you can set cutom schemas for different type args.
+For example if you have this classes structure:
+
+```java
+package test.mypackage;
+
+class MyDto {
+
+    public JAXBElement<? extends XmlElement> xmlElement;
+    public JAXBElement<? extends XmlElement2> xmlElement2;
+    public JAXBElement<? extends XmlElement3> xmlElement3;
+}
+
+class XmlElement {
+    public String propStr;
+}
+
+class XmlElement2 {
+    public String propStr2;
+}
+
+class XmlElement3 {
+    public String propStr3;
+}
+```
+
+You can customize classes structure for openapi schema:
+
+```java
+package io.micronaut.openapi;
+
+// if you want to use generic from fields with type JAXBElement<T>
+class MyJaxbElement<T> {
+    public String type;
+    public T value;
+}
+
+class MyJaxbElement2 {
+    public String type;
+    public List<String> values;
+}
+
+class MyJaxbElement3 {
+    public String type;
+    public String value;
+}
+```
+
+And set openapi properties to map classes to custom openapi schema classes:
+
+```yaml
+micronaut:
+  openapi:
+    schema:
+      io.micronaut.openapi.JAXBElement: io.micronaut.openapi.MyJaxbElement
+      io.micronaut.openapi.JAXBElement<test.mypackage.XmlElement2>: io.micronaut.openapi.MyJaxbElement2
+      io.micronaut.openapi.JAXBElement<test.mypackage.XmlElement3>: io.micronaut.openapi.MyJaxbElement3
+```
+
+NOTE: Important!
+After changing these settings, a complete recompilation of the project is necessary to ensure that the new settings are applied correctly.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,26 +3,27 @@ releaseHistory: Release History
 cli: Using the Micronaut CLI
 gettingStarted: Dependencies
 openApiDefinition: OpenAPI Definition
-configuration: 
+configuration:
   title: OpenAPI Processing Options
   propertiesFileConfiguration: Configuring OpenAPI Processing with a properties file
   systemPropertyConfiguration: Configuring OpenAPI Processing with system properties
 exposingSwaggerOutput: Exposing Swagger Output
 controllers: OpenAPI Generation for Controllers
 namingstrategy: Naming Strategy
-swaggerAnnotations: 
+customSerializers: Custom serializers
+swaggerAnnotations:
   title: Swagger Annotations
   schemasAndPojos: Schemas and POJOs
   schemasAndMetaAnnotations: Schemas and Meta Annotations
   schemasAndGenerics: Schemas and Generics
   schemasNaming: Schemas naming
   schemasAnnotationResolution: Schemas Annotation resolution
-endpoints: 
+endpoints:
   title: Exposing Endpoints
   enableendpoints: Enable Endpoints
   endpointstags: Endpoints Tags
   micronautendpoints: Micronaut Built-In Endpoints
-  endpointservers: Endpoints Servers 
+  endpointservers: Endpoints Servers
   endpointssecurityrequirements: Endpoints Security Requirements
   endpointspath: Endpoints Path
 annotationConfiguration:


### PR DESCRIPTION
Now you can set custom classes to create different open api schemas for selected classes:
```yaml
micronaut:
  openapi:
    schema:
      org.somepackage.MyComplexType: java.lang.String
      org.somepackage.MyComplexType2: java.lang.Integer
```
or by system properties:
```
-Dmicronaut.opemapi.schema.org.somepackage.MyComplexType=java.lang.String -Dmicronaut.opemapi.schema.org.somepackage.MyComplexType2=java.lang.Integer
```
or by `openapi.properties`
```properties
micronaut.opemapi.schema.org.somepackage.MyComplexType=java.lang.String
micronaut.opemapi.schema.org.somepackage.MyComplexType2=java.lang.Integer
```

Also It can be used for replace classes schema with generics, for example, if you use jaxb generated classes and have custom serializer for JAXBElement class (see tests). And you can set cutom schemas for different type args. For example if you have this classes structure:
```java
package test.mypackage;

class MyDto {

    public JAXBElement<? extends XmlElement> xmlElement;
    public JAXBElement<? extends XmlElement2> xmlElement2;
    public JAXBElement<? extends XmlElement3> xmlElement3;
}

package test.mypackage;

class XmlElement {
    public String propStr;
}

package test.mypackage;

class XmlElement2 {
    public String propStr2;
}

package test.mypackage;

class XmlElement3 {
    public String propStr3;
}
```

You can customize classes structure for openapi schema:
```java
package io.micronaut.openapi;

// if you want to use generic from fields with type JAXBElement<T>
class MyJaxbElement<T> {
    public String type;
    public T value;
}

package io.micronaut.openapi;

class MyJaxbElement2 {
    public String type;
    public List<String> values;
}

package io.micronaut.openapi;

class MyJaxbElement3 {
    public String type;
    public String value;
}
```
And set openapi properties to map classes to custom openapi schema classes:
```yaml
micronaut:
  openapi:
    schema:
      io.micronaut.openapi.JAXBElement: io.micronaut.openapi.MyJaxbElement
      io.micronaut.openapi.JAXBElement<test.mypackage.XmlElement2>: io.micronaut.openapi.MyJaxbElement2
      io.micronaut.openapi.JAXBElement<test.mypackage.XmlElement3>: io.micronaut.openapi.MyJaxbElement3
```

Fixed #654