### PR TITLE
Update to 4.1.1 & Rewrite MessageBodyWriter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ swagger-parser = "1.0.67"
 swagger-parser-v3 = "2.1.16"
 javaparser = "3.25.5"
 
-micronaut = "4.1.2"
+micronaut = "4.1.5"
 micronaut-security = "4.1.0"
 micronaut-serde = "2.2.4"
 micronaut-rxjava2 = "2.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ micronaut-validation = "4.0.3"
 micronaut-data = "4.1.2"
 micronaut-test = "4.0.2"
 micronaut-kotlin = "4.0.2"
-micronaut-platform = "4.0.5"
+micronaut-platform = "4.1.1"
 micronaut-logging = "1.1.2"
 
 [libraries]

--- a/test-suite-server-generator/src/test/resources/logback.xml
+++ b/test-suite-server-generator/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.configuration.openapi" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
I had to rewrite the `DatedResponseBodyWriter` and `PageBodyWriter` when upgrading to Micronaut Framework 4.1.1 

Was the previous usage of `createSpecific` API a correct usage of the API?. 