### PR TITLE
Add ability to generate code without `@Generated` annotation and more

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
@@ -15,14 +15,14 @@
  */
 package io.micronaut.openapi.generator;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * The generator for creating Micronaut clients.
@@ -49,7 +49,6 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
     JavaMicronautClientCodegen() {
 
         title = "OpenAPI Micronaut Client";
-        configureAuthorization = false;
 
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
             .stability(Stability.BETA)
@@ -196,11 +195,14 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
     }
 
     static class DefaultClientOptionsBuilder implements JavaMicronautClientOptionsBuilder {
+
         private List<String> additionalClientTypeAnnotations;
         private String authorizationFilterPattern;
         private String basePathSeparator;
         private String clientId;
         private boolean useAuth;
+        private boolean lombok;
+        private boolean generatedAnnotation = true;
 
         @Override
         public JavaMicronautClientOptionsBuilder withAuthorization(boolean useAuth) {
@@ -232,13 +234,28 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
             return this;
         }
 
+        @Override
+        public JavaMicronautClientOptionsBuilder withLombok(boolean lombok) {
+            this.lombok = lombok;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withGeneratedAnnotation(boolean generatedAnnotation) {
+            this.generatedAnnotation = generatedAnnotation;
+            return this;
+        }
+
         ClientOptions build() {
             return new ClientOptions(
                 additionalClientTypeAnnotations,
                 authorizationFilterPattern,
                 basePathSeparator,
                 clientId,
-                useAuth);
+                useAuth,
+                lombok,
+                generatedAnnotation
+            );
         }
     }
 
@@ -247,7 +264,9 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         String authorizationFilterPattern,
         String basePathSeparator,
         String clientId,
-        boolean useAuth
+        boolean useAuth,
+        boolean lombok,
+        boolean generatedAnnotation
     ) {
     }
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientOptionsBuilder.java
@@ -62,4 +62,20 @@ public interface JavaMicronautClientOptionsBuilder extends GeneratorOptionsBuild
      * @return this builder
      */
     JavaMicronautClientOptionsBuilder withBasePathSeparator(String basePathSeparator);
+
+    /**
+     * If set to true, generated code will be with lombok annotations.
+     *
+     * @param lombok generate code with lombok annotations or not
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withLombok(boolean lombok);
+
+    /**
+     * If set to true, generated code will be with jakarta.annotation.Generated annotation.
+     *
+     * @param generatedAnnotation generate code with jakarta.annotation.Generated annotation or not
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withGeneratedAnnotation(boolean generatedAnnotation);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerOptionsBuilder.java
@@ -60,4 +60,28 @@ public interface JavaMicronautServerOptionsBuilder extends GeneratorOptionsBuild
      * @return this builder
      */
     JavaMicronautServerOptionsBuilder withAuthentication(boolean useAuth);
