### PR TITLE
Apply Schema Attributes to subtitute Schema

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -751,16 +751,19 @@ abstract class AbstractOpenApiVisitor {
         if (type != null && schemaAnnotationValue == null) {
             schemaAnnotationValue = type.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
         }
+        boolean substitudedType = false;
         if (schemaAnnotationValue != null) {
             String impl = schemaAnnotationValue.stringValue("implementation").orElse(null);
             if (StringUtils.isNotEmpty(impl)) {
                 type = context.getClassElement(impl).orElse(type);
+                substitudedType = type != null;
             } else {
                 String schemaType = schemaAnnotationValue.stringValue("type").orElse(null);
                 if (StringUtils.isNotEmpty(schemaType) && !(type instanceof EnumElement)) {
                     PrimitiveType primitiveType = PrimitiveType.fromName(schemaType);
                     if (primitiveType != null && primitiveType != PrimitiveType.OBJECT) {
                         type = context.getClassElement(primitiveType.getKeyClass()).orElse(type);
+                        substitudedType = type != null;
                     }
                 }
             }
@@ -923,6 +926,10 @@ abstract class AbstractOpenApiVisitor {
                     schema = SchemaUtils.arraySchema(schema);
                 } else if (isNullable) {
                     schema.setNullable(true);
+                }
+
+                if (substitudedType) {
+                    ApplySubstituteSchema.apply(schemaAnnotationValue, schema);
                 }
             }
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ApplySubstituteSchema.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ApplySubstituteSchema.java
@@ -1,0 +1,66 @@
+package io.micronaut.openapi.visitor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+public class ApplySubstituteSchema {
+    private static final io.swagger.v3.oas.annotations.media.Schema DEFAULT_SCHEMA = DefaultSchema.class.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+    private static final List<ApplyIfNotDefault> APPLY_CHANGE_LIST;
+
+    static {
+        APPLY_CHANGE_LIST = new ArrayList<>();
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("pattern", String.class, DEFAULT_SCHEMA.pattern(), Schema::setPattern));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("maximum", String.class, DEFAULT_SCHEMA.maximum(), (s, v) -> s.setMaximum(new BigDecimal(v))));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("minimum", String.class, DEFAULT_SCHEMA.minimum(), (s, v) -> s.setMinimum(new BigDecimal(v))));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("maxLength", Integer.class, DEFAULT_SCHEMA.maxLength(), Schema::setMaxLength));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("minLength", Integer.class, DEFAULT_SCHEMA.minLength(), Schema::setMinLength));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("exclusiveMaximum", Boolean.class, DEFAULT_SCHEMA.exclusiveMaximum(), Schema::setExclusiveMaximum));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("exclusiveMinimum", Boolean.class, DEFAULT_SCHEMA.exclusiveMinimum(), Schema::setExclusiveMinimum));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("example", String.class, DEFAULT_SCHEMA.example(), Schema::setExample));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("defaultValue", String.class, DEFAULT_SCHEMA.defaultValue(), Schema::setDefault));
+        APPLY_CHANGE_LIST.add(new ApplyIfNotDefault<>("multipleOf", Double.class, DEFAULT_SCHEMA.multipleOf(), (s, v) -> s.setMultipleOf(new BigDecimal(v))));
+    }
+
+    /**
+     * Used when a substitute schema is used in place of the actual object or schema.  @Schema(implementation=String.class) or @Schema(type="String")
+     * Pulls values from the original Schema and applies it to the substitute Schema.
+     * @param schemaAnnotation Original Schema
+     * @param schema Substitute Schema
+     */
+    public static void apply(AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaAnnotation, Schema schema) {
+        for (ApplyIfNotDefault apply : APPLY_CHANGE_LIST) {
+            apply.apply(schemaAnnotation, schema);
+        }
+    }
+
+    private static class ApplyIfNotDefault<T> {
+        private final String getterName;
+        private final Class<T> getterType;
+        private final T defaultValue;
+        private final BiConsumer<Schema, T> setter;
+
+        public ApplyIfNotDefault(String name, Class<T> typeClass, T defaultValue, BiConsumer<Schema, T> setter) {
+            this.getterName = name;
+            this.getterType = typeClass;
+            this.defaultValue = defaultValue;
+            this.setter = setter;
+        }
+
+        public void apply(AnnotationValue<io.swagger.v3.oas.annotations.media.Schema> schemaAnnotation , Schema schema) {
+            schemaAnnotation.get(getterName, getterType)
+                .filter(v -> !Objects.equals(v, defaultValue))
+                .ifPresent(v -> setter.accept(schema, v));
+        }
+    }
+
+    // This is here to give me a place to grab a default Schema object to compare against.
+    @io.swagger.v3.oas.annotations.media.Schema
+    static class DefaultSchema{
+    }
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaJavaTimeSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaJavaTimeSpec.groovy
@@ -139,4 +139,109 @@ class MyBean {}
         openAPI.components.schemas['Response_Pet_'].properties['result'].$ref == '#/components/schemas/Pet'
     }
 
