### PR TITLE
Add ability to set visibility level for class fields

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -99,6 +99,7 @@ import static io.swagger.v3.oas.models.Components.COMPONENTS_SCHEMAS_REF;
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_JSON_FORMAT,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ENVIRONMENTS,
     OpenApiApplicationVisitor.MICRONAUT_ENVIRONMENT_ENABLED,
+    OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL,
     OpenApiApplicationVisitor.MICRONAUT_CONFIG_FILE_LOCATIONS,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_TARGET_FILE,
     OpenApiApplicationVisitor.MICRONAUT_OPENAPI_VIEWS_DEST_DIR,
@@ -139,6 +140,17 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
      * System property that specifies the location of additional swagger YAML and JSON files to read from.
      */
     public static final String MICRONAUT_OPENAPI_ADDITIONAL_FILES = "micronaut.openapi.additional.files";
+    /**
+     * System property that specifies the schema classes fields visibility level. By default, only public fields visibile.
+     * <p>
+     * Available values:
+     * </p>
+     * PRIVATE
+     * PACKAGE
+     * PROTECTED
+     * PUBLIC
+     */
+    public static final String MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL = "micronaut.openapi.field.visibility.level";
     /**
      * Default openapi config file.
      */

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
@@ -32,7 +32,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.DefaultConversionService;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.http.MediaType;
 import io.micronaut.inject.ast.ClassElement;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/VisibilityLevel.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/VisibilityLevel.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.visitor;
