### PR TITLE
Fixed bug with UI resources url prefix when use `micronaut.openapi.server.context.path`

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
@@ -78,9 +78,9 @@ public final class OpenApiViewConfig {
      */
     enum RendererType {
 
-        SWAGGER_UI(SLASH + TEMPLATES_SWAGGER_UI),
-        REDOC(SLASH + TEMPLATES_REDOC),
-        RAPIDOC(SLASH + TEMPLATES_RAPIDOC);
+        SWAGGER_UI(TEMPLATES_SWAGGER_UI),
+        REDOC(TEMPLATES_REDOC),
+        RAPIDOC(TEMPLATES_RAPIDOC);
 
         private final String templatePath;
 

--- a/openapi/src/main/java/io/micronaut/openapi/view/RapiPDFConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/RapiPDFConfig.java
@@ -92,6 +92,7 @@ final class RapiPDFConfig extends AbstractViewConfig {
     private RapiPDFConfig() {
         super("rapipdf.");
         jsUrl = DEFAULT_RAPIPDF_JS_PATH;
+        withFinalUrlPrefixCache = false;
     }
 
     /**


### PR DESCRIPTION
These changes were wrong: https://github.com/micronaut-projects/micronaut-openapi/pull/843. Now all works fine only if don't use `micronaut.server.context-path` or `micronaut.openapi.server.context.path` properties