### PR TITLE
Add parameter and response body mapping

### DIFF
--- a/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-generator-test-suite.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-generator-test-suite.gradle
@@ -25,6 +25,7 @@ def openapiGenerate = tasks.register("generateOpenApi", OpenApiGeneratorTask) {
     outputDirectory.convention(layout.buildDirectory.dir("generated/openapi"))
     generatorKind.convention("client")
     outputKinds.convention(["models", "apis", "supportingFiles", "modelTests", "apiTests"])
+    parameterMappings.convention([])
 }
 
 sourceSets {

--- a/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-generator-test-suite.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-generator-test-suite.gradle
@@ -26,6 +26,7 @@ def openapiGenerate = tasks.register("generateOpenApi", OpenApiGeneratorTask) {
     generatorKind.convention("client")
     outputKinds.convention(["models", "apis", "supportingFiles", "modelTests", "apiTests"])
     parameterMappings.convention([])
+    responseBodyMappings.convention([])
 }
 
 sourceSets {

--- a/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
+++ b/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A task which simulates what the Gradle Micronaut plugin
@@ -70,6 +71,9 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
     @Input
     public abstract ListProperty<String> getOutputKinds();
 
+    @Input
+    public abstract ListProperty<Map<String, String>> getParameterMappings();
+
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -80,6 +84,7 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
         var generatedTestSourcesDir = getGeneratedTestSourcesDirectory().get().getAsFile();
         Files.createDirectories(generatedSourcesDir.toPath());
         Files.createDirectories(generatedTestSourcesDir.toPath());
+        getProject().getLogger().info("json: " + getParameterMappings().get());
         getExecOperations().javaexec(javaexec -> {
             javaexec.setClasspath(getClasspath());
             javaexec.getMainClass().set("io.micronaut.openapi.testsuite.GeneratorMain");
@@ -88,6 +93,7 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
             args.add(getOpenApiDefinition().get().getAsFile().toURI().toString());
             args.add(getOutputDirectory().get().getAsFile().getAbsolutePath());
             args.add(String.join(",", getOutputKinds().get()));
+            args.add(getParameterMappings().get().toString());
             javaexec.args(args);
         });
     }

--- a/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
+++ b/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
@@ -74,6 +74,9 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
     @Input
     public abstract ListProperty<Map<String, String>> getParameterMappings();
 
+    @Input
+    public abstract ListProperty<Map<String, String>> getResponseBodyMappings();
+
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -94,6 +97,7 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
             args.add(getOutputDirectory().get().getAsFile().getAbsolutePath());
             args.add(String.join(",", getOutputKinds().get()));
             args.add(getParameterMappings().get().toString());
+            args.add(getResponseBodyMappings().get().toString());
             javaexec.args(args);
         });
     }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -593,6 +593,8 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
                                           List<Server> servers) {
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
+        op.vendorExtensions.put("originalParams", new ArrayList(op.allParams));
+        op.vendorExtensions.put("originReturnProperty", op.returnProperty);
         processParametersWithAdditionalMappings(op.allParams, op.imports);
         processWithResponseBodyMapping(op);
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -653,10 +653,14 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         Iterator<CodegenProperty> iter = op.responseHeaders.iterator();
         while (iter.hasNext()) {
             CodegenProperty header = iter.next();
+            System.out.println("Checking header: " + header.baseName);
             boolean headerWasMapped = false;
             for (ResponseBodyMapping mapping : responseBodyMappings) {
+                System.out.println("Checking mapping: " + mapping.headerName());
                 if (mapping.doesMatch(header.baseName, op.isArray)) {
+                    System.out.println("Mached mapping: " + mapping.headerName());
                     if (mapping.mappedBodyType() != null) {
+                        System.out.println("Body type matched: " + mapping.headerName());
                         bodyMapping = mapping;
                     }
                     headerWasMapped = true;
@@ -694,6 +698,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         for (int i = 0; i < typeName.length(); i++) {
             if (Character.isUpperCase(typeName.charAt(i))) {
                 firstCapitalIndex = i;
+                break;
             }
         }
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -655,14 +655,10 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         Iterator<CodegenProperty> iter = op.responseHeaders.iterator();
         while (iter.hasNext()) {
             CodegenProperty header = iter.next();
-            System.out.println("Checking header: " + header.baseName);
             boolean headerWasMapped = false;
             for (ResponseBodyMapping mapping : responseBodyMappings) {
-                System.out.println("Checking mapping: " + mapping.headerName());
                 if (mapping.doesMatch(header.baseName, op.isArray)) {
-                    System.out.println("Mached mapping: " + mapping.headerName());
                     if (mapping.mappedBodyType() != null) {
-                        System.out.println("Body type matched: " + mapping.headerName());
                         bodyMapping = mapping;
                     }
                     headerWasMapped = true;

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -117,6 +118,9 @@ public final class MicronautCodeGeneratorEntryPoint {
         }
         if (options.artifactId != null) {
             codeGenerator.setArtifactId(options.artifactId);
+        }
+        if (options.parameterMappings != null) {
+            codeGenerator.addParameterMappings(options.parameterMappings);
         }
         codeGenerator.setReactive(options.reactive);
         codeGenerator.setWrapInHttpResponse(options.wrapInHttpResponse);
@@ -288,6 +292,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             private boolean beanValidation = true;
             private String invokerPackage;
             private String modelPackage;
+            private List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings;
             private boolean optional = false;
             private boolean reactive = true;
             private boolean wrapInHttpResponse;
@@ -315,6 +320,12 @@ public final class MicronautCodeGeneratorEntryPoint {
             @Override
             public MicronautCodeGeneratorOptionsBuilder withArtifactId(String artifactId) {
                 this.artifactId = artifactId;
+                return this;
+            }
+
+            @Override
+            public MicronautCodeGeneratorOptionsBuilder withParameterMappings(List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings) {
+                this.parameterMappings = parameterMappings;
                 return this;
             }
 
@@ -355,7 +366,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             }
 
             private Options build() {
-                return new Options(apiPackage, modelPackage, invokerPackage, artifactId, beanValidation, optional, reactive, wrapInHttpResponse, testFramework, serializationLibraryKind);
+                return new Options(apiPackage, modelPackage, invokerPackage, artifactId, parameterMappings, beanValidation, optional, reactive, wrapInHttpResponse, testFramework, serializationLibraryKind);
             }
         }
     }
@@ -380,6 +391,7 @@ public final class MicronautCodeGeneratorEntryPoint {
         String modelPackage,
         String invokerPackage,
         String artifactId,
+        List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings,
         boolean beanValidation,
         boolean optional,
         boolean reactive,

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -122,6 +122,9 @@ public final class MicronautCodeGeneratorEntryPoint {
         if (options.parameterMappings != null) {
             codeGenerator.addParameterMappings(options.parameterMappings);
         }
+        if (options.responseBodyMappings != null) {
+            codeGenerator.addResponseBodyMappings(options.responseBodyMappings);
+        }
         codeGenerator.setReactive(options.reactive);
         codeGenerator.setWrapInHttpResponse(options.wrapInHttpResponse);
         codeGenerator.setUseOptional(options.optional);
@@ -293,6 +296,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             private String invokerPackage;
             private String modelPackage;
             private List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings;
+            private List<AbstractMicronautJavaCodegen.ResponseBodyMapping> responseBodyMappings;
             private boolean optional = false;
             private boolean reactive = true;
             private boolean wrapInHttpResponse;
@@ -326,6 +330,12 @@ public final class MicronautCodeGeneratorEntryPoint {
             @Override
             public MicronautCodeGeneratorOptionsBuilder withParameterMappings(List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings) {
                 this.parameterMappings = parameterMappings;
+                return this;
+            }
+
+            @Override
+            public MicronautCodeGeneratorOptionsBuilder withResponseBodyMappings(List<AbstractMicronautJavaCodegen.ResponseBodyMapping> responseBodyMappings) {
+                this.responseBodyMappings = responseBodyMappings;
                 return this;
             }
 
@@ -366,7 +376,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             }
 
             private Options build() {
-                return new Options(apiPackage, modelPackage, invokerPackage, artifactId, parameterMappings, beanValidation, optional, reactive, wrapInHttpResponse, testFramework, serializationLibraryKind);
+                return new Options(apiPackage, modelPackage, invokerPackage, artifactId, parameterMappings, responseBodyMappings, beanValidation, optional, reactive, wrapInHttpResponse, testFramework, serializationLibraryKind);
             }
         }
     }
@@ -392,6 +402,7 @@ public final class MicronautCodeGeneratorEntryPoint {
         String invokerPackage,
         String artifactId,
         List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings,
+        List<AbstractMicronautJavaCodegen.ResponseBodyMapping> responseBodyMappings,
         boolean beanValidation,
         boolean optional,
         boolean reactive,

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
@@ -64,6 +64,15 @@ public interface MicronautCodeGeneratorOptionsBuilder {
     MicronautCodeGeneratorOptionsBuilder withParameterMappings(List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings);
 
     /**
+     * Add the response body mappings.
+     *
+     * @param responseBodyMappings the response body mappings specified by a {@link AbstractMicronautJavaCodegen.ResponseBodyMapping} objects
+     * @return this builder
+     */
+    MicronautCodeGeneratorOptionsBuilder withResponseBodyMappings(List<AbstractMicronautJavaCodegen.ResponseBodyMapping> responseBodyMappings);
+
+
+    /**
      * If set to true, the generator will use reactive types.
      *
      * @param reactive the reactive flag

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.openapi.generator;
 
+import java.util.List;
+
 /**
  * Builder for generic options that the Micronaut code generator supports.
  */
@@ -52,6 +54,14 @@ public interface MicronautCodeGeneratorOptionsBuilder {
      * @return this builder
      */
     MicronautCodeGeneratorOptionsBuilder withArtifactId(String artifactId);
+
+    /**
+     * Add the parameter mappings.
+     *
+     * @param parameterMappings the parameter mappings specified by a {@link AbstractMicronautJavaCodegen.ParameterMapping} objects
+     * @return this builder
+     */
+    MicronautCodeGeneratorOptionsBuilder withParameterMappings(List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings);
 
     /**
      * If set to true, the generator will use reactive types.

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/operationAnnotations.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/operationAnnotations.mustache
@@ -75,9 +75,9 @@
             {{/responses}}
         }{{#hasParams}},
         parameters = {
-            {{#allParams}}
+            {{#vendorExtensions.originalParams}}
             @Parameter(name = "{{paramName}}"{{#description}}, description = "{{{description}}}"{{/description}}{{#required}}, required = true{{/required}}){{^-last}},{{/-last}}
-            {{/allParams}}
+            {{/vendorExtensions.originalParams}}
         }{{/hasParams}}{{#hasAuthMethods}},
         security = {
             {{#authMethods}}

--- a/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
+++ b/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
@@ -108,8 +108,6 @@ public class GeneratorMain {
     }
 
     private static List<Map<String, String>> parseListOfMaps(String string) {
-        System.out.println("json: " + string);
-
         List<Map<String, String>> result = new ArrayList<>();
         if (string.isBlank()) {
             return result;

--- a/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
+++ b/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
@@ -48,7 +48,11 @@ public class GeneratorMain {
      */
     public static void main(String[] args) throws URISyntaxException {
         boolean server = "server".equals(args[0]);
-        List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings = parseParameterMappings(args[4]);
+        List<AbstractMicronautJavaCodegen.ParameterMapping> parameterMappings =
+            parseParameterMappings(args[4]);
+        List<AbstractMicronautJavaCodegen.ResponseBodyMapping> responseBodyMappings =
+            parseResponseBodyMappings(args[5]);
+
         MicronautCodeGeneratorEntryPoint.OutputKind[] outputKinds
             = Arrays.stream(args[3].split(","))
             .map(MicronautCodeGeneratorEntryPoint.OutputKind::of)
@@ -67,6 +71,7 @@ public class GeneratorMain {
                 options.withReactive(true);
                 options.withTestFramework(MicronautCodeGeneratorEntryPoint.TestFramework.SPOCK);
                 options.withParameterMappings(parameterMappings);
+                options.withResponseBodyMappings(responseBodyMappings);
             });
         if (server) {
             builder.forServer(serverOptions -> {
@@ -89,6 +94,15 @@ public class GeneratorMain {
             AbstractMicronautJavaCodegen.ParameterMapping.ParameterLocation.valueOf(map.get("location")),
             map.get("mappedType"),
             map.get("mappedName"),
+            "true".equals(map.get("isValidated"))
+        )).collect(Collectors.toList());
+    }
+
+    private static List<AbstractMicronautJavaCodegen.ResponseBodyMapping> parseResponseBodyMappings(String string) {
+        return parseListOfMaps(string).stream().map(map -> new AbstractMicronautJavaCodegen.ResponseBodyMapping(
+            map.get("headerName"),
+            map.get("mappedBodyType"),
+            "true".equals(map.get("isListWrapper")),
             "true".equals(map.get("isValidated"))
         )).collect(Collectors.toList());
     }

--- a/test-suite-server-generator/build.gradle
+++ b/test-suite-server-generator/build.gradle
@@ -42,18 +42,18 @@ tasks.named("generateOpenApi") {
     outputKinds = ["models", "apis", "supportingFiles"]
     parameterMappings = [
             // Pageable parameter
-            ["name": "page", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
-            ["name": "size", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
-            ["name": "sortOrder", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
+            [name: "page", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"],
+            [name: "size", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"],
+            [name: "sortOrder", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"],
             // Ignored header
-            ["name": "ignored-header", "location": "HEADER"],
+            [name: "ignored-header", location: "HEADER"],
             // Custom filtering header
-            ["name": "Filter", "location": "HEADER", "mappedType": "io.micronaut.openapi.test.filter.MyFilter"]
+            [name: "Filter", location: "HEADER", mappedType: "io.micronaut.openapi.test.filter.MyFilter"]
     ]
     responseBodyMappings = [
             // Response with Last-Modified header mapping
-            ["headerName": "Last-Modified", "mappedBodyType": "io.micronaut.openapi.test.dated.DatedResponse"],
+            [headerName: "Last-Modified", mappedBodyType: "io.micronaut.openapi.test.dated.DatedResponse"],
             // Response with Page body
-            ["headerName": "X-Page-Number", "mappedBodyType": "io.micronaut.data.model.Page", "isListWrapper": true]
+            [headerName: "X-Page-Number", mappedBodyType: "io.micronaut.data.model.Page", isListWrapper: true]
     ]
 }

--- a/test-suite-server-generator/build.gradle
+++ b/test-suite-server-generator/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testCompileOnly("io.micronaut:micronaut-inject-java-test")
     testImplementation("io.micronaut.test:micronaut-test-spock")
     testImplementation("io.micronaut:micronaut-http-client")
-
+    implementation(mnData.micronaut.data.runtime)
 
     testRuntimeOnly("io.micronaut:micronaut-json-core")
     testRuntimeOnly("io.micronaut.serde:micronaut-serde-jackson")
@@ -40,4 +40,14 @@ tasks.named("generateOpenApi") {
     generatorKind = "server"
     openApiDefinition = layout.projectDirectory.file("spec.yaml")
     outputKinds = ["models", "apis", "supportingFiles"]
+    parameterMappings = [
+            // Pageable parameter
+            ["name": "page", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
+            ["name": "size", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
+            ["name": "sortOrder", "location": "QUERY", "mappedType": "io.micronaut.data.model.Pageable"],
+            // Ignored header
+            ["name": "ignored-header", "location": "HEADER"],
+            // Custom filtering header
+            ["name": "Filter", "location": "HEADER", "mappedType": "io.micronaut.openapi.test.filter.MyFilter"]
+    ]
 }

--- a/test-suite-server-generator/build.gradle
+++ b/test-suite-server-generator/build.gradle
@@ -50,4 +50,10 @@ tasks.named("generateOpenApi") {
             // Custom filtering header
             ["name": "Filter", "location": "HEADER", "mappedType": "io.micronaut.openapi.test.filter.MyFilter"]
     ]
+    responseBodyMappings = [
+            // Response with Last-Modified header mapping
+            ["headerName": "Last-Modified", "mappedBodyType": "io.micronaut.openapi.test.dated.DatedResponse"],
+            // Response with Page body
+            ["headerName": "X-Page-Number", "mappedBodyType": "io.micronaut.data.model.Page", "isListWrapper": true]
+    ]
 }

--- a/test-suite-server-generator/spec.yaml
+++ b/test-suite-server-generator/spec.yaml
@@ -13,32 +13,28 @@ produces:
   - application/json
 
 x-headers:
-  PageNumberHeader: &Page-Number-header
-    name: Page-Number
-    in: header
+  PageNumberHeader: &X-Page-Number-header
+    name: X-Page-Number
     type: string
     description: The page number of the current page
-  PageSizeHeader: &Page-Size-header
-    name: Page-Size
-    in: header
+  PageSizeHeader: &X-Page-Size-header
+    name: X-Page-Size
     type: string
     description: The number of items per page
-  TotalCountHeader: &Total-Count-header
-    name: Total-Count
-    in: header
+  TotalCountHeader: &X-Total-Count-header
+    name: X-Total-Count
     type: string
     description: |
       The total number of items available in the entire collections, not just the items returned in the current page
-  PageCountHeader: &Page-Count-header
-    name: Page-Count
-    in: header
+  PageCountHeader: &X-Page-Count-header
+    name: X-Page-Count
     type: string
     description: The total number of pages based on the page size and total count
-  LinkHeader: &Link-header
-    name: Link
-    in: header
+  LastModifiedHeader: &Last-Modified-header
+    name: Last-Modified
     type: string
-    description: The URLS to the first, last, previous and next pages.
+    format: date-time
+    description: The last time an entity returned with the response was modified.
 
 paths:
   /sendPrimitives/{name}:
@@ -498,11 +494,10 @@ paths:
         200:
           description: Success
           headers:
-            Page-Number: *Page-Number-header
-            Page-Size: *Page-Size-header
-            Total-Count: *Total-Count-header
-            Page-Count: *Page-Count-header
-            Link: *Link-header
+            X-Page-Number: *X-Page-Number-header
+            X-Page-Size: *X-Page-Size-header
+            X-Total-Count: *X-Total-Count-header
+            X-Page-Count: *X-Page-Count-header
           schema:
             type: array
             items:
@@ -513,13 +508,10 @@ paths:
       tags: [ responseBody ]
       description: A method to get a simple model with last-modified header
       responses:
-        202:
+        200:
           description: Success
           headers:
-            Last-Modified:
-              type: string
-              format: date-time
-              description: The last modified date for the requested object
+            Last-Modified: *Last-Modified-header
           schema:
             $ref: '#/definitions/SimpleModel'
   /getSimpleModelWithNonMappedHeader:
@@ -547,8 +539,7 @@ paths:
         200:
           description: Success
           headers:
-            Last-Modified:
-              type: string
+            Last-Modified: *Last-Modified-header
             custom-header:
               type: string
               description: A custom header

--- a/test-suite-server-generator/spec.yaml
+++ b/test-suite-server-generator/spec.yaml
@@ -194,6 +194,18 @@ paths:
           description: Success
           schema:
             type: string
+  /sendMappedParameter:
+    get:
+      operationId: sendMappedParameter
+      tags: [ parameters ]
+      description: A method that has a header that is mapped to a custom type
+      parameters:
+        - $ref: '#/parameters/FilterHeader'
+      responses:
+        200:
+          description: Success
+          schema:
+            type: string
   /sendValidatedCollection:
     post:
       operationId: sendValidatedCollection
@@ -771,6 +783,13 @@ parameters:
       Parameter describing the sort. Allows specifying the sorting direction using the keywords {@code asc} and
       {@code desc} after each property. For example, {@code "sort=name desc,age"} will sort by name in descending
       order and age in ascending.
+  FilterHeader:
+    name: Filter
+    in: header
+    type: string
+    description: |
+      A filter parameter that allows filtering the response. The conditions are comma separated and
+      must be of type [property][comparator][value] where comparator is one of =, < and >.
 
 responses:
   Error:

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ParametersController.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ParametersController.java
@@ -1,5 +1,8 @@
 package io.micronaut.openapi.test.api;
 
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Sort;
+import io.micronaut.openapi.test.filter.MyFilter;
 import io.micronaut.openapi.test.model.SendDatesResponse;
 import io.micronaut.openapi.test.model.SendPrimitivesResponse;
 import io.micronaut.http.annotation.Controller;
@@ -8,6 +11,7 @@ import reactor.core.publisher.Mono;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.stream.Collectors;
 
 @Controller
 public class ParametersController implements ParametersApi {
@@ -45,12 +49,27 @@ public class ParametersController implements ParametersApi {
     }
 
     @Override
-    public Mono<String> sendIgnoredHeader(String header) {
+    public Mono<String> sendIgnoredHeader() {
         return Mono.just("Success");
     }
 
     @Override
-    public Mono<String> sendPageQuery(Integer page, Integer size, String sort) {
-        return Mono.just("(page: " + page + ", size: " + size + ", sort: " + sort + ")");
+    public Mono<String> sendPageQuery(Pageable pageable) {
+        return Mono.just(
+            "(page: " + pageable.getNumber() +
+            ", size: " + pageable.getSize() +
+            ", sort: " + sortToString(pageable.getSort()) + ")"
+        );
+    }
+
+    @Override
+    public Mono<String> sendMappedParameter(MyFilter myFilter) {
+        return Mono.just(myFilter.toString());
+    }
+
+    private String sortToString(Sort sort) {
+        return sort.getOrderBy().stream().map(
+            order -> order.getProperty() + "(dir=" + order.getDirection() + ")"
+        ).collect(Collectors.joining(" "));
     }
 }

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
@@ -1,5 +1,6 @@
 package io.micronaut.openapi.test.api;
 
+import io.micronaut.data.model.Pageable;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.openapi.test.model.SimpleModel;
 import io.micronaut.openapi.test.model.StateEnum;
@@ -37,7 +38,7 @@ public class ResponseBodyController implements ResponseBodyApi {
     }
 
     @Override
-    public Mono<List<SimpleModel>> getPaginatedSimpleModel(Integer page) {
+    public Mono<List<SimpleModel>> getPaginatedSimpleModel(Pageable pageable) {
         return Mono.just(SIMPLE_MODELS);
     }
 

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
@@ -1,7 +1,9 @@
 package io.micronaut.openapi.test.api;
 
+import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.openapi.test.dated.DatedResponse;
 import io.micronaut.openapi.test.model.SimpleModel;
 import io.micronaut.openapi.test.model.StateEnum;
 import io.micronaut.http.HttpStatus;
@@ -10,6 +12,7 @@ import io.micronaut.http.exceptions.HttpStatusException;
 import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayInputStream;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Controller
@@ -32,19 +35,24 @@ public class ResponseBodyController implements ResponseBodyApi {
                             .state(StateEnum.RUNNING)
                             .points(List.of("1,1", "2,2", "3,3")));
 
+    public static final String LAST_MODIFIED_STRING = "2023-01-24T10:15:59.100+06:00";
+
+    public static final ZonedDateTime LAST_MODIFIED_DATE =
+        ZonedDateTime.parse(LAST_MODIFIED_STRING);
+
     @Override
     public Mono<SimpleModel> getSimpleModel() {
         return Mono.just(SIMPLE_MODEL);
     }
 
     @Override
-    public Mono<List<SimpleModel>> getPaginatedSimpleModel(Pageable pageable) {
-        return Mono.just(SIMPLE_MODELS);
+    public Mono<Page<SimpleModel>> getPaginatedSimpleModel(Pageable pageable) {
+        return Mono.just(Page.of(SIMPLE_MODELS, pageable, SIMPLE_MODELS.size()));
     }
 
     @Override
-    public Mono<SimpleModel> getDatedSimpleModel() {
-        return Mono.just(SIMPLE_MODEL);
+    public Mono<DatedResponse<SimpleModel>> getDatedSimpleModel() {
+        return Mono.just(DatedResponse.of(SIMPLE_MODEL).withLastModified(LAST_MODIFIED_DATE));
     }
 
     @Override
@@ -53,8 +61,8 @@ public class ResponseBodyController implements ResponseBodyApi {
     }
 
     @Override
-    public Mono<SimpleModel> getDatedSimpleModelWithNonMappedHeader() {
-        return Mono.just(SIMPLE_MODEL);
+    public Mono<DatedResponse<SimpleModel>> getDatedSimpleModelWithNonMappedHeader() {
+        return Mono.just(DatedResponse.of(SIMPLE_MODEL));
     }
 
     @Override

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/dated/DatedResponse.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/dated/DatedResponse.java
@@ -1,0 +1,73 @@
+package io.micronaut.openapi.test.dated;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+import java.time.ZonedDateTime;
+
+/**
+ * A response that contains information about last modification.
+ *
+ * @param <T> The response body type.
+ */
+public final class DatedResponse<T> {
+
+    @Nullable
+    private ZonedDateTime lastModified;
+
+    @NonNull
+    private final T body;
+
+    private DatedResponse(T body, ZonedDateTime lastModified) {
+        this.body = body;
+        this.lastModified = lastModified;
+    }
+
+    /**
+     * Set the last modified to this object.
+     *
+     * @param lastModified the last modification date.
+     * @return this response.
+     */
+    public DatedResponse<T> withLastModified(ZonedDateTime lastModified) {
+        this.lastModified = lastModified;
+        return this;
+    }
+
+    /**
+     * @return The last modification date of returned resource.
+     */
+    public ZonedDateTime getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * @return The response body.
+     */
+    public T getBody() {
+        return body;
+    }
+
+    /**
+     * Create a response by specifying only the body.
+     *
+     * @param body The response body.
+     * @return The response.
+     * @param <T> The response body type.
+     */
+    public static <T> DatedResponse<T> of(@NonNull T body) {
+        return new DatedResponse<T>(body, null);
+    }
+
+    /**
+     * Create a response by specifying both the body and last modification date of the resource.
+     *
+     * @param body The body.
+     * @param lastModified The last modification date.
+     * @return The response.
+     * @param <T> The body type.
+     */
+    public static <T> DatedResponse<T> of(@NonNull T body, @Nullable ZonedDateTime lastModified) {
+        return new DatedResponse<T>(body, lastModified);
+    }
+}

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/dated/DatedResponseBodyWriter.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/dated/DatedResponseBodyWriter.java
@@ -1,0 +1,90 @@
+package io.micronaut.openapi.test.dated;
+
+
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyWriter;
+import io.micronaut.http.codec.CodecException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * An class for writing {@link DatedResponse} to the HTTP response with JSON body.
+ *
+ * @param <T> the type of the response body
+ */
+@Singleton
+@Produces(MediaType.APPLICATION_JSON)
+@Order(-1)
+final class DatedResponseBodyWriter<T> implements MessageBodyWriter<DatedResponse<T>> {
+
+    private static final String LAST_MODIFIED_HEADER = "Last-Modified";
+
+    private final MessageBodyHandlerRegistry registry;
+    private final MessageBodyWriter<T> bodyWriter;
+    private final Argument<T> bodyType;
+
+    @Inject
+    DatedResponseBodyWriter(MessageBodyHandlerRegistry registry) {
+        this(registry, null, null);
+    }
+
+    private DatedResponseBodyWriter(
+        MessageBodyHandlerRegistry registry,
+        @Nullable MessageBodyWriter<T> bodyWriter,
+        @Nullable Argument<T> bodyType
+    ) {
+        this.registry = registry;
+        this.bodyWriter = bodyWriter;
+        this.bodyType = bodyType;
+    }
+
+    @Override
+    public MessageBodyWriter<DatedResponse<T>> createSpecific(
+        Argument<DatedResponse<T>> type
+    ) {
+        Argument<T> bt = type.getTypeParameters()[0];
+        MessageBodyWriter<T> writer = registry.findWriter(bt, List.of(MediaType.APPLICATION_JSON_TYPE))
+                .orElseThrow(() -> new ConfigurationException("No JSON message writer present"));
+        return new DatedResponseBodyWriter<>(registry, writer, bt);
+    }
+
+    @Override
+    public void writeTo(
+        Argument<DatedResponse<T>> type,
+        MediaType mediaType,
+        DatedResponse<T> dated,
+        MutableHeaders headers,
+        OutputStream outputStream
+    ) throws CodecException {
+        if (bodyType != null && bodyWriter != null) {
+            headers.add(LAST_MODIFIED_HEADER, dated.getLastModified().toString());
+            bodyWriter.writeTo(bodyType, mediaType, dated.getBody(), headers, outputStream);
+        } else {
+            throw new ConfigurationException("No JSON message writer present");
+        }
+    }
+
+    @Override
+    public boolean isWriteable(
+        Argument<DatedResponse<T>> type,
+        MediaType mediaType
+    ) {
+        return bodyType != null && bodyWriter != null && bodyWriter.isWriteable(bodyType, mediaType);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return bodyWriter != null && bodyWriter.isBlocking();
+    }
+
+}

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/filter/MyFilter.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/filter/MyFilter.java
@@ -1,0 +1,132 @@
+package io.micronaut.openapi.test.filter;
+
+import io.micronaut.core.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A type for specifying result filtering.
+ * <p>This is used to demonstrate custom parameter mapping, as it is mapped from the
+ * Filter header and bound with a custom binder.</p>
+ *
+ * @param conditions The filtering conditions
+ */
+public record MyFilter (
+    List<Condition> conditions
+) {
+
+    private static final String CONDITION_REGEX = "^(.+)([<>=])(.+)$";
+    private static final Pattern CONDITION_PATTERN = Pattern.compile(CONDITION_REGEX);
+
+    /**
+     * An implementation with no filtering.
+     */
+    public static final MyFilter EMPTY = new MyFilter(List.of());
+
+    /**
+     * Parse the filter from a query parameter.
+     *
+     * @param value the string representation of filter.
+     * @return the filter.
+     */
+    public static MyFilter parse(@Nullable String value) {
+        if (value == null) {
+            return EMPTY;
+        }
+        List<Condition> conditions = Arrays.stream(value.split(","))
+            .map(Condition::parse)
+            .collect(Collectors.toList());
+        return new MyFilter(conditions);
+    }
+
+    @Override
+    public String toString() {
+        return conditions.stream().map(Object::toString).collect(Collectors.joining(","));
+    }
+
+    /**
+     * A filtering condition.
+     *
+     * @param propertyName the parameter to use for filtering
+     * @param comparator the filtering comparator
+     * @param value the value to compare with
+     */
+    public record Condition(
+        String propertyName,
+        ConditionComparator comparator,
+        Object value
+    ) {
+        /**
+         * Parse the condition from a string representation.
+         *
+         * @param string the string
+         * @return the parsed condition
+         */
+        public static Condition parse(String string) {
+            Matcher matcher = CONDITION_PATTERN.matcher(string);
+            if (matcher.find()) {
+                return new Condition(
+                    matcher.group(1),
+                    ConditionComparator.parse(matcher.group(2)),
+                    matcher.group(3)
+                );
+            } else {
+                throw new ParseException("The filter condition must match '" + CONDITION_REGEX +
+                    "' but is '" + string + "'");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return propertyName + comparator + value;
+        }
+    }
+
+    /**
+     * An enum value for specifying how to compare in the condition.
+     */
+    public enum ConditionComparator {
+        EQUALS("="),
+        GREATER_THAN(">"),
+        LESS_THAN("<");
+
+        private final String representation;
+
+        ConditionComparator(String representation) {
+            this.representation = representation;
+        }
+
+        /**
+         * Parse the condition comparator from string representation.
+         *
+         * @param string the string
+         * @return the comparator
+         */
+        public static ConditionComparator parse(String string) {
+            return Arrays.stream(values())
+                .filter(v -> v.representation.equals(string))
+                .findFirst()
+                .orElseThrow(
+                    () -> new ParseException("Condition comparator not supported: '" + string + "'")
+                );
+        }
+
+        @Override
+        public String toString() {
+            return representation;
+        }
+    }
+
+    /**
+     * A custom exception for failed parsing
+     */
+    public static class ParseException extends RuntimeException {
+        private ParseException(String message) {
+            super(message);
+        }
+    }
+}

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/filter/MyFilterBinder.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/filter/MyFilterBinder.java
@@ -1,0 +1,42 @@
+package io.micronaut.openapi.test.filter;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
+import io.micronaut.http.exceptions.HttpStatusException;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+
+/**
+ * A custom parameter binder for MyFilter parameter type.
+ */
+@Singleton
+final class MyFilterBinder implements TypedRequestArgumentBinder<MyFilter> {
+
+    public static final String HEADER_NAME = "Filter";
+
+    @Override
+    public Argument<MyFilter> argumentType() {
+        return Argument.of(MyFilter.class);
+    }
+
+    @Override
+    public BindingResult<MyFilter> bind(
+        ArgumentConversionContext<MyFilter> context,
+        HttpRequest<?> source
+    ) {
+        String filter = source.getHeaders().get(HEADER_NAME);
+        return () -> {
+            try {
+                return Optional.of(MyFilter.parse(filter));
+            } catch (MyFilter.ParseException e) {
+                throw new HttpStatusException(HttpStatus.BAD_REQUEST,
+                    "Could not parse the " + HEADER_NAME + " query parameter. " + e.getMessage());
+            }
+        };
+    }
+
+}

--- a/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/page/PageBodyWriter.java
+++ b/test-suite-server-generator/src/main/java/io/micronaut/openapi/test/page/PageBodyWriter.java
@@ -1,0 +1,98 @@
+package io.micronaut.openapi.test.page;
+
+
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.data.model.Page;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyWriter;
+import io.micronaut.http.codec.CodecException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * An class for writing {@link Page} to the HTTP response with content as JSON body.
+ *
+ * @param <T> the type of page item
+ */
+@Singleton
+@Produces(MediaType.APPLICATION_JSON)
+@Order(-1)
+final class PageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
+
+    private static final String PAGE_NUMBER_HEADER = "X-Page-Number";
+    private static final String PAGE_SIZE_HEADER = "X-Page-Size";
+    private static final String TOTAL_COUNT_HEADER = "X-Total-Count";
+    private static final String PAGE_COUNT_HEADER = "X-Page-Count";
+
+    private final MessageBodyHandlerRegistry registry;
+    private final MessageBodyWriter<List<T>> bodyWriter;
+    private final Argument<List<T>> bodyType;
+
+    @Inject
+    PageBodyWriter(MessageBodyHandlerRegistry registry) {
+        this(registry, null, null);
+    }
+
+    private PageBodyWriter(
+        MessageBodyHandlerRegistry registry,
+        @Nullable MessageBodyWriter<List<T>> bodyWriter,
+        @Nullable Argument<List<T>> bodyType
+    ) {
+        this.registry = registry;
+        this.bodyWriter = bodyWriter;
+        this.bodyType = bodyType;
+    }
+
+    @Override
+    public MessageBodyWriter<Page<T>> createSpecific(
+        Argument<Page<T>> type
+    ) {
+        Argument<List<T>> bt = Argument.listOf(type.getTypeParameters()[0]);
+        MessageBodyWriter<List<T>> writer = registry.findWriter(bt, List.of(MediaType.APPLICATION_JSON_TYPE))
+                .orElseThrow(() -> new ConfigurationException("No JSON message writer present"));
+        return new PageBodyWriter<>(registry, writer, bt);
+    }
+
+    @Override
+    public void writeTo(
+        Argument<Page<T>> type,
+        MediaType mediaType,
+        Page<T> page,
+        MutableHeaders headers,
+        OutputStream outputStream
+    ) throws CodecException {
+        if (bodyType != null && bodyWriter != null) {
+            headers.add(PAGE_NUMBER_HEADER, String.valueOf(page.getPageNumber()));
+            headers.add(PAGE_SIZE_HEADER, String.valueOf(page.getSize()));
+            headers.add(PAGE_COUNT_HEADER, String.valueOf(page.getTotalPages()));
+            headers.add(TOTAL_COUNT_HEADER, String.valueOf(page.getTotalSize()));
+
+            bodyWriter.writeTo(bodyType, mediaType, page.getContent(), headers, outputStream);
+        } else {
+            throw new ConfigurationException("No JSON message writer present");
+        }
+    }
+
+    @Override
+    public boolean isWriteable(
+        Argument<Page<T>> type,
+        MediaType mediaType
+    ) {
+        return bodyType != null && bodyWriter != null && bodyWriter.isWriteable(bodyType, mediaType);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return bodyWriter != null && bodyWriter.isBlocking();
+    }
+
+}

--- a/test-suite-server-generator/src/test/groovy/io/micronaut/openapi/test/api/ResponseBodyControllerSpec.groovy
+++ b/test-suite-server-generator/src/test/groovy/io/micronaut/openapi/test/api/ResponseBodyControllerSpec.groovy
@@ -41,24 +41,38 @@ class ResponseBodyControllerSpec extends Specification {
         ResponseBodyController.SIMPLE_MODEL == response.body()
     }
 
-    // TODO implement the behavior and test
     void "test get paginated simple model"() {
+        given:
+        var page = "12"
+        var pageSize = "10"
+
         when:
+        HttpRequest<?> request = HttpRequest.GET("/getPaginatedSimpleModel?page=${page}&size=${pageSize}")
         HttpResponse<List<SimpleModel>> response =
-                client.exchange(HttpRequest.GET("/getPaginatedSimpleModel"), Argument.listOf(SimpleModel))
+                client.exchange(request, Argument.listOf(SimpleModel))
 
         then:
+        var totalCount = "3"
+        var pageCount = "1"
+
         HttpStatus.OK == response.status
         ResponseBodyController.SIMPLE_MODELS == response.body()
+        page == response.header("X-Page-Number")
+        totalCount == response.header("X-Total-Count")
+        3 == response.body().size()
+        pageSize == response.header("X-Page-Size")
+        pageCount == response.header("X-Page-Count")
     }
 
-    // TODO implement the behavior and test
     void "test get dated simple model"() {
+        when:
         HttpResponse<SimpleModel> response =
                 client.exchange(HttpRequest.GET("/getDatedSimpleModel"), Argument.of(SimpleModel))
 
-        HttpStatus.ACCEPTED == response.status()
+        then:
+        HttpStatus.OK == response.status()
         ResponseBodyController.SIMPLE_MODEL == response.body()
+        ResponseBodyController.LAST_MODIFIED_STRING == response.header("Last-Modified")
     }
 
     void "test get simple model with non standard status"() {


### PR DESCRIPTION
These changes are to allow the use of custom types for parameters and response bodies to utilize all Micronaut capabilities for code simplification.

## Parameters mapping

As an example, if we add the following parameter mappings:
```js
[
  {name: "page", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"},
  {name: "size", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"},
  {name: "sortOrder", location: "QUERY", mappedType: "io.micronaut.data.model.Pageable"},
]
```
micronaut `Pageable` will be used for `page`, `size` or `sortOrder` headers:
```java
    @Get("/sendPageQuery")
    @Produces({"application/json"})
    Mono<String> sendPageQuery(
        @NotNull
        Pageable pageable
    );
```
instead of each header being a separate parameter:
```java
    @Get("/sendPageQuery")
    @Produces({"application/json"})
    Mono<String> sendPageQuery(
        @HeaderParam
        Integer page,
        @HeaderParam
        Integer size,
        @Headerparam
        String sortOrder
    );
```

The spec in this case is :
```yaml
operations:
  /sendPageQuery:
    get:
      operationId: sendPageQuery
      tags: [ parameters ]
      description: A method that takes page query as its argument
      parameters:
        - $ref: '#/parameters/PageQueryParam'
        - $ref: '#/parameters/PageSizeQueryParam'
        - $ref: '#/parameters/PageSortQueryParam'
      responses:
        200:
          description: Success
          schema:
            type: string
parameters:
  PageQueryParam:
    name: page
    in: query
    type: integer
    minimum: 0
    default: 0
    description: The page number to retrieve starting from 0.
  PageSizeQueryParam:
    name: size
    in: query
    type: integer
    minimum: 1
    default: 10
    description: The number of items per page.
  PageSortQueryParam:
    name: sortOrder
    in: query
    type: string
    description: |
      Parameter describing the sort. Allows specifying the sorting direction using the keywords {@code asc} and
      {@code desc} after each property. For example, {@code "sort=name,desc,&sort=age"} will sort by name in descending
      order and age in ascending.
```

Similarly to the example above, custom types can be created with `TypedRequestArgumentBinder` implementations. Parameters can be ignored by setting the `mappedType` to `null`, as some parameters may be consumed inside interceptors or filters. 

## Response body mapping

The body mapping works in a similar way, but changes the return type of operation. Since server can only return header parameters, the mapping is done based on them.

For example, if we add the following body mapping:
```js
{headerName: "Last-Modified", mappedBodyType: "io.micronaut.openapi.test.dated.DatedResponse"}
```
the operation would be created as (if a `Last-Modified` header is specified):
```
    @Get("/getDatedSimpleModel")
    @Produces({"application/json"})
    Mono<DatedResponse<SimpleModel>> getDatedSimpleModel();
```
The custom `DatedResponse` object then would need a `MessageBodyWriter` implementation and include the required header.

The specification in the case above:
```yaml
operations:
  /getDatedSimpleModel:
    get:
      operationId: getDatedSimpleModel
      tags: [ responseBody ]
      description: A method to get a simple model with last-modified header
      responses:
        200:
          description: Success
          headers:
            Last-Modified: *Last-Modified-header
          schema:
            $ref: '#/definitions/SimpleModel'
x-headers:
  LastModifiedHeader: &Last-Modified-header
    name: Last-Modified
    type: string
    format: date-time
    description: The last time an entity returned with the response was modified.
```

## Note
We can make this interface available in gradle/maven plugins or keep available for extension generators only.

