### PR TITLE
ci: make visitor package internal

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/package-info.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes related with OpenAPI Visitor.
+ * @author Sergio del Amo
+ * @since 4.8.3
+ */
+@Internal
+package io.micronaut.openapi.visitor;
+
+import io.micronaut.core.annotation.Internal;


### PR DESCRIPTION
This PR changes the package `io.micronaut.openapi.visitor` to be internal. 

There were breaking changes: 

```
Constructor io.micronaut.openapi.visitor.OpenApiControllerVisitor(java.util.List,java.util.List): Is not binary compatible. 
If you did this intentionally, please accept the change and provide an explanation: [Accept this change](file:///Users/sdelamo/github/micronaut-projects/micronaut-openapi/openapi/build/reports/binary-compatibility-openapi.html#accept-io_micronaut_openapi_visitor_OpenApiControllerVisitorConstructor_io_micronaut_openapi_visitor_OpenApiControllerVisitor_java_util_List_java_util_List_)

Constructor has been removed
```

