### PR TITLE
Add getting schema type from JsonValue method and fixed incorrect processing supertypes for enums

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -2088,7 +2088,8 @@ abstract class AbstractOpenApiVisitor {
         return schema;
     }
 
-    private String checkEnumJsonValueType(EnumElement type, String schemaType) {
+    @NonNull
+    private String checkEnumJsonValueType(@NonNull EnumElement type, @Nullable String schemaType) {
         if (schemaType != null && !schemaType.equals(PrimitiveType.STRING.getCommonName())) {
             return schemaType;
         }


### PR DESCRIPTION
Don't need to create schemas and process them for classes `java.lang.Object` and `java.lang.Enum`