### PR TITLE
Fix logic for `micronaut.environment.enabled`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ projectVersion=4.8.2-SNAPSHOT
 projectGroup=io.micronaut.openapi
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.7.4
+micronautVersion=3.8.0
 micronautTestVersion=3.8.0
-groovyVersion=3.0.13
+groovyVersion=3.0.14
 spockVersion=2.3-groovy-3.0
 
 title=OpenAPI/Swagger Support

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ managed-slf4j = "1.7.36"
 # Versions beyond 0.62.2 require Java 11
 managed-html2md-converter = "0.62.2"
 
-kotlin = "1.7.21"
+kotlin = "1.7.22"
 
 [libraries]
 # Duplicated to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0

--- a/openapi/build.gradle
+++ b/openapi/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api(libs.managed.swagger.models)
     api(libs.managed.swagger.annotations)
     api(libs.managed.javadoc.parser)
-    api(libs.managed.slf4j.nop)
+    api(mn.slf4j.nop)
     api(libs.managed.html2md.converter) {
         exclude group: "org.jetbrains", module: "annotations"
     }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -51,7 +51,6 @@ import java.util.stream.Stream;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
@@ -301,11 +300,8 @@ abstract class AbstractOpenApiVisitor {
                 result.append(c);
             }
 
-            String resultPath = result.toString();
-            Environment environment = OpenApiApplicationVisitor.getEnv(context);
-            if (environment != null) {
-                resultPath = environment.getPlaceholderResolver().resolvePlaceholders(resultPath).orElse(resultPath);
-            }
+            String resultPath = OpenApiApplicationVisitor.replacePlaceholders(result.toString(), context);
+
             if (!resultPath.startsWith("/") && !resultPath.startsWith("$")) {
                 resultPath = "/" + resultPath;
             }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -493,6 +493,10 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
 
     @Nullable
     public static Environment getEnv(VisitorContext context) {
+        if (!isEnvEnabled(context)) {
+            return null;
+        }
+
         Environment existedEnvironment = context != null ? context.get(MICRONAUT_ENVIRONMENT, Environment.class).orElse(null) : null;
         Boolean envCreated = context != null ? context.get(MICRONAUT_ENVIRONMENT_CREATED, Boolean.class).orElse(null) : null;
         if (envCreated != null && envCreated) {
@@ -508,8 +512,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         return environment;
     }
 
-    public static List<String> getActiveEnvs(VisitorContext context) {
-
+    private static boolean isEnvEnabled(VisitorContext context) {
         String isEnabledStr = System.getProperty(MICRONAUT_ENVIRONMENT_ENABLED, readOpenApiConfigFile(context).getProperty(MICRONAUT_ENVIRONMENT_ENABLED));
         boolean isEnabled = true;
         if (StringUtils.isNotEmpty(isEnabledStr)) {
@@ -518,7 +521,12 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         if (context != null) {
             context.put(MICRONAUT_ENVIRONMENT_ENABLED, isEnabled);
         }
-        if (!isEnabled) {
+        return isEnabled;
+    }
+
+    public static List<String> getActiveEnvs(VisitorContext context) {
+
+        if (!isEnvEnabled(context)) {
             return Collections.emptyList();
         }
 
@@ -871,16 +879,43 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     }
 
     public static String expandProperties(String s, List<Map.Entry<String, String>> properties, VisitorContext context) {
-        if (StringUtils.isEmpty(s)) {
+        if (StringUtils.isEmpty(s) || !s.contains(Utils.PLACEHOLDER_PREFIX)) {
             return s;
         }
+
+        // form openapi file (expandable properties)
         if (CollectionUtils.isNotEmpty(properties)) {
             for (Map.Entry<String, String> entry : properties) {
                 s = s.replace(entry.getKey(), entry.getValue());
             }
         }
-        Environment environment = getEnv(context);
-        return environment != null ? environment.getPlaceholderResolver().resolvePlaceholders(s).orElse(s) : s;
+
+        return replacePlaceholders(s, context);
+    }
+
+    public static String replacePlaceholders(String value, VisitorContext context) {
+        if (StringUtils.isEmpty(value) || !value.contains(Utils.PLACEHOLDER_PREFIX)) {
+            return value;
+        }
+        // system properties
+        if (CollectionUtils.isNotEmpty(System.getProperties())) {
+            for (Map.Entry<Object, Object> sysProp : System.getProperties().entrySet()) {
+                value = value.replace(Utils.PLACEHOLDER_PREFIX + sysProp.getKey().toString() + Utils.PLACEHOLDER_POSTFIX, sysProp.getValue().toString());
+            }
+        }
+
+        // form openapi file
+        for (Map.Entry<Object, Object> fileProp : OpenApiApplicationVisitor.readOpenApiConfigFile(context).entrySet()) {
+            value = value.replace(Utils.PLACEHOLDER_PREFIX + fileProp.getKey().toString() + Utils.PLACEHOLDER_POSTFIX, fileProp.getValue().toString());
+        }
+
+        // from environments
+        Environment environment = OpenApiApplicationVisitor.getEnv(context);
+        if (environment != null) {
+            value = environment.getPlaceholderResolver().resolvePlaceholders(value).orElse(value);
+        }
+
+        return value;
     }
 
     public static List<Map.Entry<String, String>> getExpandableProperties(VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import io.micronaut.context.RequiresCondition;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
-import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -187,21 +186,19 @@ public class OpenApiControllerVisitor extends AbstractOpenApiEndpointVisitor imp
             controllerValue = customUri;
         }
 
-        Environment environment = OpenApiApplicationVisitor.getEnv(context);
-        PropertyPlaceholderResolver propertyPlaceholderResolver = environment != null ? environment.getPlaceholderResolver() : Utils.getPropertyPlaceholderResolver();
-        controllerValue = propertyPlaceholderResolver.resolvePlaceholders(controllerValue).orElse(controllerValue);
+        controllerValue = OpenApiApplicationVisitor.replacePlaceholders(controllerValue, context);
 
         UriMatchTemplate matchTemplate = UriMatchTemplate.of(controllerValue);
         // check if we have multiple uris
         String[] uris = element.stringValues(HttpMethodMapping.class, "uris");
         if (uris.length == 0) {
             String methodValue = element.getValue(HttpMethodMapping.class, String.class).orElse("/");
-            methodValue = propertyPlaceholderResolver.resolvePlaceholders(methodValue).orElse(methodValue);
+            methodValue = OpenApiApplicationVisitor.replacePlaceholders(methodValue, context);
             return Collections.singletonList(matchTemplate.nest(methodValue));
         } else {
             List<UriMatchTemplate> matchTemplates = new ArrayList<>(uris.length);
             for (String methodValue : uris) {
-                methodValue = propertyPlaceholderResolver.resolvePlaceholders(methodValue).orElse(methodValue);
+                methodValue = OpenApiApplicationVisitor.replacePlaceholders(methodValue, context);
                 matchTemplates.add(matchTemplate.nest(methodValue));
             }
             return matchTemplates;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/Utils.java
@@ -47,6 +47,9 @@ import io.swagger.v3.oas.models.OpenAPI;
  */
 public final class Utils {
 
+    public static final String PLACEHOLDER_PREFIX = "${";
+    public static final String PLACEHOLDER_POSTFIX = "}";
+
     public static final String ATTR_OPENAPI = "io.micronaut.OPENAPI";
     public static final String ATTR_TEST_MODE = "io.micronaut.OPENAPI_TEST";
     public static final String ATTR_VISITED_ELEMENTS = "io.micronaut.OPENAPI.visited.elements";

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPageSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPageSpec.groovy
@@ -81,7 +81,6 @@ class MyBean {}
         sliceMyDtoSchema.properties.empty
         sliceMyDtoSchema.properties.numberOfElements
 
-        sortSchema.properties.sorted
         sortSchema.properties.orderBy
 
         sortOrderSchema.properties.ignoreCase


### PR DESCRIPTION
Fix logic for `micronaut.environment.enabled`.
Improve process logic to resolve placeholders.
Fix read system properties, when environments disabled.
Micronaut 3.8.0

Fixes #854