+
+    /**
+     * If set to true, generated code will be with lombok annotations.
+     *
+     * @param lombok generate code with lombok annotations or not
+     * @return this builder
+     */
+    JavaMicronautServerOptionsBuilder withLombok(boolean lombok);
+
+    /**
+     * If set to true, generated code will be with jakarta.annotation.Generated annotation.
+     *
+     * @param generatedAnnotation generate code with jakarta.annotation.Generated annotation or not
+     * @return this builder
+     */
+    JavaMicronautServerOptionsBuilder withGeneratedAnnotation(boolean generatedAnnotation);
+
+    /**
+     * If set to true, generated compatible code with micronaut-aot.
+     *
+     * @param aot generate compatible code with micronaut-aot or not
+     * @return this builder
+     */
+    JavaMicronautServerOptionsBuilder withAot(boolean aot);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -15,12 +15,6 @@
  */
 package io.micronaut.openapi.generator;
 
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.DefaultGenerator;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -29,6 +23,13 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.DefaultGenerator;
 
 /**
  * Main entry point for Micronaut OpenAPI code generation.
@@ -146,6 +147,8 @@ public final class MicronautCodeGeneratorEntryPoint {
             serverCodegen.setGenerateOperationsToReturnNotImplemented(serverOptions.generateOperationsToReturnNotImplemented());
             serverCodegen.setGenerateControllerFromExamples(serverOptions.generateControllerFromExamples());
             serverCodegen.setUseAuth(serverOptions.useAuth());
+            serverCodegen.setLombok(serverOptions.lombok());
+            serverCodegen.setGeneratedAnnotation(serverOptions.generatedAnnotation());
         }
     }
 
@@ -164,6 +167,8 @@ public final class MicronautCodeGeneratorEntryPoint {
                 clientCodegen.setBasePathSeparator(clientCodegen.basePathSeparator);
             }
             clientCodegen.setConfigureAuthorization(clientOptions.useAuth());
+            clientCodegen.setLombok(clientOptions.lombok());
+            clientCodegen.setGeneratedAnnotation(clientOptions.generatedAnnotation());
         }
     }
 
@@ -402,6 +407,7 @@ public final class MicronautCodeGeneratorEntryPoint {
      * by this generator.
      */
     public enum TestFramework {
+
         JUNIT5(AbstractMicronautJavaCodegen.OPT_TEST_JUNIT),
         SPOCK(AbstractMicronautJavaCodegen.OPT_TEST_SPOCK);
 

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
@@ -42,11 +42,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 {{#formatOneEmptyLine}}
 {{#additionalClientTypeAnnotations}}
-	{{{.}}}
+{{{.}}}
 {{/additionalClientTypeAnnotations}}
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
-@Client({{#configureClientId}}id = "{{clientId}}",
-  path = {{/configureClientId}}"${{openbrace}}{{{applicationName}}}{{basePathSeparator}}base-path{{closebrace}}")
+{{/withGeneratedAnnotation}}
+@Client({{#configureClientId}}id = "{{clientId}}", path = {{/configureClientId}}"${{openbrace}}{{{applicationName}}}{{basePathSeparator}}base-path{{closebrace}}")
 public interface {{classname}} {
 {{#operations}}
 
@@ -54,16 +55,16 @@ public interface {{classname}} {
     {{#formatNoEmptyLines}}
 {{>common/operationAnnotations}}{{!
 }}    @{{#lambda.pascalcase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.pascalcase}}("{{{path}}}")
-    {{#hasProduces}}
-    {{#produces}}{{#-first}}@Consumes({{openbrace}}{{/-first}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{#-last}}{{closebrace}}){{/-last}}{{/produces}}
-    {{/hasProduces}}
-    {{#hasConsumes}}
-    {{#consumes}}{{#-first}}@Produces({{openbrace}}{{/-first}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{#-last}}{{closebrace}}){{/-last}}{{/consumes}}
-    {{/hasConsumes}}
+    {{^vendorExtensions.onlyDefaultConsumeOrEmpty}}
+    {{#produces}}{{#-first}}@Consumes({{#produces.1}}{{openbrace}}{{/produces.1}}{{/-first}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{#-last}}{{#produces.1}}{{closebrace}}{{/produces.1}}){{/-last}}{{/produces}}
+    {{/vendorExtensions.onlyDefaultConsumeOrEmpty}}
+    {{^vendorExtensions.onlyDefaultProduceOrEmpty}}
+    {{#consumes}}{{#-first}}@Produces({{#consumes.1}}{{openbrace}}{{/consumes.1}}{{/-first}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{#-last}}{{#consumes.1}}{{closebrace}}{{/consumes.1}}){{/-last}}{{/consumes}}
+    {{/vendorExtensions.onlyDefaultProduceOrEmpty}}
     {{!auth methods}}
         {{#configureAuth}}
             {{#authMethods}}
-    @Authorization(name = "{{{name}}}"{{!scopes}}{{#isOAuth}}, scopes = {{openbrace}}{{#scopes}}"{{{scope}}}"{{^-last}}, {{/-last}}{{/scopes}}{{closebrace}}{{/isOAuth}})
+    @Authorization(name = "{{{name}}}"{{!scopes}}{{#isOAuth}}, scopes = {{#scopes.1}}{{openbrace}}{{/scopes.1}}{{#scopes}}"{{{scope}}}"{{^-last}}, {{/-last}}{{/scopes}}{{#scopes.1}}{{closebrace}}{{/scopes.1}}{{/isOAuth}})
             {{/authMethods}}
         {{/configureAuth}}
     {{!the method definition}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/Authorization.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/Authorization.mustache
@@ -13,7 +13,9 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import {{javaxPackage}}.annotation.Generated;
 
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 @Documented
 @Retention(RUNTIME)
 @Target(METHOD)
@@ -22,19 +24,19 @@ import {{javaxPackage}}.annotation.Generated;
 public @interface Authorization {
 
     /**
-     * The name of the authorization
+     * The name of the authorization.
      */
     @AliasFor(annotation = Bindable.class, member = "value")
     String value() default "";
 
     /**
-     * The name of the authorization
+     * The name of the authorization.
      */
     @AliasFor(annotation = Bindable.class, member = "value")
     String name() default "";
 
     /**
-     * The scopes for the oauth authorization
+     * The scopes for the oauth authorization.
      */
     String[] scopes() default {};
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/AuthorizationBinder.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/AuthorizationBinder.mustache
@@ -15,11 +15,13 @@ import java.util.ArrayList;
 import java.util.List;
 import {{javaxPackage}}.annotation.Generated;
 
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 @Singleton
 public class AuthorizationBinder implements AnnotatedClientRequestBinder<Authorization> {
 
-    public static final CharSequence AUTHORIZATION_NAMES  = "micronaut.security.AUTHORIZATION_NAMES";
+    public static final CharSequence AUTHORIZATION_NAMES = "micronaut.security.AUTHORIZATION_NAMES";
 
     @NonNull
     @Override
@@ -37,7 +39,7 @@ public class AuthorizationBinder implements AnnotatedClientRequestBinder<Authori
 
         if (CollectionUtils.isNotEmpty(annotations)) {
             List<String> authorizationNames = new ArrayList<>();
-            for (AnnotationValue<Authorization> annotation: annotations) {
+            for (AnnotationValue<Authorization> annotation : annotations) {
                 annotation.get("name", String.class)
                         .filter(StringUtils::isNotEmpty)
                         .ifPresent(v -> authorizationNames.add(configurationName(v)));

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/AuthorizationFilter.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/AuthorizationFilter.mustache
@@ -19,11 +19,15 @@ import io.micronaut.security.oauth2.client.clientcredentials.ClientCredentialsCo
 import io.micronaut.security.oauth2.client.clientcredentials.propagation.ClientCredentialsHttpClientFilter;
 import io.micronaut.security.oauth2.client.clientcredentials.propagation.ClientCredentialsTokenPropagator;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
-import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
 import {{invokerPackage}}.auth.configuration.ConfigurableAuthorization;
 import org.reactivestreams.Publisher;
+{{#lombok}}
+import lombok.extern.slf4j.Slf4j;
+{{/lombok}}
+{{^lombok}}
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+{{/lombok}}
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -35,13 +39,19 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import {{javaxPackage}}.annotation.Generated;
 
-
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
+{{#lombok}}
+@Slf4j
+{{/lombok}}
 @Filter({{#configureAuthFilterPattern}}"{{authorizationFilterPattern}}"{{/configureAuthFilterPattern}}{{^configureAuthFilterPattern}}Filter.MATCH_ALL_PATTERN{{/configureAuthFilterPattern}})
 public class AuthorizationFilter implements HttpClientFilter {
+{{^lombok}}
 
     private static final Logger log = LoggerFactory.getLogger(ClientCredentialsHttpClientFilter.class);
 
+{{/lombok}}
     private final BeanContext beanContext;
     private final Map<String, OauthClientConfiguration> clientConfigurationByName;
 
@@ -58,13 +68,13 @@ public class AuthorizationFilter implements HttpClientFilter {
             Stream<ConfigurableAuthorization> configurableAuthorizations
     ) {
         this.beanContext = beanContext;
-        this.clientConfigurationByName = clientConfigurations
+        this.defaultTokenPropagator = defaultTokenPropagator;
+        clientConfigurationByName = clientConfigurations
                 .filter(Toggleable::isEnabled)
                 .collect(Collectors.toMap(OauthClientConfiguration::getName, v -> v));
-        this.defaultTokenPropagator = defaultTokenPropagator;
-        this.tokenPropagatorByName = new HashMap<>();
-        this.clientCredentialsClientByName = new HashMap<>();
-        this.authorizationsByName = configurableAuthorizations
+        tokenPropagatorByName = new HashMap<>();
+        clientCredentialsClientByName = new HashMap<>();
+        authorizationsByName = configurableAuthorizations
                 .collect(Collectors.toMap(ConfigurableAuthorization::getName, v -> v));
     }
 
@@ -75,13 +85,12 @@ public class AuthorizationFilter implements HttpClientFilter {
     ) {
         List<?> names = request.getAttribute(AuthorizationBinder.AUTHORIZATION_NAMES, List.class).orElse(null);
         if (CollectionUtils.isNotEmpty(names)) {
-            List<Publisher<HttpRequest>> authorizers = new ArrayList<>(names.size());
+            var authorizers = new ArrayList<Publisher<HttpRequest<?>>>(names.size());
 
             for (Object nameObject : names) {
-                if (!(nameObject instanceof String)) {
+                if (!(nameObject instanceof String name)) {
                     continue;
                 }
-                String name = (String) nameObject;
 
                 // Check if other authorizations have the key
                 if (authorizationsByName.containsKey(name)) {
@@ -106,10 +115,10 @@ public class AuthorizationFilter implements HttpClientFilter {
                 }
 
                 ClientCredentialsTokenPropagator tokenHandler = getTokenPropagator(name);
-                Flux<HttpRequest> authorizer = Flux.from(clientCredentialsClient
+                Flux<HttpRequest<?>> authorizer = Flux.from(clientCredentialsClient
                         .requestToken(getScope(clientConfiguration)))
-                        .map(TokenResponse::getAccessToken)
-                        .map(accessToken -> {
+                        .map(tokenResponse -> {
+                            var accessToken = tokenResponse.getAccessToken();
                             if (StringUtils.isNotEmpty(accessToken)) {
                                 tokenHandler.writeToken(request, accessToken);
                             }
@@ -121,7 +130,6 @@ public class AuthorizationFilter implements HttpClientFilter {
             return Flux.concat(authorizers)
                     .switchMap(v -> chain.proceed(request));
         }
-
 
         return chain.proceed(request);
     }
@@ -151,6 +159,8 @@ public class AuthorizationFilter implements HttpClientFilter {
 
     @Nullable
     protected String getScope(@NonNull OauthClientConfiguration oauthClient) {
-        return oauthClient.getClientCredentials().flatMap(ClientCredentialsConfiguration::getScope).orElse(null);
+        return oauthClient.getClientCredentials()
+                .flatMap(ClientCredentialsConfiguration::getScope)
+                .orElse(null);
     }
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/Authorizations.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/Authorizations.mustache
@@ -10,7 +10,9 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import {{javaxPackage}}.annotation.Generated;
 
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 @Documented
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
@@ -8,11 +8,21 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.cookie.Cookie;
 import {{javaxPackage}}.annotation.Generated;
+{{#lombok}}
+import lombok.Getter;
+import lombok.Setter;
+{{/lombok}}
 
-
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
+{{#lombok}}
+@Getter
+@Setter
+{{/lombok}}
 @EachProperty("security.api-key-auth")
 public class ApiKeyAuthConfiguration implements ConfigurableAuthorization {
+
     private final String name;
     private AuthKeyLocation location;
     private String paramName;
@@ -33,14 +43,15 @@ public class ApiKeyAuthConfiguration implements ConfigurableAuthorization {
 
     @Override
     public void applyAuthorization(@NonNull MutableHttpRequest<?> request) {
-        if (this.location == AuthKeyLocation.HEADER) {
-            request.header(this.paramName, this.apiKey);
-        } else if (this.location == AuthKeyLocation.QUERY) {
-            request.getParameters().add(this.paramName, this.apiKey);
-        } else if (this.location == AuthKeyLocation.COOKIE) {
-            request.cookie(Cookie.of(this.paramName, this.apiKey));
+        if (location == AuthKeyLocation.HEADER) {
+            request.header(paramName, apiKey);
+        } else if (location == AuthKeyLocation.QUERY) {
+            request.getParameters().add(paramName, apiKey);
+        } else if (location == AuthKeyLocation.COOKIE) {
+            request.cookie(Cookie.of(paramName, apiKey));
         }
     }
+{{^lombok}}
 
     @Override
     public String getName() {
@@ -70,10 +81,11 @@ public class ApiKeyAuthConfiguration implements ConfigurableAuthorization {
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
     }
+{{/lombok}}
 
     public enum AuthKeyLocation {
         HEADER,
         QUERY,
-        COOKIE;
+        COOKIE
     }
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/ConfigurableAuthorization.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/ConfigurableAuthorization.mustache
@@ -5,9 +5,11 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
 import {{javaxPackage}}.annotation.Generated;
 
-
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 public interface ConfigurableAuthorization {
+
     String getName();
 
     void applyAuthorization(@NonNull MutableHttpRequest<?> request);

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/HttpBasicAuthConfiguration.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/auth/configuration/HttpBasicAuthConfiguration.mustache
@@ -7,11 +7,21 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
 import {{javaxPackage}}.annotation.Generated;
+{{#lombok}}
+import lombok.Getter;
+import lombok.Setter;
+{{/lombok}}
 
-
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
+{{#lombok}}
+@Getter
+@Setter
+{{/lombok}}
 @EachProperty("security.basic-auth")
 public class HttpBasicAuthConfiguration implements ConfigurableAuthorization {
+
     private final String name;
     private String username;
     private String password;
@@ -31,6 +41,7 @@ public class HttpBasicAuthConfiguration implements ConfigurableAuthorization {
     public void applyAuthorization(@NonNull MutableHttpRequest<?> request) {
         request.basicAuth(username, password);
     }
+{{^lombok}}
 
     @Override
     public String getName() {
@@ -52,4 +63,5 @@ public class HttpBasicAuthConfiguration implements ConfigurableAuthorization {
     public void setPassword(String password) {
         this.password = password;
     }
+{{/lombok}}
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/params/queryParams.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/params/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}@QueryValue(value = "{{{baseName}}}"{{!default value}}{{#defaultValue}}, defaultValue = "{{{defaultValue}}}"{{/defaultValue}}) {{!validation and type}}{{>common/params/validation}}{{>client/params/type}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@QueryValue({{#defaultValue}}value = {{/defaultValue}}"{{{baseName}}}"{{!default value}}{{#defaultValue}}, defaultValue = "{{{defaultValue}}}"{{/defaultValue}}) {{!validation and type}}{{>common/params/validation}}{{>client/params/type}} {{paramName}}{{/isQueryParam}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/test/api_test.groovy.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/test/api_test.groovy.mustache
@@ -16,7 +16,6 @@ import java.util.List
 import java.util.Map
 import java.util.HashSet
 
-
 /**
  * API tests for {{classname}}
  */
@@ -25,7 +24,6 @@ class {{classname}}Spec extends Specification {
 
     @Inject
     {{classname}} api
-
     {{#operations}}{{#operation}}
     /**
      * {{summary}}
@@ -54,6 +52,6 @@ class {{classname}}Spec extends Specification {
         true
         // TODO: test validations
     }
-
     {{/operation}}{{/operations}}
+
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/test/api_test.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/test/api_test.mustache
@@ -21,22 +21,21 @@ import java.util.HashSet;
  * API tests for {{classname}}
  */
 @MicronautTest
-public class {{classname}}Test {
+class {{classname}}Test {
 
     @Inject
     {{classname}} api;
-
     {{#operations}}{{#operation}}
     /**
      * {{summary}}
      {{#notes}}
-     *
+     * <p>
      * {{notes}}
      {{/notes}}
      */
     @Test
     @Disabled("Not Implemented")
-    public void {{operationId}}Test() {
+    void {{operationId}}Test() {
         // given
         {{#allParams}}
         {{{dataType}}} {{paramName}} = {{{example}}};
@@ -54,6 +53,5 @@ public class {{classname}}Test {
         // then
         // TODO implement the {{operationId}}Test()
     }
-
     {{/operation}}{{/operations}}
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/test/model_test.groovy.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/test/model_test.groovy.mustache
@@ -11,6 +11,7 @@ import jakarta.inject.Inject
  */
 @MicronautTest
 public class {{classname}}Spec extends Specification {
+
     {{#models}}
     {{#model}}
     {{^vendorExtensions.x-is-one-of-interface}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/test/model_test.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/test/model_test.mustache
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.Assertions;
  * Model tests for {{classname}}
  */
 @MicronautTest
-public class {{classname}}Test {
+class {{classname}}Test {
+
     {{#models}}
     {{#model}}
     {{^vendorExtensions.x-is-one-of-interface}}
@@ -22,7 +23,7 @@ public class {{classname}}Test {
      * Model tests for {{classname}}
      */
     @Test
-    public void test{{classname}}() {
+    void test{{classname}}() {
         // TODO: test {{classname}}
     }
 
@@ -31,7 +32,7 @@ public class {{classname}}Test {
      * Test the property '{{name}}'
      */
     @Test
-    public void {{name}}Test() {
+    void {{name}}Test() {
         // TODO: test {{name}}
     }
 

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/configuration/Application.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/configuration/Application.mustache
@@ -1,8 +1,24 @@
 package {{invokerPackage}};
 
+{{#aot}}
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.context.annotation.ContextConfigurer;
+{{/aot}}
 import io.micronaut.runtime.Micronaut;
 
 public class Application {
+{{#aot}}
+
+    @ContextConfigurer
+    public static class MyConfigurer implements ApplicationContextConfigurer {
+
+        @Override
+        public void configure(ApplicationContextBuilder context) {
+            context.deduceEnvironment(false);
+        }
+    }
+{{/aot}}
 
     public static void main(String[] args) {
         Micronaut.run(Application.class, args);

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/configuration/logback.xml.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/configuration/logback.xml.mustache
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -5,11 +6,12 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %highlight(%-5level) %gray([%thread]) %magenta(%logger{25}) [%file:%line] - %msg%n</pattern>
+            <charset>UTF-8</charset>
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/generatedAnnotation.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@Generated({{^hideGenerationTimestamp}}value = {{/hideGenerationTimestamp}}"{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/enum.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/enum.mustache
@@ -5,6 +5,10 @@
 @XmlType(name="{{datatypeWithEnum}}")
 @XmlEnum({{dataType}}.class)
 {{/withXml}}
+{{#lombok}}
+@RequiredArgsConstructor
+@Getter(onMethod = @__(@JsonValue))
+{{/lombok}}
 {{#micronaut_serde_jackson}}
 @Serdeable
 {{/micronaut_serde_jackson}}
@@ -28,6 +32,7 @@
     {{/allowableValues}}
 
     private final {{{dataType}}} value;
+{{^lombok}}
 
     {{#formatSingleLine}}{{>common/model/enumName}}{{/formatSingleLine}}({{{dataType}}} value) {
         this.value = value;
@@ -42,18 +47,20 @@
     public {{{dataType}}} getValue() {
         return value;
     }
+{{/lombok}}
 
     @Override
     public String toString() {
         return String.valueOf(value);
     }
 
-    {{#formatSingleLine}}private final static Map<{{{dataType}}}, {{>common/model/enumName}}> VALUE_MAPPING = Arrays.stream(values()){{/formatSingleLine}}
-        .collect(Collectors.toMap(v -> v.getValue(){{#isString}}{{#useEnumCaseInsensitive}}.toLowerCase(){{/useEnumCaseInsensitive}}{{/isString}}, v -> v));
+    {{#formatSingleLine}}public final static Map<{{{dataType}}}, {{>common/model/enumName}}> VALUE_MAPPING = Map.copyOf(Arrays.stream(values()){{/formatSingleLine}}
+        .collect(Collectors.toMap(v -> v.value{{#isString}}{{#useEnumCaseInsensitive}}.toLowerCase(){{/useEnumCaseInsensitive}}{{/isString}}, v -> v)));
 
     /**
      * Create this enum from a value.
-     * @return The enum.
+     *
+     * @return The enum
      */
     {{#jackson}}
     @JsonCreator

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/jackson_annotations.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/jackson_annotations.mustache
@@ -25,13 +25,13 @@
     {{/isMap}}
     {{#withXml}}
         {{^isContainer}}
-    @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-    @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
         {{/isContainer}}
         {{#isContainer}}
             {{#isXmlWrapped}}
     // items.xmlName={{items.xmlName}}
-    @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
+    @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
             {{/isXmlWrapped}}
         {{/isContainer}}
     {{/withXml}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/model.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/model.mustache
@@ -19,6 +19,16 @@ import {{import}};
 import java.io.Serial;
 import java.io.Serializable;
 {{/serializableModel}}
+{{#lombok}}
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+{{/lombok}}
 {{#jackson}}
 import com.fasterxml.jackson.annotation.*;
 {{/jackson}}
@@ -46,7 +56,9 @@ import io.micronaut.core.annotation.Nullable;
 {{#generateHardNullable}}
 import {{{invokerPackage}}}.annotation.HardNullable;
 {{/generateHardNullable}}
+{{#withGeneratedAnnotation}}
 import {{javaxPackage}}.annotation.Generated;
+{{/withGeneratedAnnotation}}
 {{#generateSwagger1Annotations}}
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/oneof_interface.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/oneof_interface.mustache
@@ -2,7 +2,9 @@
 {{#additionalOneOfTypeAnnotations}}
 {{{.}}}
 {{/additionalOneOfTypeAnnotations}}
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 {{>common/model/typeInfoAnnotation}}
 {{>common/model/xmlAnnotation}}
 public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/pojo.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/pojo.mustache
@@ -10,20 +10,35 @@
 @Schema({{#name}}name = "{{name}}", {{/name}}description = "{{{description}}}")
     {{/generateSwagger2Annotations}}
 {{/description}}
+{{#lombok}}
+    {{#parent}}
+@EqualsAndHashCode(callSuper = true)
+    {{/parent}}
+@Accessors(chain = true)
+@NoArgsConstructor
+@Data
+{{/lombok}}
 {{#micronaut_serde_jackson}}
 @Serdeable
 {{/micronaut_serde_jackson}}
 {{#jackson}}
-@JsonPropertyOrder({
+{{#vendorExtensions.withMultipleVars}}
+@JsonPropertyOrder({{openbrace}}
     {{#vars}}
     {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
     {{/vars}}
-})
+{{closebrace}})
+{{/vendorExtensions.withMultipleVars}}
+{{^vendorExtensions.withMultipleVars}}
+@JsonPropertyOrder({{#vars}}{{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{/vars}})
+{{/vendorExtensions.withMultipleVars}}
 {{/jackson}}
 {{#additionalModelTypeAnnotations}}
 {{{.}}}
 {{/additionalModelTypeAnnotations}}
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 {{#discriminator}}
 {{>common/model/typeInfoAnnotation}}
 {{/discriminator}}
@@ -37,6 +52,7 @@
 {{!Declare the class with extends and implements}}
 public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{/formatNoEmptyLines}}
+
     {{#serializableModel}}
 
     @Serial
@@ -61,17 +77,17 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
             {{/isXmlAttribute}}
             {{^isXmlAttribute}}
                 {{^isContainer}}
-    @XmlElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    @XmlElement({{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
                 {{/isContainer}}
                 {{#isContainer}}
-    // Is a container wrapped={{isXmlWrapped}}
+    // Is a container wrapped = {{isXmlWrapped}}
                     {{#items}}
-    // items.name={{name}} items.baseName={{baseName}} items.xmlName={{xmlName}} items.xmlNamespace={{xmlNamespace}}
-    // items.example={{example}} items.type={{dataType}}
-    @XmlElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    // items.name = {{name}} items.baseName = {{baseName}} items.xmlName = {{xmlName}} items.xmlNamespace = {{xmlNamespace}}
+    // items.example = {{example}} items.type = {{dataType}}
+    @XmlElement({{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
                     {{/items}}
                     {{#isXmlWrapped}}
-    @XmlElementWrapper({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    @XmlElementWrapper({{#xmlNamespace}}namespace = "{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
                     {{/isXmlWrapped}}
                 {{/isContainer}}
             {{/isXmlAttribute}}
@@ -115,6 +131,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
     {{/vars}}
 
     {{#requiredPropertiesInConstructor}}
+        {{#vendorExtensions.withRequiredVars}}
     public {{classname}}({{#vendorExtensions.requiredVarsWithoutDiscriminator}}{{#isReadOnly}}{{#vendorExtensions.isServer}}{{^-first}}, {{/-first}}{{{datatypeWithEnum}}} {{name}}{{/vendorExtensions.isServer}}{{/isReadOnly}}{{^isReadOnly}}{{^-first}}, {{/-first}}{{{datatypeWithEnum}}} {{name}}{{/isReadOnly}}{{/vendorExtensions.requiredVarsWithoutDiscriminator}}) {
         {{#parent}}
         super({{#vendorExtensions.requiredParentVarsWithoutDiscriminator}}{{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.requiredParentVarsWithoutDiscriminator}});
@@ -132,19 +149,15 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
             {{/isDiscriminator}}
         {{/vendorExtensions.requiredVars}}
     }
-    {{/requiredPropertiesInConstructor}}
-    {{^requiredPropertiesInConstructor}}
-    public {{classname}}() {
-        {{#parent}}
-        super();
-        {{/parent}}
-    }
+        {{/vendorExtensions.withRequiredVars}}
     {{/requiredPropertiesInConstructor}}
 
     {{#vars}}
+        {{^vendorExtensions.lombok}}
     /**
         {{#description}}
      * {{description}}
+     *
         {{/description}}
      * @return the {{name}} property value
      */
@@ -165,12 +178,14 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         return {{name}};
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
     }
+        {{/vendorExtensions.lombok}}
 
     {{#useOptional}}
         {{^required}}
     /**
         {{#description}}
      * {{description}}
+     *
         {{/description}}
      * @return the {{name}} property value wrapped in an optional
      */
@@ -188,6 +203,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         {{/required}}
     {{/useOptional}}
 
+    {{^vendorExtensions.lombok}}
     /**
      * Set the {{name}} property value
      */
@@ -202,10 +218,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         this.{{name}} = {{name}};
             {{/vendorExtensions.x-is-jackson-optional-nullable}}
     }
+    {{/vendorExtensions.lombok}}
 
             {{#vendorExtensions.x-is-jackson-optional-nullable}}
     /**
      * A JsonNullable getter that will be used for JSON serialization.
+     *
      * @return JsonNullable version of {{name}}
      */
 {{>common/model/jackson_annotations}}
@@ -220,8 +238,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
         {{^isReadOnly}}
+            {{^vendorExtensions.lombok}}
     /**
      * Set {{name}} in a chainable fashion.
+     *
      * @return The same instance of {{classname}} for chaining.
      */
     public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
@@ -233,30 +253,31 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
             {{/vendorExtensions.x-is-jackson-optional-nullable}}
         return this;
     }
-
+            {{/vendorExtensions.lombok}}
             {{#isArray}}
     /**
      * Add an item to the {{name}} property in a chainable fashion.
+     *
      * @return The same instance of {{classname}} for chaining.
      */
     public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
                 {{#vendorExtensions.x-is-jackson-optional-nullable}}
-        if (this.{{name}} == null || !this.{{name}}.isPresent()) {
-            this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}});
+        if ({{name}} == null || !{{name}}.isPresent()) {
+            {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}});
         }
         try {
-            this.{{name}}.get().add({{name}}Item);
+            {{name}}.get().add({{name}}Item);
         } catch (java.util.NoSuchElementException e) {
             // this can never happen, as we make sure above that the value is present
         }
                 {{/vendorExtensions.x-is-jackson-optional-nullable}}
                 {{^vendorExtensions.x-is-jackson-optional-nullable}}
                     {{^required}}
-        if (this.{{name}} == null) {
-            this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+        if ({{name}} == null) {
+            {{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
         }
                     {{/required}}
-        this.{{name}}.add({{name}}Item);
+        {{name}}.add({{name}}Item);
                 {{/vendorExtensions.x-is-jackson-optional-nullable}}
         return this;
     }
@@ -265,6 +286,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
             {{#isMap}}
     /**
      * Set the value for the key for the {{name}} map property in a chainable fashion.
+     *
      * @return The same instance of {{classname}} for chaining.
      */
     public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
@@ -296,8 +318,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
     {{#parentVars}}
         {{^isReadOnly}}
     @Override
-    public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
-        {{{setter}}}({{name}});
+    public {{classname}} {{#lombok}}{{{setter}}}{{/lombok}}{{^lombok}}{{name}}{{/lombok}}({{{datatypeWithEnum}}} {{name}}) {
+        super.{{{setter}}}({{name}});
         return this;
     }
 
@@ -320,6 +342,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         {{/isReadOnly}}
     {{/parentVars}}
 
+{{^lombok}}
     @Override
     public boolean equals(Object o) {
     {{#useReflectionEqualsHashCode}}
@@ -334,7 +357,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         }
         {{#hasVars}}
         {{classname}} {{classVarName}} = ({{classname}}) o;
-        return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
             {{/-last}}{{/vars}}{{#parent}} &&
             super.equals(o){{/parent}};
         {{/hasVars}}
@@ -362,6 +385,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
         {{/allVars}}
             + ")";
     }
+{{/lombok}}
 
     {{#parcelableModel}}
     public void writeToParcel(Parcel out, int flags) {
@@ -441,6 +465,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
      * @param <R> the return type of the visitor
      */
     public interface Visitor<R> {
+
         {{#discriminator.mappedModels}}
         R visit{{modelName}}({{modelName}} value);
         {{/discriminator.mappedModels}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/operationAnnotations.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/operationAnnotations.mustache
@@ -1,6 +1,6 @@
     /**
     {{#summary}}
-     * {{summary}}
+     * {{openbrace}}@summary {{summary}}{{closebrace}}
     {{/summary}}
     {{#notes}}
      * {{notes}}
@@ -11,11 +11,15 @@
         {{/notes}}
     {{/summary}}
     {{#allParams}}
+        {{#-first}}
      *
-     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+        {{/-first}}
+     * @param {{paramName}}{{#description}} {{description}}{{/description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
     {{/allParams}}
     {{#returnType}}
+        {{^allParams.0}}
      *
+        {{/allParams.0}}
      * @return {{returnType}}
     {{/returnType}}
     {{#externalDocs}}
@@ -32,20 +36,23 @@
         notes = "{{{notes}}}"{{/notes}}{{#returnBaseType}},
         response = {{{returnBaseType}}}.class{{/returnBaseType}}{{#returnContainer}},
         responseContainer = "{{{returnContainer}}}"{{/returnContainer}},
-        authorizations = {{openbrace}}{{#hasAuthMethods}}
+    {{#hasAuthMethods}}
+        authorizations = {{#authMethods.1}}{{openbrace}}{{/authMethods.1}}
         {{#authMethods}}
             {{#isOAuth}}
-            @Authorization(value = "{{name}}"{{#scopes.0}}, scopes = {
+            @Authorization(value = "{{name}}"{{#scopes.0}}, scopes = {{#scopes.1}}{{openbrace}}
+            {{/scopes.1}}
                 {{#scopes}}
                 @AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{^-last}},{{/-last}}
-                {{/scopes}}
-            }{{/scopes.0}}){{^-last}},{{/-last}}
+                {{/scopes}}{{#scopes.1}}
+            {{closebrace}}{{/scopes.1}}{{/scopes.0}}){{^-last}},{{/-last}}
             {{/isOAuth}}
             {{^isOAuth}}
             @Authorization(value = "{{name}}"){{^-last}},{{/-last}}
             {{/isOAuth}}
         {{/authMethods}}
-        {{/hasAuthMethods}}{{closebrace}},
+        {{#authMethods.1}}{{closebrace}}{{/authMethods.1}}
+    {{/hasAuthMethods}},
         tags = { {{#vendorExtensions.x-tags}}"{{tag}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-tags}} }
     )
     @ApiResponses(value = {{openbrace}}{{#responses}}
@@ -63,42 +70,46 @@
         {{/description}}
         {{#tags.1}}
         {{!generate only when at least 2 tags}}
-        tags = { {{#tags}}"{{name}}"{{^-last}}, {{/-last}}{{/tags}} },
+        tags = {{openbrace}} {{#tags}}"{{name}}"{{^-last}}, {{/-last}}{{/tags}} {{closebrace}},
         {{/tags.1}}
-        responses = {
-            {{#responses}}
-            @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = {
+        responses = {{#responses.1}}{{openbrace}}
+    {{/responses.1}}{{#responses}}{{#responses.1}}
+            {{/responses.1}}@ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = {{#produces.1}}{{openbrace}}
                 {{#produces}}
                 @Content(mediaType = "{{{mediaType}}}", schema = @Schema(implementation = {{{baseType}}}.class)){{^-last}},{{/-last}}
                 {{/produces}}
-            }{{/baseType}}){{^-last}},{{/-last}}
-            {{/responses}}
-        }{{#hasParams}},
-        parameters = {
-            {{#vendorExtensions.originalParams}}
-            @Parameter(name = "{{paramName}}"{{#description}}, description = "{{{description}}}"{{/description}}{{#required}}, required = true{{/required}}){{^-last}},{{/-last}}
-            {{/vendorExtensions.originalParams}}
-        }{{/hasParams}}{{#hasAuthMethods}},
-        security = {
-            {{#authMethods}}
-            @SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = { {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }{{/isOAuth}}){{^-last}},{{/-last}}
-            {{/authMethods}}
-        }{{/hasAuthMethods}}
+            {{closebrace}}{{/produces.1}}{{^produces.1}}{{#produces}}@Content(mediaType = "{{{mediaType}}}", schema = @Schema(implementation = {{{baseType}}}.class)){{/produces}}{{/produces.1}}{{/baseType}}){{^-last}},{{/-last}}{{#responses.1}}
+            {{/responses.1}}{{/responses}}{{#responses.1}}
+        {{closebrace}}{{/responses.1}}{{#hasParams}},
+        parameters = {{#vendorExtensions.originalParams.1}}{{openbrace}}
+            {{/vendorExtensions.originalParams.1}}{{#vendorExtensions.originalParams}}{{#vendorExtensions.originalParams.1}}
+            {{/vendorExtensions.originalParams.1}}@Parameter(name = "{{paramName}}"{{#description}}, description = "{{{description}}}"{{/description}}{{#required}}, required = true{{/required}}){{^-last}},{{/-last}}{{#vendorExtensions.hasMultipleParams}}
+            {{/vendorExtensions.hasMultipleParams}}{{/vendorExtensions.originalParams}}{{#vendorExtensions.originalParams.1}}
+        {{closebrace}}{{/vendorExtensions.originalParams.1}}{{/hasParams}}{{#hasAuthMethods}},
+        security = {{#authMethods.1}}{{openbrace}}
+            {{/authMethods.1}}{{#authMethods}}{{#authMethods.1}}
+            {{/authMethods.1}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {{openbrace}}{{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}}{{closebrace}}{{/isOAuth}}){{^-last}},{{/-last}}
+            {{/authMethods}}{{#authMethods.1}}
+        {{closebrace}}{{/authMethods.1}}{{/hasAuthMethods}}
     )
     {{/generateSwagger2Annotations}}
     {{#implicitHeadersParams.0}}
         {{#generateSwagger2Annotations}}
-    @Parameters({
+            {{#implicitHeadersParams.1}}
+    @Parameters({{openbrace}}
+            {{/implicitHeadersParams.1}}
             {{#implicitHeadersParams}}
         @Parameter(name = "{{paramName}}"{{#description}}, description = "{{{description}}}"{{/description}}{{#required}}, required = true{{/required}}){{^-last}},{{/-last}}
             {{/implicitHeadersParams}}
-    })
+            {{#implicitHeadersParams.1}}
+    {{closebrace}})
+            {{/implicitHeadersParams.1}}
         {{/generateSwagger2Annotations}}
         {{#generateSwagger1Annotations}}
-    @ApiImplicitParams({
-        {{#implicitHeadersParams}}
+    @ApiImplicitParams({{openbrace}}
+            {{#implicitHeadersParams}}
         @ApiImplicitParam(name = "{{{baseName}}}", value = "{{{description}}}", {{#required}}required = true,{{/required}} dataType = "{{{dataType}}}", paramType = "header"){{^-last}},{{/-last}}
-        {{/implicitHeadersParams}}
-    })
+            {{/implicitHeadersParams}}
+    {{closebrace}})
         {{/generateSwagger1Annotations}}
     {{/implicitHeadersParams.0}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/test/model_test.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/test/model_test.mustache
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions;
  */
 @MicronautTest
 class {{classname}}Test {
+
     {{#models}}
     {{#model}}
     {{^vendorExtensions.x-is-one-of-interface}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-implementation.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-implementation.mustache
@@ -24,9 +24,9 @@ import java.util.Map;
 import java.util.Arrays;
 {{/generateControllerFromExamples}}
 
-
 @Controller
 public class {{controllerClassname}} implements {{classname}} {
+
 {{#operations}}
     {{#operation}}
     {{!the method definition}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
@@ -1,6 +1,5 @@
 {{>common/licenseInfo}}
 package {{apiPackage}};
-
 {{#formatNoEmptyLines}}
 import io.micronaut.http.annotation.*;
 {{^generateHardNullable}}
@@ -50,7 +49,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 {{/formatNoEmptyLines}}
 
 {{#formatOneEmptyLine}}
+{{#withGeneratedAnnotation}}
 {{>common/generatedAnnotation}}
+{{/withGeneratedAnnotation}}
 {{^generateControllerAsAbstract}}
 @Controller
 {{/generateControllerAsAbstract}}
@@ -64,21 +65,19 @@ public interface {{classname}} {
         {{#formatNoEmptyLines}}
 {{>common/operationAnnotations}}
     @{{#lambda.pascalcase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.pascalcase}}("{{{path}}}")
-    @Produces({{openbrace}}{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}{{closebrace}})
-    {{#consumes.0}}
-    @Consumes({{openbrace}}{{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}{{closebrace}})
-    {{/consumes.0}}
+    {{^vendorExtensions.onlyDefaultProduceOrEmpty}}
+    @Produces({{#produces.1}}{{openbrace}}{{/produces.1}}{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}{{#produces.1}}{{closebrace}}{{/produces.1}})
+    {{/vendorExtensions.onlyDefaultProduceOrEmpty}}
+    {{^vendorExtensions.onlyDefaultConsumeOrEmpty}}
+    @Consumes({{#consumes.1}}{{openbrace}}{{/consumes.1}}{{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}{{#consumes.1}}{{closebrace}}{{/consumes.1}})
+    {{/vendorExtensions.onlyDefaultConsumeOrEmpty}}
     {{!security annotations}}
     {{#useAuth}}
-    @Secured({{openbrace}}{{#vendorExtensions.x-roles}}{{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-roles}}{{closebrace}})
+    @Secured({{#vendorExtensions.x-roles.1}}{{openbrace}}{{/vendorExtensions.x-roles.1}}{{#vendorExtensions.x-roles}}{{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-roles}}{{#vendorExtensions.x-roles.1}}{{closebrace}}{{/vendorExtensions.x-roles.1}})
     {{/useAuth}}
     {{!the method definition}}
     {{^returnType}}void{{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}} {{nickname}}({{#allParams}}
-        {{#indent}}
-            {{>common/params/validation}}
-        {{/indent}}
-        {{>server/params/annotations}}
-        {{#formatSingleLine}}{{>server/params/type}} {{paramName}}{{^-last}},{{/-last}}{{/formatSingleLine}}
+        {{#formatSingleLine}}{{>server/params/annotations}}{{#indent}}{{>common/params/validation}}{{/indent}}{{>server/params/type}} {{paramName}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}});
         {{/formatNoEmptyLines}}
 

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/test/controller_test.groovy.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/test/controller_test.groovy.mustache
@@ -25,7 +25,6 @@ import reactor.core.publisher.Mono
 import java.io.File
 import java.io.FileReader
 
-
 /**
  * Controller tests for {{classname}}
  */

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/MicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/MicronautClientCodegenTest.java
@@ -159,8 +159,6 @@ class MicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
         assertFileContains(modelPath + "Pet.java", "public Pet(String name, List<String> photoUrls)");
         assertFileNotContains(modelPath + "Pet.java", "public Pet()");
-        assertFileContains(modelPath + "User.java", "public User()");
-        assertFileContains(modelPath + "Order.java", "public Order()");
     }
 
     @Test
@@ -171,11 +169,8 @@ class MicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         // Constructor should have properties
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
-        assertFileContains(modelPath + "Pet.java", "public Pet()");
         assertFileNotContainsRegex(modelPath + "Pet.java", "public Pet\\([^)]+\\)");
-        assertFileContains(modelPath + "User.java", "public User()");
         assertFileNotContainsRegex(modelPath + "User.java", "public User\\([^)]+\\)");
-        assertFileContains(modelPath + "Order.java", "public Order()");
         assertFileNotContainsRegex(modelPath + "Order.java", "public Order\\([^)]+\\)");
     }
 
@@ -188,7 +183,7 @@ class MicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         // body and response content types should be properly annotated using @Consumes and @Produces micronaut annotations
         String apiPath = outputPath + "src/main/java/org/openapitools/api/";
         assertFileContains(apiPath + "DefaultApi.java", "@Consumes({\"application/vnd.oracle.resource+json; type=collection\", \"application/vnd.oracle.resource+json; type=error\"})");
-        assertFileContains(apiPath + "DefaultApi.java", "@Produces({\"application/vnd.oracle.resource+json; type=singular\"})");
+        assertFileContains(apiPath + "DefaultApi.java", "@Produces(\"application/vnd.oracle.resource+json; type=singular\")");
     }
 
     @Test

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/MicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/MicronautServerCodegenTest.java
@@ -145,8 +145,6 @@ class MicronautServerCodegenTest extends AbstractMicronautCodegenTest {
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
         assertFileContains(modelPath + "Pet.java", "public Pet(String name, List<String> photoUrls)");
         assertFileNotContains(modelPath + "Pet.java", "public Pet()");
-        assertFileContains(modelPath + "User.java", "public User()");
-        assertFileContains(modelPath + "Order.java", "public Order()");
     }
 
     @Test
@@ -157,16 +155,13 @@ class MicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         // Constructor should have properties
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
-        assertFileContains(modelPath + "Pet.java", "public Pet()");
         assertFileNotContainsRegex(modelPath + "Pet.java", "public Pet\\([^)]+\\)");
-        assertFileContains(modelPath + "User.java", "public User()");
         assertFileNotContainsRegex(modelPath + "User.java", "public User\\([^)]+\\)");
-        assertFileContains(modelPath + "Order.java", "public Order()");
         assertFileNotContainsRegex(modelPath + "Order.java", "public Order\\([^)]+\\)");
     }
 
     @Test
-    @Disabled("Feature may not be fully implemented in OpenAPI generator")
+    @Disabled("Feature is not fully implemented in OpenAPI generator 6.x. Will be fixed in openapi-generator 7.0.0")
     void testExtraAnnotations() {
 
         JavaMicronautServerCodegen codegen = new JavaMicronautServerCodegen();
@@ -196,7 +191,7 @@ class MicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         String apiPath = outputPath + "src/main/java/org/openapitools/api/";
         assertFileContainsRegex(apiPath + "BooksApi.java", "IS_ANONYMOUS[^;]{0,100}bookSearchGet");
-        assertFileContainsRegex(apiPath + "BooksApi.java", "@Secured\\(\\{\"admin\"\\}\\)[^;]{0,100}createBook");
+        assertFileContainsRegex(apiPath + "BooksApi.java", "@Secured\\(\"admin\"\\)[^;]{0,100}createBook");
         assertFileContainsRegex(apiPath + "BooksApi.java", "IS_ANONYMOUS[^;]{0,100}getBook");
         assertFileContainsRegex(apiPath + "BooksApi.java", "IS_AUTHENTICATED[^;]{0,100}reserveBook");
 

--- a/openapi-generator/src/test/resources/3_0/micronaut/multi-tags-test.yaml
+++ b/openapi-generator/src/test/resources/3_0/micronaut/multi-tags-test.yaml
@@ -69,6 +69,8 @@ paths:
       responses:
         '200':
           description: success
+        '404':
+          description: error
   /book/createEntry:
     post:
       tags: [books]
@@ -138,7 +140,7 @@ components:
       default:
         name: "Bob's Adventures"
         availability: "available"
-    BookAvailability: 
+    BookAvailability:
       type: string
       enum: ["available", "not available", "reserved"]
       default: "not available"


### PR DESCRIPTION
 - Add ability to generate code without `@Generated` annotation.
 - Add ability to generate compatible code with micronaut-aot.
 - Add ability to generate code with lombok annotations.
 - Remove generating unnecessary default constructor in POJOs.
 - Cosmetics for generated code.
 - Remove unnecessary default consumes / produces media type "application/json"
 - Removed braces in annotaions when we have only one element in collection