### PR TITLE
New feature: schema decorators

### DIFF
--- a/openapi/openapi-schema-decorators.properties
+++ b/openapi/openapi-schema-decorators.properties
@@ -1,0 +1,2 @@
+micronaut.openapi.schema-postfix.io.micronaut.openapi.api.v1_0_0=1_0_0
+micronaut.openapi.schema-postfix.io.micronaut.openapi.api.v2_0_1=2_0_1

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -2121,11 +2121,11 @@ abstract class AbstractOpenApiVisitor {
         if (metaAnnName != null && !io.swagger.v3.oas.annotations.media.Schema.class.getName().equals(metaAnnName)) {
             return NameUtils.getSimpleName(metaAnnName);
         }
-        String fullClassName;
+        String packageName;
         String javaName;
         if (type instanceof TypedElement) {
             ClassElement typeType = ((TypedElement) type).getType();
-            fullClassName = typeType.getName();
+            packageName = typeType.getPackageName();
             if (CollectionUtils.isNotEmpty(typeType.getTypeArguments())) {
                 javaName = computeNameWithGenerics(typeType, typeArgs, context);
             } else {
@@ -2133,9 +2133,8 @@ abstract class AbstractOpenApiVisitor {
             }
         } else {
             javaName = type.getSimpleName();
-            fullClassName = type.getName();
+            packageName = NameUtils.getPackageName(type.getName());
         }
-        String packageName = fullClassName.substring(0, fullClassName.lastIndexOf('.'));
         OpenApiApplicationVisitor.SchemaDecorator schemaDecorator = OpenApiApplicationVisitor.getSchemaDecoration(packageName, context);
         javaName = javaName.replace("$", ".");
         if (schemaDecorator != null) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -219,7 +219,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     private static final String MICRONAUT_OPENAPI_SCHEMA = "micronaut.openapi.schema";
     private static final String MICRONAUT_CUSTOM_SCHEMAS = "micronaut.internal.custom.schemas";
     /**
-     * Properties prefix to set schema name prefixe or postfix by package.
+     * Properties prefix to set schema name prefix or postfix by package.
      * For example, if you have some classes with same names in different packages you can set postfix like this:
      * <p>
      * micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -219,6 +219,25 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     private static final String MICRONAUT_OPENAPI_SCHEMA = "micronaut.openapi.schema";
     private static final String MICRONAUT_CUSTOM_SCHEMAS = "micronaut.internal.custom.schemas";
     /**
+     * Properties prefix to set schema name prefixe or postfix by package.
+     * For example, if you have some classes with same names in different packages you can set postfix like this:
+     * <p>
+     * micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0
+     * micronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
+     * <p>
+     * Also, you can set it in your application.yml file like this:
+     * <p>
+     * micronaut:
+     *   openapi:
+     *     schema-postfix:
+     *         org.api.v1_0_0: 1_0_0
+     *         org.api.v2_0_0: 2_0_0
+     *       ...
+     */
+    private static final String MICRONAUT_OPENAPI_SCHEMA_PREFIX = "micronaut.openapi.schema-prefix";
+    private static final String MICRONAUT_OPENAPI_SCHEMA_POSTFIX = "micronaut.openapi.schema-postfix";
+    private static final String MICRONAUT_SCHEMA_DECORATORS = "micronaut.internal.schema-decorators";
+    /**
      * Loaded expandable properties. Need to save them to reuse in diffferent places.
      */
     private static final String MICRONAUT_INTERNAL_EXPANDBLE_PROPERTIES = "micronaut.internal.expandable.props";
@@ -284,6 +303,76 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         }
 
         classElement = element;
+    }
+
+    public static SchemaDecorator getSchemaDecoration(String packageName, VisitorContext context) {
+
+        Map<String, SchemaDecorator> schemaDecorators = (Map<String, SchemaDecorator>) context.get(MICRONAUT_SCHEMA_DECORATORS, Map.class).orElse(null);
+        if (schemaDecorators != null) {
+            return schemaDecorators.get(packageName);
+        }
+
+        schemaDecorators = new HashMap<>();
+
+        // first read system properties
+        Properties sysProps = System.getProperties();
+        readSchemaDecorators(sysProps, schemaDecorators, context);
+
+        // second read openapi.properties file
+        Properties fileProps = readOpenApiConfigFile(context);
+        readSchemaDecorators(fileProps, schemaDecorators, context);
+
+        // third read environments properties
+        Environment environment = getEnv(context);
+        if (environment != null) {
+            for (Map.Entry<String, Object> entry : environment.getProperties(MICRONAUT_OPENAPI_SCHEMA_PREFIX, StringConvention.RAW).entrySet()) {
+                String configuredPackageName = entry.getKey();
+                SchemaDecorator decorator = schemaDecorators.get(entry.getKey());
+                if (decorator == null) {
+                    schemaDecorators.put(entry.getKey(), decorator = new SchemaDecorator());
+                }
+                decorator.setPrefix((String) entry.getValue());
+            }
+
+            for (Map.Entry<String, Object> entry : environment.getProperties(MICRONAUT_OPENAPI_SCHEMA_POSTFIX, StringConvention.RAW).entrySet()) {
+                String configuredPackageName = entry.getKey();
+                SchemaDecorator decorator = schemaDecorators.get(entry.getKey());
+                if (decorator == null) {
+                    schemaDecorators.put(entry.getKey(), decorator = new SchemaDecorator());
+                }
+                decorator.setPostfix((String) entry.getValue());
+            }
+        }
+
+        context.put(MICRONAUT_SCHEMA_DECORATORS, schemaDecorators);
+
+        return schemaDecorators.get(packageName);
+    }
+
+    private static void readSchemaDecorators(Properties props, Map<String, SchemaDecorator> schemaDecorators, VisitorContext context) {
+
+        for (String prop : props.stringPropertyNames()) {
+            boolean isPrefix = false;
+            String packageName = null;
+            if (prop.startsWith(MICRONAUT_OPENAPI_SCHEMA_PREFIX)) {
+                packageName = prop.substring(MICRONAUT_OPENAPI_SCHEMA_PREFIX.length() + 1);
+                isPrefix = true;
+            } else if (prop.startsWith(MICRONAUT_OPENAPI_SCHEMA_POSTFIX)) {
+                packageName = prop.substring(MICRONAUT_OPENAPI_SCHEMA_POSTFIX.length() + 1);
+            }
+            if (StringUtils.isEmpty(packageName)) {
+                continue;
+            }
+            SchemaDecorator schemaDecorator = schemaDecorators.get(packageName);
+            if (schemaDecorator == null) {
+                schemaDecorators.put(packageName, schemaDecorator = new SchemaDecorator());
+            }
+            if (isPrefix) {
+                schemaDecorator.setPrefix(props.getProperty(prop));
+            } else {
+                schemaDecorator.setPostfix(props.getProperty(prop));
+            }
+        }
     }
 
     public static ClassElement getCustomSchema(String className, Map<String, ClassElement> typeArgs, VisitorContext context) {
@@ -1058,6 +1147,28 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
 
         public ClassElement getClassElement() {
             return classElement;
+        }
+    }
+
+    static final class SchemaDecorator {
+
+        private String prefix;
+        private String postfix;
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPostfix() {
+            return postfix;
+        }
+
+        public void setPostfix(String postfix) {
+            this.postfix = postfix;
         }
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/api/v1_0_0/MyDto.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/api/v1_0_0/MyDto.java
@@ -1,0 +1,4 @@
+package io.micronaut.openapi.api.v1_0_0;
+
+public class MyDto {
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/api/v2_0_1/MyDto.java
+++ b/openapi/src/test/groovy/io/micronaut/openapi/api/v2_0_1/MyDto.java
@@ -1,0 +1,4 @@
+package io.micronaut.openapi.api.v2_0_1;
+
+public class MyDto {
+}

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaDecoratorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaDecoratorSpec.groovy
@@ -1,0 +1,135 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.context.env.Environment
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
+
+class OpenApiSchemaDecoratorSpec extends AbstractOpenApiTypeElementSpec {
+
+    void "test custom OpenAPI schema decorators"() {
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE, "openapi-schema-decorators.properties")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller
+class OpenApiController {
+
+    @Get("/v0")
+    public MyDto getV0() {
+        return null;
+    }
+
+    @Get("/v1")
+    public io.micronaut.openapi.api.v1_0_0.MyDto getV1() {
+        return null;
+    }
+
+    @Get("/v2")
+    public io.micronaut.openapi.api.v2_0_1.MyDto getV2() {
+        return null;
+    }
+}
+
+class MyDto {
+
+    public String field;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        Utils.testReference != null
+
+        when:
+        OpenAPI openAPI = Utils.testReference
+        Schema myDtoSchema = openAPI.components.schemas.MyDto
+        Schema myDtoSchema1 = openAPI.components.schemas.MyDto1_0_0
+        Schema myDtoSchema2 = openAPI.components.schemas.MyDto2_0_1
+
+        then:
+
+        myDtoSchema
+        openAPI.paths."/v0".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto'
+
+        myDtoSchema1
+        openAPI.paths."/v1".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto1_0_0'
+
+        myDtoSchema2
+        openAPI.paths."/v2".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto2_0_1'
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_CONFIG_FILE)
+    }
+
+    void "test custom OpenAPI schema decorators with environments"() {
+        given:
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_CONFIG_FILE_LOCATIONS, "project:/src/test/resources/")
+        System.setProperty(Environment.ENVIRONMENTS_PROPERTY, "schemadecorator")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller
+class OpenApiController {
+
+    @Get("/v0")
+    public MyDto getV0() {
+        return null;
+    }
+
+    @Get("/v1")
+    public io.micronaut.openapi.api.v1_0_0.MyDto getV1() {
+        return null;
+    }
+
+    @Get("/v2")
+    public io.micronaut.openapi.api.v2_0_1.MyDto getV2() {
+        return null;
+    }
+}
+
+class MyDto {
+
+    public String field;
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        Utils.testReference != null
+
+        when:
+        OpenAPI openAPI = Utils.testReference
+        Schema myDtoSchema = openAPI.components.schemas.MyDto
+        Schema myDtoSchema1 = openAPI.components.schemas.MyDto1_0_0
+        Schema myDtoSchema2 = openAPI.components.schemas.MyDto2_0_1
+
+        then:
+
+        myDtoSchema
+        openAPI.paths."/v0".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto'
+
+        myDtoSchema1
+        openAPI.paths."/v1".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto1_0_0'
+
+        myDtoSchema2
+        openAPI.paths."/v2".get.responses['200'].content."application/json".schema.$ref == '#/components/schemas/MyDto2_0_1'
+
+        cleanup:
+        System.clearProperty(OpenApiApplicationVisitor.MICRONAUT_CONFIG_FILE_LOCATIONS)
+        System.clearProperty(Environment.ENVIRONMENTS_PROPERTY)
+    }
+}

--- a/openapi/src/test/resources/application-schemadecorator.yml
+++ b/openapi/src/test/resources/application-schemadecorator.yml
@@ -1,0 +1,5 @@
+micronaut:
+  openapi:
+    schema-postfix:
+      io.micronaut.openapi.api.v1_0_0: '1_0_0'
+      io.micronaut.openapi.api.v2_0_1: '2_0_1'

--- a/src/main/docs/guide/schemaDecorators.adoc
+++ b/src/main/docs/guide/schemaDecorators.adoc
@@ -1,0 +1,25 @@
+If you have some classes with same names in different packages you can set postfix like this:
+
+```yaml
+micronaut:
+  openapi:
+    schema-postfix:
+      org.api.v1_0_0: 1_0_0
+      org.api.v2_0_0: 2_0_0
+```
+
+or by system properties:
+
+```
+-Dmicronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0 -Dmicronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
+```
+
+or by openapi.properties
+
+```properties
+micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0
+micronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
+```
+
+NOTE: Important!
+After changing these settings, a complete recompilation of the project is necessary to ensure that the new settings are applied correctly.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -11,6 +11,7 @@ exposingSwaggerOutput: Exposing Swagger Output
 controllers: OpenAPI Generation for Controllers
 namingstrategy: Naming Strategy
 customSerializers: Custom serializers
+schemaDecorators: Schema decorators
 swaggerAnnotations:
   title: Swagger Annotations
   schemasAndPojos: Schemas and POJOs


### PR DESCRIPTION
If you have some classes with same names in different packages you can set postfix like this:

```yaml
micronaut:
  openapi:
    schema-postfix:
      org.api.v1_0_0: 1_0_0
      org.api.v2_0_0: 2_0_0
```
or by system properties:
```
-Dmicronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0 -Dmicronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
```
or by openapi.properties
```properties
micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0
micronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
```
