### PR TITLE
Minor fixes for allOf and other improvements.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=4.8.7-SNAPSHOT
 projectGroup=io.micronaut.openapi
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.8.8
+micronautVersion=3.8.9
 micronautTestVersion=3.9.1
 groovyVersion=3.0.15
 spockVersion=2.3-groovy-3.0

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -659,7 +659,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             return;
         }
 
-        Parameter newParameter = processMethodParameterAnnotation(context, permitsRequestBody, pathVariables, parameter, extraBodyParameters);
+        Parameter newParameter = processMethodParameterAnnotation(context, swaggerOperation, permitsRequestBody, pathVariables, parameter, extraBodyParameters);
         if (newParameter == null) {
             return;
         }
@@ -744,7 +744,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         }
     }
 
-    private Parameter processMethodParameterAnnotation(VisitorContext context, boolean permitsRequestBody,
+    private Parameter processMethodParameterAnnotation(VisitorContext context, io.swagger.v3.oas.models.Operation swaggerOperation,
+                                                       boolean permitsRequestBody,
                                                        Map<String, UriMatchVariable> pathVariables, TypedElement parameter,
                                                        List<TypedElement> extraBodyParameters) {
         Parameter newParameter = null;
@@ -761,7 +762,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             String paramName = parameter.getValue(PathVariable.class, String.class).orElse(parameterName);
             UriMatchVariable variable = pathVariables.get(paramName);
             if (variable == null) {
-                context.fail("Path variable name: '" + paramName + "' not found in path.", parameter);
+                context.warn("Path variable name: '" + paramName + "' not found in path, operation: " + swaggerOperation.getOperationId(), parameter);
                 return null;
             }
             newParameter = new PathParameter();

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -1557,7 +1557,9 @@ abstract class AbstractOpenApiVisitor {
                     }
                     s.setType(null);
                 }
-                schemaToBind.addAllOfItem(s);
+                if (schemaToBind.getAllOf() == null || !schemaToBind.getAllOf().contains(s)) {
+                    schemaToBind.addAllOfItem(s);
+                }
             }
         }
         final AnnotationClassValue<?>[] anyOf = (AnnotationClassValue<?>[]) annValues.get("anyOf");
@@ -2132,7 +2134,9 @@ abstract class AbstractOpenApiVisitor {
                     }
                     s.setType(null);
                 }
-                composedSchema.addAllOfItem(s);
+                if (composedSchema.getAllOf() == null || !composedSchema.getAllOf().contains(s)) {
+                    composedSchema.addAllOfItem(s);
+                }
             }
         }
         final AnnotationClassValue<?>[] anyOf = (AnnotationClassValue<?>[]) values.get("anyOf");

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaInheritanceSpec.groovy
@@ -546,19 +546,34 @@ class MyBean {}
         !emailSendProtocolDtoSchemaFromReadEmailSettingsDto.required
     }
 