+    void "test parse the OpenAPI with Java @Schema implementation/type override"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;import com.fasterxml.jackson.annotation.JsonValue;import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.parameters.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.security.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.enums.*;
+import io.swagger.v3.oas.annotations.links.*;
+import io.micronaut.http.annotation.*;
+import java.time.*;
+import java.util.List;
+
+@Controller("/")
+class MyController {
+
+    @Put("/")
+    public Response<Pet> updatePet(Pet pet) {
+        return null;
+    }
+}
+
+class Pet {
+    private PetType petType;
+    private PetAge age;
+
+    public PetType getPetType() { return petType; }
+    public void setPetType(PetType newValue) { this.petType = newValue; }
+
+    public PetAge getPetAge() { return age; }
+    public void setPetAge(PetAge newValue) { this.age = newValue; }
+}
+
+@Schema(implementation = String.class, pattern = "pet_pattern", minLength = 3, maxLength = 10, example = "Dog", defaultValue = "Cat")
+class PetType {
+    private String value = "Cat";
+
+    @JsonCreator
+    public PetType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}
+
+
+@Schema(type = "Integer", minimum = "1", exclusiveMinimum = true, maximum = "200", exclusiveMaximum = true, multipleOf = 1)
+class PetAge {
+    private Integer value = 2;
+
+    @JsonCreator
+    public PetAge(Integer value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public Integer getValue() {
+        return value;
+    }
+}
+
+class Response<T> {
+    T r;
+    public T getResult() {
+        return r;
+    };
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openAPI = Utils.testReference
+        Operation operation = openAPI.paths?.get("/")?.put
+
+        expect:
+        operation
+        operation.responses.size() == 1
+        openAPI.components.schemas['Pet'].properties['petType'].type == 'string'
+        openAPI.components.schemas['Pet'].properties['petType'].pattern == 'pet_pattern'
+        openAPI.components.schemas['Pet'].properties['petType'].maxLength == 10
+        openAPI.components.schemas['Pet'].properties['petType'].minLength == 3
+        openAPI.components.schemas['Pet'].properties['petType'].example == "Dog"
+        openAPI.components.schemas['Pet'].properties['petType'].default == "Cat"
+        openAPI.components.schemas['Pet'].properties['petType'].exclusiveMaximum == null
+        openAPI.components.schemas['Pet'].properties['petType'].exclusiveMinimum == null
+        openAPI.components.schemas['Pet'].properties['petType'].multipleOf == null
+
+        openAPI.components.schemas['Pet'].properties['petAge'].type == 'integer'
+        openAPI.components.schemas['Pet'].properties['petAge'].maximum == 200
+        openAPI.components.schemas['Pet'].properties['petAge'].exclusiveMaximum
+        openAPI.components.schemas['Pet'].properties['petAge'].minimum == 1
+        openAPI.components.schemas['Pet'].properties['petAge'].exclusiveMinimum
+        openAPI.components.schemas['Pet'].properties['petAge'].multipleOf == 1
+        openAPI.components.schemas['Pet'].properties['petAge'].default == null
+        openAPI.components.schemas['Response_Pet_'].properties['result'].$ref == '#/components/schemas/Pet'
+    }
+
 }


### PR DESCRIPTION
This is attempting to address issue #847. If you would like me to adjust things please let me know.

When specifying @Schema(implementation=String.class ...) all of the other parameters on the annotation are lost. The changes here will apply many of those annotation parameter values to the substitute Schema. The ones I applied are pattern, maximum, minimum, maxLength, minLength, exclusiveMaximum, exclusiveMinimum, example, defaultValue, multipleOf.

