### PR TITLE
Make abstract code generator public

### DIFF
--- a/openapi-generator/build.gradle
+++ b/openapi-generator/build.gradle
@@ -11,7 +11,7 @@ dependencies {
             because("OpenAPI generator depends on older release which isn't compatible with SnakeYAML")
         }
     }
-    implementation libs.openapi.generator
+    api libs.openapi.generator
 
     testImplementation mnTest.micronaut.test.junit5
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -51,7 +51,8 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 
-abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBuilder> extends AbstractJavaCodegen implements BeanValidationFeatures, OptionalFeatures, MicronautCodeGenerator<T> {
+@SuppressWarnings("checkstyle:DesignForExtension")
+public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBuilder> extends AbstractJavaCodegen implements BeanValidationFeatures, OptionalFeatures, MicronautCodeGenerator<T> {
 
     public static final String OPT_TITLE = "title";
     public static final String OPT_TEST = "test";

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
@@ -24,7 +24,8 @@ import org.openapitools.codegen.meta.Stability;
 import java.util.Arrays;
 import java.util.List;
 
-class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<JavaMicronautClientOptionsBuilder> {
+@SuppressWarnings("checkstyle:DesignForExtension")
+public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<JavaMicronautClientOptionsBuilder> {
 
     public static final String OPT_CONFIGURE_AUTH = "configureAuth";
     public static final String OPT_CONFIGURE_AUTH_FILTER_PATTERN = "configureAuthFilterPattern";

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
@@ -27,7 +27,8 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<JavaMicronautServerOptionsBuilder> {
+@SuppressWarnings("checkstyle:DesignForExtension")
+public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<JavaMicronautServerOptionsBuilder> {
 
     public static final String OPT_CONTROLLER_PACKAGE = "controllerPackage";
     public static final String OPT_GENERATE_CONTROLLER_FROM_EXAMPLES = "generateControllerFromExamples";


### PR DESCRIPTION
Without this, it isn't possible for 3rd parties to implement their own code generator.