-    void "test OpenAPI with inheritance and allOf together"() {
+    void "test OpenAPI with inheritance and allOf together in complex openApi"() {
         given:
         buildBeanDefinition('test.MyBean', '''
 
 package test;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 @Controller
 class MyController {
@@ -590,33 +605,305 @@ class Owner {
 
 @Introspected
 @Schema(description = "Vehicle of the owner.")
-abstract class Vehicle {
+abstract class Vehicle<T> {
+
+    private List<T> vehicleField;
+
+    /**
+     * Getter javadoc.
+     */
+    @ArraySchema(schema = @Schema(implementation = Document.class, description = "List of objects"))
+    @NotNull
+    public List<T> getVehicleField() {
+        return vehicleField;
+    }
+
+    public void setVehicleField(List<T> vehicleField) {
+        this.vehicleField = vehicleField;
+    }
 }
 
+/**
+ * Bike schema.
+ */
 @Introspected
-@Schema(allOf = Vehicle.class)
-class Bike extends Vehicle {
+class Bike extends Vehicle<MyDocument> {
+
+    /**
+     * Child getter javadoc.
+     */
+    @Override
+    public List<MyDocument> getVehicleField() {
+        return super.getVehicleField();
+    }
 }
 
+/**
+ * Car schema.
+ */
 @Introspected
-@Schema(allOf = Vehicle.class)
-class Car extends Vehicle {
+class Car extends Vehicle<AverageStats> {
+
+    private String carField;
+
+    /**
+     * Child getter javadoc.
+     */
+    @Override
+    public List<AverageStats> getVehicleField() {
+        return super.getVehicleField();
+    }
+
+    /**
+     * Getter javadoc.
+     */
+    public String getCarField() {
+        return carField;
+    }
+
+    public void setCarField(String carField) {
+        this.carField = carField;
+    }
+}
+
+/**
+ * AverageStats class javadoc.
+ */
+@Schema(allOf = Document.class)
+class AverageStats extends DocumentImpl {
+
+    /**
+     * Average value
+     */
+    @NotNull
+    private Double statValue;
+    /**
+     * The second metric.
+     */
+    @NotNull
+    private Long secondMetric;
+
+    public Double getStatValue() {
+        return statValue;
+    }
+
+    public void setStatValue(Double statValue) {
+        this.statValue = statValue;
+    }
+
+    public Long getSecondMetric() {
+        return secondMetric;
+    }
+
+    public void setSecondMetric(Long secondMetric) {
+        this.secondMetric = secondMetric;
+    }
+}
+
+/**
+ * MyDocument class javadoc.
+ */
+@Schema(allOf = Document.class)
+class MyDocument extends DocumentImpl {
+
+    /**
+     * NII field
+     */
+    @NotNull
+    private Long nii;
+    /**
+     * Field2 description
+     */
+    @NotNull
+    private Long field2;
+
+    public Long getField2() {
+        return field2;
+    }
+
+    public void setField2(Long field2) {
+       this.field2 = field2;
+    }
+
+    public Long getNii() {
+        return nii;
+    }
+
+    public void setNii(Long nii) {
+       this.nii = nii;
+    }
+}
+
+/**
+ * DocumentImpl class javadoc.
+ */
+class DocumentImpl implements Document, Serializable {
+
+    @Schema(description = "Inique id", required = true)
+    private String id;
+
+    @Schema(hidden = true)
+    @Hidden
+    private Boolean hidden;
+
+    @Schema(description = "Modification date in UnixTime",
+            implementation = long.class,
+            accessMode = Schema.AccessMode.READ_ONLY)
+    private long modified;
+
+    @Schema(description = "Shema name",
+            implementation = String.class,
+            accessMode = Schema.AccessMode.READ_ONLY)
+    @JsonProperty(required = true)
+    private String schema;
+
+    @Hidden
+    @JsonIgnore
+    private Set<DocumentProperty> properties;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Hidden
+    @JsonIgnore
+    public Boolean isHidden() {
+        return hidden;
+    }
+
+    @Schema(hidden = true)
+    @JsonProperty
+    public void setHidden(Boolean hidden) {
+        this.hidden = hidden;
+    }
+
+    @JsonProperty
+    @Override
+    public long getModified() {
+        return modified;
+    }
+
+    @JsonProperty
+    @Override
+    public @NotNull String getSchema() {
+        return null;
+    }
+
+    @JsonProperty
+    public Document setSchema(String schema) {
+        this.schema = schema;
+        return this;
+    }
+
+    @JsonIgnore
+    @Override
+    public final @Nullable Object getExpand(String field) {
+        return null;
+    }
+
+    @JsonAnyGetter
+    @NotNull
+    @Override
+    public final Map<String, Object> getExpands() {
+        return Collections.emptyMap();
+    }
+
+    @JsonAnySetter
+    @Override
+    public final void setExpand(@Nullable String field, @Nullable Object value) {
+    }
+}
+
+enum DocumentProperty {
+    READ_ONLY
+}
+
+interface Document {
+
+    /**
+     * @return document identified
+     */
+    String getId();
+
+    /**
+     * @return document modified time as UnixTime
+     */
+    long getModified();
+
+    /**
+     * @return document schema
+     */
+    @NotNull
+    String getSchema();
+
+    /**
+     * @param field to get value
+     * @return specified field value
+     */
+    @Nullable
+    Object getExpand(String field);
+
+    /**
+     * @return retrieve all documents expand fields
+     */
+    @NotNull
+    Map<String, Object> getExpands();
+
+    /**
+     * @param field to set value to
+     * @param value to set for field
+     */
+    void setExpand(@Nullable String field, @Nullable Object value);
 }
 
 @jakarta.inject.Singleton
 class MyBean {}
 ''')
 
-        OpenAPI openAPI = Utils.testReference
-        Map<String, Schema> schemas = openAPI.getComponents().getSchemas()
+        OpenAPI openAPI = Utils.testReferenceAfterPlaceholders
+        def schemas = openAPI.getComponents().getSchemas()
 
         expect:
-        Schema owner = schemas["Vehicle"]
-        Schema vehicleRef = owner.getProperties()["Owner.Vehicle"]
-        vehicleRef.allOf[0].$ref == "#/components/schemas/Owner.Vehicle"
-        vehicleRef.allOf[1].description == "Vehicle of the owner. Here a car or bike with a name"
-        Schema ownerVehicle = schemas["Owner.Vehicle"]
-        ownerVehicle.oneOf[0].$ref == '#/components/schemas/Car'
-        ownerVehicle.oneOf[1].$ref == '#/components/schemas/Bike'
+        schemas
+        schemas.size() == 9
+
+        def averageStats = schemas.AverageStats
+        averageStats.allOf.size() == 3
+        averageStats.allOf.get(0).$ref == '#/components/schemas/Document'
+        averageStats.allOf.get(1).$ref == '#/components/schemas/DocumentImpl'
+        averageStats.allOf.get(2).$ref == null
+
+        def bike = schemas.Bike
+        bike.allOf.size() == 2
+        bike.allOf.get(0).$ref == '#/components/schemas/Vehicle_MyDocument_'
+        bike.allOf.get(1).$ref == null
+        bike.allOf.get(1).properties.size() == 1
+        bike.allOf.get(1).properties.vehicleField.description == 'Child getter javadoc.'
+
+        def car = schemas.Car
+        car.allOf.size() == 2
+        car.allOf.get(0).$ref == '#/components/schemas/Vehicle_AverageStats_'
+        car.allOf.get(1).$ref == null
+        car.allOf.get(1).properties.size() == 2
+        car.allOf.get(1).properties.vehicleField.description == 'Child getter javadoc.'
+        car.allOf.get(1).properties.carField.description == 'Getter javadoc.'
+
+        def document = schemas.Document
+        document.properties.id
+        document.properties.modified
+        document.properties.schema
+        document.properties.expands
+        document.properties.expands.additionalProperties == true
+
+        def myDocument = schemas.MyDocument
+        myDocument.allOf.size() == 3
+        myDocument.allOf.get(0).$ref == '#/components/schemas/Document'
+        myDocument.allOf.get(1).$ref == '#/components/schemas/DocumentImpl'
+        myDocument.allOf.get(2).$ref == null
     }
 }


### PR DESCRIPTION
 - Changed `context.fail` to `context.warn` when path variable is not found (!critical because now if pathVariable is not found the build will fail)
 - Fix duplicates references in allOf block
 - Sorting schemas in allOf block: schemas with ref must be first