+
+/**
+ * Visibility level for properties, constructors and methods.
+ */
+public enum VisibilityLevel {
+    PRIVATE,
+    PACKAGE,
+    PROTECTED,
+    PUBLIC
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPublicFieldsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPublicFieldsSpec.groovy
@@ -9,17 +9,18 @@ class OpenApiPublicFieldsSpec extends AbstractOpenApiTypeElementSpec {
 
     void "test that public fields can also be used to define schema"() {
 
-        given:"An API definition"
+        given: "An API definition"
         when:
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import io.reactivex.*;
-import io.micronaut.http.annotation.*;
-import java.util.List;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.*;
-import com.fasterxml.jackson.annotation.*;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * @author graemerocher
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.annotation.*;
 @Controller("/pets")
 interface PetOperations<T extends Pet> {
 
-    @Post("/")
+    @Post
     Single<T> save(String name, int age);
 }
 
@@ -58,23 +59,23 @@ class Pet {
 @jakarta.inject.Singleton
 class MyBean {}
 ''')
-        then:"the state is correct"
+        then: "the state is correct"
         Utils.testReference != null
 
-        when:"The OpenAPI is retrieved"
+        when: "The OpenAPI is retrieved"
         OpenAPI openAPI = Utils.testReference
         Schema petSchema = openAPI.components.schemas['Pet']
 
-        then:"the components are valid"
+        then: "the components are valid"
         petSchema.type == 'object'
         petSchema.properties.size() == 1
         petSchema.properties['age'].type == 'integer'
         !petSchema.required
 
-        when:"the /pets path is retrieved"
+        when: "the /pets path is retrieved"
         PathItem pathItem = openAPI.paths.get("/pets")
 
-        then:"it is included in the OpenAPI doc"
+        then: "it is included in the OpenAPI doc"
         pathItem.post.operationId == 'save'
         pathItem.post.requestBody
         pathItem.post.requestBody.required
@@ -85,5 +86,411 @@ class MyBean {}
         pathItem.post.requestBody.content['application/json'].schema.properties.size() == 2
         pathItem.post.requestBody.content['application/json'].schema.properties['name'].type == 'string'
         !pathItem.post.requestBody.content['application/json'].schema.properties['name'].nullable
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
+    }
+
+    void "test private visibility level"() {
+
+        given: "An API definition"
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL, VisibilityLevel.PRIVATE.toString())
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    @Post
+    Single<T> save(String name, int age);
+}
+
+class Pet {
+
+    private int privateAge;
+    protected int protectedAge;
+    int packageAge;
+
+    public int age;
+
+    // ignored by json
+    @JsonIgnore
+    public int ignored;
+    // hidden by swagger
+    @Hidden
+    public int hidden;
+    // hidden by swagger
+    @Schema(hidden = true)
+    public int hidden2;
+
+    // private should not be included
+    private String name;
+
+    // protected should not be included
+    protected String protectme;
+
+    // static should not be included
+    public static String CONST;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then: "the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 6
+        petSchema.properties.privateAge.type == 'integer'
+        petSchema.properties.protectedAge.type == 'integer'
+        petSchema.properties.packageAge.type == 'integer'
+        petSchema.properties.age.type == 'integer'
+        petSchema.properties.name.type == 'string'
+        petSchema.properties.protectme.type == 'string'
+        !petSchema.required
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
+    }
+
+    void "test package-private visibility level"() {
+
+        given: "An API definition"
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL, VisibilityLevel.PACKAGE.toString())
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    @Post
+    Single<T> save(String name, int age);
+}
+
+class Pet {
+
+    private int privateAge;
+    protected int protectedAge;
+    int packageAge;
+
+    public int age;
+
+    // ignored by json
+    @JsonIgnore
+    public int ignored;
+    // hidden by swagger
+    @Hidden
+    public int hidden;
+    // hidden by swagger
+    @Schema(hidden = true)
+    public int hidden2;
+
+    // private should not be included
+    private String name;
+
+    // protected should not be included
+    protected String protectme;
+
+    // static should not be included
+    public static String CONST;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then: "the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 4
+        petSchema.properties.protectedAge.type == 'integer'
+        petSchema.properties.packageAge.type == 'integer'
+        petSchema.properties.age.type == 'integer'
+        petSchema.properties.protectme.type == 'string'
+        !petSchema.required
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
+    }
+
+    void "test protected visibility level"() {
+
+        given: "An API definition"
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL, VisibilityLevel.PROTECTED.toString())
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    @Post
+    Single<T> save(String name, int age);
+}
+
+class Pet {
+
+    private int privateAge;
+    protected int protectedAge;
+    int packageAge;
+
+    public int age;
+
+    // ignored by json
+    @JsonIgnore
+    public int ignored;
+    // hidden by swagger
+    @Hidden
+    public int hidden;
+    // hidden by swagger
+    @Schema(hidden = true)
+    public int hidden2;
+
+    // private should not be included
+    private String name;
+
+    // protected should not be included
+    protected String protectme;
+
+    // static should not be included
+    public static String CONST;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then: "the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 3
+        petSchema.properties.protectedAge.type == 'integer'
+        petSchema.properties.age.type == 'integer'
+        petSchema.properties.protectme.type == 'string'
+        !petSchema.required
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
+    }
+
+    void "test public visibility level"() {
+
+        given: "An API definition"
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL, VisibilityLevel.PUBLIC.toString())
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    @Post
+    Single<T> save(String name, int age);
+}
+
+class Pet {
+
+    private int privateAge;
+    protected int protectedAge;
+    int packageAge;
+
+    public int age;
+
+    // ignored by json
+    @JsonIgnore
+    public int ignored;
+    // hidden by swagger
+    @Hidden
+    public int hidden;
+    // hidden by swagger
+    @Schema(hidden = true)
+    public int hidden2;
+
+    // private should not be included
+    private String name;
+
+    // protected should not be included
+    protected String protectme;
+
+    // static should not be included
+    public static String CONST;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then: "the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 1
+        petSchema.properties.age.type == 'integer'
+        !petSchema.required
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
+    }
+
+    void "test private visibility level with getters"() {
+
+        given: "An API definition"
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL, VisibilityLevel.PRIVATE.toString())
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.reactivex.Single;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Controller("/pets")
+interface PetOperations<T extends Pet> {
+
+    @Post
+    Single<T> save(String name, int age);
+}
+
+class Pet {
+
+    private int privateAge;
+    protected int protectedAge;
+    int packageAge;
+
+    public int age;
+
+    // ignored by json
+    @JsonIgnore
+    public int ignored;
+    // hidden by swagger
+    @Hidden
+    public int hidden;
+    // hidden by swagger
+    @Schema(hidden = true)
+    public int hidden2;
+
+    // private should not be included
+    private String name;
+
+    // protected should not be included
+    protected String protectme;
+
+    // static should not be included
+    public static String CONST;
+
+    int getPrivateAge() {
+        return privateAge;
+    }
+
+    void setPrivateAge(int privateAge) {
+        this.privateAge = privateAge;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Schema petSchema = openAPI.components.schemas['Pet']
+
+        then: "the components are valid"
+        petSchema.type == 'object'
+        petSchema.properties.size() == 6
+        petSchema.properties.privateAge.type == 'integer'
+        petSchema.properties.protectedAge.type == 'integer'
+        petSchema.properties.packageAge.type == 'integer'
+        petSchema.properties.age.type == 'integer'
+        petSchema.properties.name.type == 'string'
+        petSchema.properties.protectme.type == 'string'
+        !petSchema.required
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL)
     }
 }


### PR DESCRIPTION
I ran into a problem: I have classes that have fields starting with a capital letter (this is a legacy api that needs to be translated to a new engine with backwards compatibility). Okay, the problem can be solved with the JacksonProperty annotation, but when you have several hundred fields, it's very difficult.

My solution is this: I describe the fields in the classes in the same way as they are serialized in json, but in order to have less code, I use the scope for the fields - package-private (otherwise you will have to write the word `public` too many times). I did not add getters or setters to reduce the number of lines, and even lombok will not help here, because there will be a conflict in the names of getters and setters due to the fact that the fields start with a capital letter. Next, I added an object mapper setting:
```java
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
```

This method works and will allow you to write code to a minimum.

But there is a problem with the openapi generator, because micronaut-openapi only respects public fields at the moment.

This PR allows you to set the visibility level for the fields in the class that need to be taken into account when generating the model