### PR TITLE
New module: Openapi to ADoc

### DIFF
--- a/config/checkstyle/custom-suppressions.xml
+++ b/config/checkstyle/custom-suppressions.xml
@@ -8,4 +8,5 @@
     <suppress checks="." files="io[\\/]micronaut[\\/]openapi[\\/]swagger[\\/]core[\\/]" />
     <suppress checks="FileLength" files=".*" />
     <suppress checks="ParameterNumber" files=".*" />
+    <suppress checks="." files="io[\\/]micronaut[\\/]openapi[\\/]adoc[\\/]md" />
 </suppressions>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@ managed-swagger = "2.2.16"
 managed-javadoc-parser = "0.3.1"
 managed-jsoup = "1.16.1"
 managed-html2md-converter = "0.64.8"
+managed-parboiled = "1.4.1"
+managed-freemarker = "2.3.32"
 
 kotlin = "1.9.10"
 jspecify = "0.3.0"
@@ -14,6 +16,7 @@ swagger-parser = "1.0.67"
 swagger-parser-v3 = "2.1.16"
 javaparser = "3.25.5"
 commons-codec = "1.16.0"
+pegdown = "1.6.0"
 
 micronaut = "4.1.6"
 micronaut-security = "4.1.0"
@@ -52,6 +55,8 @@ managed-swagger-models = { module = "io.swagger.core.v3:swagger-models", version
 managed-javadoc-parser = { module = "com.github.chhorz:javadoc-parser", version.ref = "managed-javadoc-parser" }
 managed-html2md-converter = { module = "com.vladsch.flexmark:flexmark-html2md-converter", version.ref = "managed-html2md-converter" }
 managed-jsoup = { module = "org.jsoup:jsoup", version.ref = "managed-jsoup" }
+managed-parboiled = { module = "org.parboiled:parboiled-java", version.ref = "managed-parboiled" }
+managed-freemarker = { module = "org.freemarker:freemarker", version.ref = "managed-freemarker" }
 
 # Versions from BOM
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
@@ -67,6 +72,7 @@ jdt-annotation = { module = "org.eclipse.jdt:org.eclipse.jdt.annotation", versio
 android-annotation = { module = "androidx.annotation:annotation", version.ref = "android-annotation" }
 javaparser = { module = "com.github.javaparser:javaparser-symbol-solver-core", version.ref = "javaparser" }
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
+pegdown = {module = "org.pegdown:pegdown", version.ref = "pegdown"}
 
 openapi-generator = { module = "org.openapitools:openapi-generator", version.ref = "openapi-generator" }
 swagger-parser = { module = "io.swagger:swagger-parser", version.ref = "swagger-parser" }

--- a/openapi-common/build.gradle
+++ b/openapi-common/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "io.micronaut.build.internal.binary-compatibility-check"
+    id 'io.micronaut.build.internal.module'
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = false
+    }
+}
+
+dependencies {
+    api(mn.jackson.databind)
+    api(libs.jackson.dataformat.yaml)
+    api(libs.jackson.datatype.jsr310)
+    api(libs.managed.swagger.models)
+    api(libs.managed.javadoc.parser)
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/OpenApiUtils.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/OpenApiUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.util.ObjectMapperFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Convert utilities methods.
+ *
+ * @since 4.4.1
+ */
+@Internal
+public final class OpenApiUtils {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
+    };
+    /**
+     * The JSON mapper.
+     */
+    private static final ObjectMapper JSON_MAPPER = ObjectMapperFactory.createJson()
+        .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    /**
+     * The JSON 3.1 mapper.
+     */
+    private static final ObjectMapper JSON_MAPPER_31 = ObjectMapperFactory.createJson31()
+        .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    /**
+     * The JSON mapper for security scheme.
+     */
+    private static final ObjectMapper CONVERT_JSON_MAPPER = ObjectMapperFactory.buildStrictGenericObjectMapper()
+        .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS, SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING, DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    /**
+     * The YAML mapper.
+     */
+    private static final ObjectMapper YAML_MAPPER = ObjectMapperFactory.createYaml();
+
+    private OpenApiUtils() {
+    }
+
+    public static ObjectMapper getJsonMapper() {
+        return JSON_MAPPER;
+    }
+
+    public static ObjectMapper getJsonMapper31() {
+        return JSON_MAPPER_31;
+    }
+
+    public static ObjectMapper getConvertJsonMapper() {
+        return CONVERT_JSON_MAPPER;
+    }
+
+    public static ObjectMapper getYamlMapper() {
+        return YAML_MAPPER;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/SimpleSchema.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/SimpleSchema.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi;
+
+import java.util.Objects;
+
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * Copy of MapSchema but without type 'object'. Need this class to correct deserializing schema without type.
+ *
+ * @since 4.8.7
+ */
+public class SimpleSchema extends Schema<Object> {
+
+    public SimpleSchema() {
+        super(null, null);
+    }
+
+    @Override
+    public SimpleSchema type(String type) {
+        super.setType(type);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "class SimpleSchema {\n" +
+            "    " + toIndentedString(super.toString()) + "\n" +
+            "}";
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/ApiResponsesSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/ApiResponsesSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ApiResponsesSerializer extends JsonSerializer<ApiResponses> {
+
+    @Override
+    public void serialize(ApiResponses value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (value != null && value.getExtensions() != null && !value.getExtensions().isEmpty()) {
+            jgen.writeStartObject();
+
+            if (!value.isEmpty()) {
+                for (Entry<String, ApiResponse> entry : value.entrySet()) {
+                    jgen.writeObjectField(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Entry<String, Object> entry : value.getExtensions().entrySet()) {
+                jgen.writeObjectField(entry.getKey(), entry.getValue());
+            }
+            jgen.writeEndObject();
+        } else {
+            provider.defaultSerializeValue(value, jgen);
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/CallbackSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/CallbackSerializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.callbacks.Callback;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class CallbackSerializer extends JsonSerializer<Callback> {
+
+    @Override
+    public void serialize(Callback value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        // has extensions
+        if (value != null && value.getExtensions() != null && !value.getExtensions().isEmpty()) {
+            jgen.writeStartObject();
+
+            // not a ref
+            if (!StringUtils.hasText(value.get$ref())) {
+                if (!value.isEmpty()) {
+                    // write map
+                    for (Entry<String, PathItem> entry : value.entrySet()) {
+                        jgen.writeObjectField(entry.getKey(), entry.getValue());
+                    }
+                }
+            } else { // handle ref schema serialization skipping all other props ...
+                jgen.writeStringField("$ref", value.get$ref());
+            }
+            for (String ext : value.getExtensions().keySet()) {
+                jgen.writeObjectField(ext, value.getExtensions().get(ext));
+            }
+            jgen.writeEndObject();
+        } else {
+            if (value == null || !StringUtils.hasText(value.get$ref())) {
+                provider.defaultSerializeValue(value, jgen);
+            } else { // handle ref schema serialization skipping all other props
+                jgen.writeStartObject();
+                jgen.writeStringField("$ref", value.get$ref());
+                jgen.writeEndObject();
+            }
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/ExampleSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/ExampleSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.examples.Example;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 5.0.0
+ */
+@Internal
+public class ExampleSerializer extends JsonSerializer<Example> implements ResolvableSerializer {
+
+    private JsonSerializer<Object> defaultSerializer;
+
+    public ExampleSerializer(JsonSerializer<Object> serializer) {
+        defaultSerializer = serializer;
+    }
+
+    @Override
+    public void resolve(SerializerProvider serializerProvider) throws JsonMappingException {
+        if (defaultSerializer instanceof ResolvableSerializer) {
+            ((ResolvableSerializer) defaultSerializer).resolve(serializerProvider);
+        }
+    }
+
+    @Override
+    public void serialize(Example example, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (example.getValueSetFlag() && example.getValue() == null) {
+            jgen.writeStartObject();
+            defaultSerializer.unwrappingSerializer(null).serialize(example, jgen, provider);
+            jgen.writeNullField("value");
+            jgen.writeEndObject();
+        } else {
+            defaultSerializer.serialize(example, jgen, provider);
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/MediaTypeSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/MediaTypeSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.MediaType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class MediaTypeSerializer extends JsonSerializer<MediaType> implements ResolvableSerializer {
+
+    private JsonSerializer<Object> defaultSerializer;
+
+    public MediaTypeSerializer(JsonSerializer<Object> serializer) {
+        defaultSerializer = serializer;
+    }
+
+    @Override
+    public void resolve(SerializerProvider serializerProvider) throws JsonMappingException {
+        if (defaultSerializer instanceof ResolvableSerializer) {
+            ((ResolvableSerializer) defaultSerializer).resolve(serializerProvider);
+        }
+    }
+
+    @Override
+    public void serialize(MediaType value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (value.getExampleSetFlag() && value.getExample() == null) {
+            jgen.writeStartObject();
+            defaultSerializer.unwrappingSerializer(null).serialize(value, jgen, provider);
+            jgen.writeNullField("example");
+            jgen.writeEndObject();
+        } else {
+            defaultSerializer.serialize(value, jgen, provider);
+        }
+    }
+}
+
+

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/PathsSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/PathsSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class PathsSerializer extends JsonSerializer<Paths> {
+
+    @Override
+    public void serialize(Paths value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (value != null && value.getExtensions() != null && !value.getExtensions().isEmpty()) {
+            jgen.writeStartObject();
+
+            if (!value.isEmpty()) {
+                for (Entry<String, PathItem> entry : value.entrySet()) {
+                    jgen.writeObjectField(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Entry<String, Object> entry : value.getExtensions().entrySet()) {
+                jgen.writeObjectField(entry.getKey(), entry.getValue());
+            }
+            jgen.writeEndObject();
+        } else {
+            provider.defaultSerializeValue(value, jgen);
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/Schema31Serializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/Schema31Serializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.Schema;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class Schema31Serializer extends JsonSerializer<Schema> implements ResolvableSerializer {
+
+    private JsonSerializer<Object> defaultSerializer;
+
+    public Schema31Serializer(JsonSerializer<Object> serializer) {
+        defaultSerializer = serializer;
+    }
+
+    @Override
+    public void resolve(SerializerProvider serializerProvider) throws JsonMappingException {
+        if (defaultSerializer instanceof ResolvableSerializer) {
+            ((ResolvableSerializer) defaultSerializer).resolve(serializerProvider);
+        }
+    }
+
+    @Override
+    public void serialize(Schema value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (value.getBooleanSchemaValue() != null) {
+            jgen.writeBoolean(value.getBooleanSchemaValue());
+            return;
+        }
+        if (value.getExampleSetFlag() && value.getExample() == null) {
+            jgen.writeStartObject();
+            defaultSerializer.unwrappingSerializer(null).serialize(value, jgen, provider);
+            jgen.writeNullField("example");
+            jgen.writeEndObject();
+        } else {
+            defaultSerializer.serialize(value, jgen, provider);
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/SchemaSerializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/SchemaSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson;
+
+import java.io.IOException;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.swagger.v3.oas.models.media.Schema;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class SchemaSerializer extends JsonSerializer<Schema> implements ResolvableSerializer {
+
+    private JsonSerializer<Object> defaultSerializer;
+
+    public SchemaSerializer(JsonSerializer<Object> serializer) {
+        defaultSerializer = serializer;
+    }
+
+    @Override
+    public void resolve(SerializerProvider serializerProvider) throws JsonMappingException {
+        if (defaultSerializer instanceof ResolvableSerializer) {
+            ((ResolvableSerializer) defaultSerializer).resolve(serializerProvider);
+        }
+    }
+
+    @Override
+    public void serialize(Schema value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+        if (!StringUtils.hasText(value.get$ref())) {
+
+            if (value.getExampleSetFlag() && value.getExample() == null) {
+                jgen.writeStartObject();
+                defaultSerializer.unwrappingSerializer(null).serialize(value, jgen, provider);
+                jgen.writeNullField("example");
+                jgen.writeEndObject();
+            } else {
+                defaultSerializer.serialize(value, jgen, provider);
+            }
+
+        } else {
+            // handle ref schema serialization skipping all other props
+            jgen.writeStartObject();
+            jgen.writeStringField("$ref", value.get$ref());
+            jgen.writeEndObject();
+        }
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Components31Mixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Components31Mixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.CallbackSerializer;
+import io.swagger.v3.oas.models.callbacks.Callback;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class Components31Mixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonSerialize(contentUsing = CallbackSerializer.class)
+    public abstract Map<String, Callback> getCallbacks();
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ComponentsMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ComponentsMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.CallbackSerializer;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.callbacks.Callback;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class ComponentsMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonSerialize(contentUsing = CallbackSerializer.class)
+    public abstract Map<String, Callback> getCallbacks();
+
+    @JsonIgnore
+    public abstract Map<String, PathItem> getPathItems();
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/DateSchemaMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/DateSchemaMixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class DateSchemaMixin {
+
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+    public abstract Object getExample();
+
+    @JsonIgnore
+    public abstract Object getJsonSchemaImpl();
+
+    @JsonIgnore
+    public abstract Map<String, Object> getJsonSchema();
+
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Discriminator31Mixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Discriminator31Mixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class Discriminator31Mixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/DiscriminatorMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/DiscriminatorMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class DiscriminatorMixin {
+
+    @JsonIgnore
+    public abstract Map<String, Object> getExtensions();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ExampleMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ExampleMixin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class ExampleMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonInclude(Include.NON_NULL)
+    public abstract Object getValue();
+
+    @JsonIgnore
+    public abstract boolean getValueSetFlag();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ExtensionsMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/ExtensionsMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class ExtensionsMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Info31Mixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Info31Mixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class Info31Mixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/InfoMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/InfoMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class InfoMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract String getSummary();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/LicenseMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/LicenseMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class LicenseMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract String getIdentifier();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/MediaTypeMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/MediaTypeMixin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class MediaTypeMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract boolean getExampleSetFlag();
+
+    @JsonInclude(Include.NON_NULL)
+    public abstract Object getExample();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OpenAPI31Mixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OpenAPI31Mixin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.PathsSerializer;
+import io.swagger.v3.oas.models.Paths;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class OpenAPI31Mixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonSerialize(using = PathsSerializer.class)
+    public abstract Paths getPaths();
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OpenAPIMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OpenAPIMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.PathsSerializer;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class OpenAPIMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonSerialize(using = PathsSerializer.class)
+    public abstract Paths getPaths();
+
+    @JsonIgnore
+    public abstract Map<String, PathItem> getWebhooks();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OperationMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/OperationMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.ApiResponsesSerializer;
+import io.micronaut.openapi.swagger.core.jackson.CallbackSerializer;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class OperationMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonSerialize(contentUsing = CallbackSerializer.class)
+    public abstract Map<String, Callback> getCallbacks();
+
+    @JsonSerialize(using = ApiResponsesSerializer.class)
+    public abstract ApiResponses getResponses();
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Schema31Mixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/Schema31Mixin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+
+import io.micronaut.core.annotation.Internal;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+@JsonPropertyOrder(value = {"type", "format", "if", "then", "else"}, alphabetic = true)
+public abstract class Schema31Mixin {
+
+    @JsonIgnore
+    public abstract Map<String, Object> getJsonSchema();
+
+    @JsonIgnore
+    public abstract Boolean getNullable();
+
+    @JsonIgnore
+    public abstract Boolean getExclusiveMinimum();
+
+    @JsonIgnore
+    public abstract Boolean getExclusiveMaximum();
+
+    @JsonProperty("exclusiveMinimum")
+    public abstract BigDecimal getExclusiveMinimumValue();
+
+    @JsonProperty("exclusiveMaximum")
+    public abstract BigDecimal getExclusiveMaximumValue();
+
+    @JsonIgnore
+    public abstract String getType();
+
+    @JsonProperty("type")
+    @JsonSerialize(using = TypeSerializer.class)
+    public abstract Set<String> getTypes();
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract boolean getExampleSetFlag();
+
+    @JsonInclude(Include.NON_NULL)
+    public abstract Object getExample();
+
+    @JsonIgnore
+    public abstract Object getJsonSchemaImpl();
+
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
+
+    public static class TypeSerializer extends JsonSerializer<Set<String>> {
+
+        @Override
+        public void serialize(Set<String> types, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+            if (types != null && types.size() == 1) {
+                jsonGenerator.writeString((String) types.toArray()[0]);
+            } else if (types != null && types.size() > 1) {
+                jsonGenerator.writeStartArray();
+                for (String t : types) {
+                    jsonGenerator.writeString(t);
+                }
+                jsonGenerator.writeEndArray();
+            }
+        }
+    }
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/SchemaConverterMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/SchemaConverterMixin.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class SchemaConverterMixin {
+
+    @JsonIgnore
+    public abstract Map<String, Object> getJsonSchema();
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract boolean getExampleSetFlag();
+
+    @JsonInclude(Include.NON_NULL)
+    public abstract Object getExample();
+
+    @JsonIgnore
+    public abstract Object getJsonSchemaImpl();
+
+    @JsonIgnore
+    public abstract BigDecimal getExclusiveMinimumValue();
+
+    @JsonIgnore
+    public abstract BigDecimal getExclusiveMaximumValue();
+
+    @JsonIgnore
+    public abstract Schema getContains();
+
+    @JsonIgnore
+    public abstract String get$id();
+
+    @JsonIgnore
+    public abstract String get$anchor();
+
+    @JsonIgnore
+    public abstract String get$schema();
+
+    @JsonIgnore
+    public abstract Set<String> getTypes();
+
+    @JsonIgnore
+    public abstract Map<String, Schema> getPatternProperties();
+
+    @JsonIgnore
+    public abstract List<Schema> getPrefixItems();
+
+    @JsonIgnore
+    public abstract String getContentEncoding();
+
+    @JsonIgnore
+    public abstract String getContentMediaType();
+
+    @JsonIgnore
+    public abstract Schema getContentSchema();
+
+    @JsonIgnore
+    public abstract Schema getPropertyNames();
+
+    @JsonIgnore
+    public abstract Object getUnevaluatedProperties();
+
+    @JsonIgnore
+    public abstract Integer getMaxContains();
+
+    @JsonIgnore
+    public abstract Integer getMinContains();
+
+    @JsonIgnore
+    public abstract Schema getAdditionalItems();
+
+    @JsonIgnore
+    public abstract Schema getUnevaluatedItems();
+
+    @JsonIgnore
+    public abstract Schema getIf();
+
+    @JsonIgnore
+    public abstract Schema getElse();
+
+    @JsonIgnore
+    public abstract Schema getThen();
+
+    @JsonIgnore
+    public abstract Map<String, Schema> getDependentSchemas();
+
+    @JsonIgnore
+    public abstract Map<String, List<String>> getDependentRequired();
+
+    @JsonIgnore
+    public abstract String get$comment();
+
+    @JsonIgnore
+    public abstract List<Object> getExamples();
+
+    @JsonIgnore
+    public abstract Object getConst();
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/SchemaMixin.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/jackson/mixin/SchemaMixin.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.jackson.mixin;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public abstract class SchemaMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract boolean getExampleSetFlag();
+
+    @JsonInclude(Include.NON_NULL)
+    public abstract Object getExample();
+
+    @JsonIgnore
+    public abstract Map<String, Object> getJsonSchema();
+
+    @JsonIgnore
+    public abstract BigDecimal getExclusiveMinimumValue();
+
+    @JsonIgnore
+    public abstract BigDecimal getExclusiveMaximumValue();
+
+    @JsonIgnore
+    public abstract Schema getContains();
+
+    @JsonIgnore
+    public abstract String get$id();
+
+    @JsonIgnore
+    public abstract String get$anchor();
+
+    @JsonIgnore
+    public abstract String get$schema();
+
+    @JsonIgnore
+    public abstract Set<String> getTypes();
+
+    @JsonIgnore
+    public abstract Map<String, Schema> getPatternProperties();
+
+    @JsonIgnore
+    public abstract Object getJsonSchemaImpl();
+
+    @JsonIgnore
+    public abstract List<Schema> getPrefixItems();
+
+    @JsonIgnore
+    public abstract String getContentEncoding();
+
+    @JsonIgnore
+    public abstract String getContentMediaType();
+
+    @JsonIgnore
+    public abstract Schema getContentSchema();
+
+    @JsonIgnore
+    public abstract Schema getPropertyNames();
+
+    @JsonIgnore
+    public abstract Object getUnevaluatedProperties();
+
+    @JsonIgnore
+    public abstract Integer getMaxContains();
+
+    @JsonIgnore
+    public abstract Integer getMinContains();
+
+    @JsonIgnore
+    public abstract Schema getAdditionalItems();
+
+    @JsonIgnore
+    public abstract Schema getUnevaluatedItems();
+
+    @JsonIgnore
+    public abstract Schema getIf();
+
+    @JsonIgnore
+    public abstract Schema getElse();
+
+    @JsonIgnore
+    public abstract Schema getThen();
+
+    @JsonIgnore
+    public abstract Map<String, Schema> getDependentSchemas();
+
+    @JsonIgnore
+    public abstract Map<String, List<String>> getDependentRequired();
+
+    @JsonIgnore
+    public abstract String get$comment();
+
+    @JsonIgnore
+    public abstract List<Object> getExamples();
+
+    @JsonIgnore
+    public abstract Object getConst();
+
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ApiResponses31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ApiResponses31Deserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ApiResponses31Deserializer extends ApiResponsesDeserializer {
+
+    public ApiResponses31Deserializer() {
+        openapi31 = true;
+    }
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ApiResponsesDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ApiResponsesDeserializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ApiResponsesDeserializer extends JsonDeserializer<ApiResponses> {
+
+    protected boolean openapi31;
+
+    @Override
+    public ApiResponses deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+
+        final ObjectMapper mapper;
+        if (openapi31) {
+            mapper = OpenApiUtils.getJsonMapper31();
+        } else {
+            mapper = OpenApiUtils.getJsonMapper();
+        }
+        ApiResponses result = new ApiResponses();
+        JsonNode node = jp.getCodec().readTree(jp);
+        ObjectNode objectNode = (ObjectNode) node;
+        Map<String, Object> extensions = new LinkedHashMap<>();
+        for (Iterator<String> it = objectNode.fieldNames(); it.hasNext(); ) {
+            String childName = it.next();
+            JsonNode child = objectNode.get(childName);
+            // if name start with `x-` consider it an extension
+            if (childName.startsWith("x-")) {
+                extensions.put(childName, mapper.convertValue(child, Object.class));
+            } else {
+                result.put(childName, mapper.convertValue(child, ApiResponse.class));
+            }
+        }
+        if (!extensions.isEmpty()) {
+            result.setExtensions(extensions);
+        }
+        return result;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Callback31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Callback31Deserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class Callback31Deserializer extends CallbackDeserializer {
+
+    public Callback31Deserializer() {
+        openapi31 = true;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/CallbackDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/CallbackDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.callbacks.Callback;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class CallbackDeserializer extends JsonDeserializer<Callback> {
+
+    protected boolean openapi31;
+
+    @Override
+    public Callback deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+
+        final ObjectMapper mapper;
+        if (openapi31) {
+            mapper = OpenApiUtils.getJsonMapper31();
+        } else {
+            mapper = OpenApiUtils.getJsonMapper();
+        }
+        Callback result = new Callback();
+        JsonNode node = jp.getCodec().readTree(jp);
+        ObjectNode objectNode = (ObjectNode) node;
+        Map<String, Object> extensions = new LinkedHashMap<>();
+        for (Iterator<String> it = objectNode.fieldNames(); it.hasNext(); ) {
+            String childName = it.next();
+            JsonNode child = objectNode.get(childName);
+            // if name start with `x-` consider it an extension
+            if (childName.startsWith("x-")) {
+                extensions.put(childName, mapper.convertValue(child, Object.class));
+            } else if (childName.equals("$ref")) {
+                result.$ref(child.asText());
+            } else {
+                result.put(childName, mapper.convertValue(child, PathItem.class));
+            }
+        }
+        if (!extensions.isEmpty()) {
+            result.setExtensions(extensions);
+        }
+        return result;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/DeserializationModule.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/DeserializationModule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.Encoding;
+import io.swagger.v3.oas.models.media.EncodingProperty;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class DeserializationModule extends SimpleModule {
+
+    public DeserializationModule() {
+
+        addDeserializer(Schema.class, new ModelDeserializer());
+        addDeserializer(Parameter.class, new ParameterDeserializer());
+        addDeserializer(Header.StyleEnum.class, new HeaderStyleEnumDeserializer());
+        addDeserializer(Encoding.StyleEnum.class, new EncodingStyleEnumDeserializer());
+        addDeserializer(EncodingProperty.StyleEnum.class, new EncodingPropertyStyleEnumDeserializer());
+
+        addDeserializer(SecurityScheme.class, new SecuritySchemeDeserializer());
+
+        addDeserializer(ApiResponses.class, new ApiResponsesDeserializer());
+        addDeserializer(Paths.class, new PathsDeserializer());
+        addDeserializer(Callback.class, new CallbackDeserializer());
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/DeserializationModule31.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/DeserializationModule31.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.Encoding;
+import io.swagger.v3.oas.models.media.EncodingProperty;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class DeserializationModule31 extends SimpleModule {
+
+    public DeserializationModule31() {
+
+        addDeserializer(Schema.class, new Model31Deserializer());
+        addDeserializer(Parameter.class, new Parameter31Deserializer());
+        addDeserializer(Header.StyleEnum.class, new HeaderStyleEnumDeserializer());
+        addDeserializer(Encoding.StyleEnum.class, new EncodingStyleEnumDeserializer());
+        addDeserializer(EncodingProperty.StyleEnum.class, new EncodingPropertyStyleEnumDeserializer());
+
+        addDeserializer(SecurityScheme.class, new SecurityScheme31Deserializer());
+
+        addDeserializer(ApiResponses.class, new ApiResponses31Deserializer());
+        addDeserializer(Paths.class, new Paths31Deserializer());
+        addDeserializer(Callback.class, new Callback31Deserializer());
+
+
+        setDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+                if (beanDesc.getBeanClass() == OpenAPI.class) {
+                    return new OpenAPI31Deserializer(deserializer);
+                }
+                return deserializer;
+            }
+        });
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/EncodingPropertyStyleEnumDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/EncodingPropertyStyleEnumDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.EncodingProperty;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class EncodingPropertyStyleEnumDeserializer extends JsonDeserializer<EncodingProperty.StyleEnum> {
+
+    @Override
+    public EncodingProperty.StyleEnum deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (node != null) {
+            String value = node.asText();
+            return getStyleEnum(value);
+        }
+        return null;
+    }
+
+    private EncodingProperty.StyleEnum getStyleEnum(String value) {
+        return Arrays.stream(
+                EncodingProperty.StyleEnum.values())
+            .filter(i -> i.toString().equals(value))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(
+                String.format("Can not deserialize value of type EncodingProperty.StyleEnum from String \"%s\": value not one of declared Enum instance names: %s",
+                    value,
+                    Arrays.stream(EncodingProperty.StyleEnum.values()).map(EncodingProperty.StyleEnum::toString).collect(Collectors.joining(", ", "[", "]")))));
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/EncodingStyleEnumDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/EncodingStyleEnumDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.media.Encoding;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class EncodingStyleEnumDeserializer extends JsonDeserializer<Encoding.StyleEnum> {
+
+    @Override
+    public Encoding.StyleEnum deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (node != null) {
+            String value = node.asText();
+            return getStyleEnum(value);
+        }
+        return null;
+    }
+
+    private Encoding.StyleEnum getStyleEnum(String value) {
+        return Arrays.stream(
+                Encoding.StyleEnum.values())
+            .filter(i -> i.toString().equals(value))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(
+                String.format("Can not deserialize value of type Encoding.StyleEnum from String \"%s\": value not one of declared Enum instance names: %s",
+                    value,
+                    Arrays.stream(Encoding.StyleEnum.values()).map(Encoding.StyleEnum::toString).collect(Collectors.joining(", ", "[", "]")))));
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/HeaderStyleEnumDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/HeaderStyleEnumDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import io.micronaut.core.annotation.Internal;
+import io.swagger.v3.oas.models.headers.Header;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class HeaderStyleEnumDeserializer extends JsonDeserializer<Header.StyleEnum> {
+
+    @Override
+    public Header.StyleEnum deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (node != null) {
+            String value = node.asText();
+            return getStyleEnum(value);
+        }
+        return null;
+    }
+
+    private Header.StyleEnum getStyleEnum(String value) {
+        return Arrays.stream(
+                Header.StyleEnum.values())
+            .filter(i -> i.toString().equals(value))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(
+                String.format("Can not deserialize value of type Header.StyleEnum from String \"%s\": value not one of declared Enum instance names: %s",
+                    value,
+                    Arrays.stream(Header.StyleEnum.values()).map(Header.StyleEnum::toString).collect(Collectors.joining(", ", "[", "]")))));
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Model31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Model31Deserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class Model31Deserializer extends ModelDeserializer {
+
+    public Model31Deserializer() {
+        openapi31 = true;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ModelDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ModelDeserializer.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.openapi.OpenApiUtils;
+import io.micronaut.openapi.SimpleSchema;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.EmailSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.JsonSchema;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.PasswordSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.UUIDSchema;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ModelDeserializer extends JsonDeserializer<Schema> {
+
+    protected boolean openapi31;
+
+    @Override
+    public Schema deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        Schema schema = null;
+
+        if (openapi31) {
+            schema = deserializeJsonSchema(node);
+            return schema;
+        }
+        if (node.isBoolean()) {
+            return new Schema().booleanSchemaValue(node.booleanValue());
+        }
+
+        List<String> composed = Arrays.asList("allOf", "anyOf", "oneOf");
+        for (String field : composed) {
+            if (node.get(field) != null) {
+                return OpenApiUtils.getJsonMapper().convertValue(node, ComposedSchema.class);
+            }
+        }
+
+        JsonNode type = node.get("type");
+        String format = node.get("format") == null ? "" : node.get("format").textValue();
+
+        if (type != null && "array".equals(type.textValue())) {
+            schema = OpenApiUtils.getJsonMapper().convertValue(node, ArraySchema.class);
+        } else if (type != null) {
+            if (type.textValue().equals("integer")) {
+                schema = OpenApiUtils.getJsonMapper().convertValue(node, IntegerSchema.class);
+                if (!StringUtils.hasText(format)) {
+                    schema.setFormat(null);
+                }
+            } else if (type.textValue().equals("number")) {
+                schema = OpenApiUtils.getJsonMapper().convertValue(node, NumberSchema.class);
+            } else if (type.textValue().equals("boolean")) {
+                schema = OpenApiUtils.getJsonMapper().convertValue(node, BooleanSchema.class);
+            } else if (type.textValue().equals("string")) {
+                if ("date".equals(format)) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, DateSchema.class);
+                } else if ("date-time".equals(format)) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, DateTimeSchema.class);
+                } else if ("email".equals(format)) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, EmailSchema.class);
+                } else if ("password".equals(format)) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, PasswordSchema.class);
+                } else if ("uuid".equals(format)) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, UUIDSchema.class);
+                } else {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, StringSchema.class);
+                }
+            } else if (type.textValue().equals("object")) {
+                schema = deserializeObjectSchema(node, true);
+            }
+        } else if (node.get("$ref") != null) {
+            schema = new Schema().$ref(node.get("$ref").asText());
+        } else { // assume object
+            schema = deserializeObjectSchema(node, false);
+        }
+
+        return schema;
+    }
+
+    private Schema deserializeObjectSchema(JsonNode node, boolean withType) {
+        JsonNode additionalProperties = node.get("additionalProperties");
+        Schema schema;
+        if (additionalProperties != null) {
+            if (additionalProperties.isBoolean()) {
+                Boolean additionalPropsBoolean = OpenApiUtils.getJsonMapper().convertValue(additionalProperties, Boolean.class);
+                ((ObjectNode) node).remove("additionalProperties");
+                if (additionalPropsBoolean) {
+                    schema = OpenApiUtils.getJsonMapper().convertValue(node, MapSchema.class);
+                } else {
+                    if (withType) {
+                        schema = OpenApiUtils.getJsonMapper().convertValue(node, ObjectSchema.class);
+                    } else {
+                        schema = OpenApiUtils.getJsonMapper().convertValue(node, SimpleSchema.class);
+                    }
+                }
+                schema.setAdditionalProperties(additionalPropsBoolean);
+            } else {
+                Schema innerSchema = OpenApiUtils.getJsonMapper().convertValue(additionalProperties, Schema.class);
+                ((ObjectNode) node).remove("additionalProperties");
+                MapSchema ms = OpenApiUtils.getJsonMapper().convertValue(node, MapSchema.class);
+                ms.setAdditionalProperties(innerSchema);
+                schema = ms;
+            }
+        } else {
+            if (withType) {
+                schema = OpenApiUtils.getJsonMapper().convertValue(node, ObjectSchema.class);
+            } else {
+                schema = OpenApiUtils.getJsonMapper().convertValue(node, SimpleSchema.class);
+            }
+        }
+        if (schema != null) {
+            try {
+                schema.jsonSchema(OpenApiUtils.getJsonMapper31().readValue(OpenApiUtils.getJsonMapper31().writeValueAsString(node), Map.class));
+            } catch (JsonProcessingException e) {
+                System.err.println("Exception converting jsonSchema to Map " + e.getMessage());
+            }
+        }
+        return schema;
+    }
+
+    private Schema deserializeJsonSchema(JsonNode node) {
+        if (node.isBoolean()) {
+            return new Schema().booleanSchemaValue(node.booleanValue());
+        }
+        JsonNode additionalProperties = node.get("additionalProperties");
+        JsonNode type = node.get("type");
+        Schema schema;
+
+        if (type != null || additionalProperties != null) {
+            if (type != null) {
+                ((ObjectNode) node).remove("type");
+            }
+            if (additionalProperties != null) {
+                ((ObjectNode) node).remove("additionalProperties");
+            }
+            schema = OpenApiUtils.getJsonMapper31().convertValue(node, JsonSchema.class);
+            if (type instanceof TextNode) {
+                schema.types(new LinkedHashSet<>(Collections.singletonList(type.textValue())));
+            } else if (type instanceof ArrayNode) {
+                Set<String> types = new LinkedHashSet<>();
+                type.elements().forEachRemaining(n -> types.add(n.textValue()));
+                schema.types(types);
+            }
+            if (additionalProperties != null) {
+                try {
+                    if (additionalProperties.isBoolean()) {
+                        schema.setAdditionalProperties(additionalProperties.booleanValue());
+                    } else {
+                        Schema innerSchema = deserializeJsonSchema(additionalProperties);
+                        schema.setAdditionalProperties(innerSchema);
+                    }
+                } catch (Exception e) {
+                    Boolean additionalPropsBoolean = OpenApiUtils.getJsonMapper31().convertValue(additionalProperties, Boolean.class);
+                    schema.setAdditionalProperties(additionalPropsBoolean);
+                }
+            }
+
+        } else {
+            schema = OpenApiUtils.getJsonMapper31().convertValue(node, JsonSchema.class);
+        }
+        return schema;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ObjectMapperFactory.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ObjectMapperFactory.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.swagger.core.jackson.ExampleSerializer;
+import io.micronaut.openapi.swagger.core.jackson.MediaTypeSerializer;
+import io.micronaut.openapi.swagger.core.jackson.Schema31Serializer;
+import io.micronaut.openapi.swagger.core.jackson.SchemaSerializer;
+import io.micronaut.openapi.swagger.core.jackson.mixin.Components31Mixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.ComponentsMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.DateSchemaMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.Discriminator31Mixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.DiscriminatorMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.ExampleMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.ExtensionsMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.InfoMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.LicenseMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.MediaTypeMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.OpenAPI31Mixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.OpenAPIMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.OperationMixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.Schema31Mixin;
+import io.micronaut.openapi.swagger.core.jackson.mixin.SchemaMixin;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.links.Link;
+import io.swagger.v3.oas.models.links.LinkParameter;
+import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.Encoding;
+import io.swagger.v3.oas.models.media.EncodingProperty;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.XML;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.OAuthFlow;
+import io.swagger.v3.oas.models.security.OAuthFlows;
+import io.swagger.v3.oas.models.security.Scopes;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.oas.models.servers.ServerVariables;
+import io.swagger.v3.oas.models.tags.Tag;
+
+import org.yaml.snakeyaml.LoaderOptions;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ObjectMapperFactory {
+
+    private ObjectMapperFactory() {
+    }
+
+    public static ObjectMapper createJson() {
+        return create(null, false);
+    }
+
+    public static ObjectMapper createYaml(boolean openapi31) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+        YAMLFactory factory = new YAMLFactoryBuilder(new YAMLFactory())
+            .loaderOptions(loaderOptions)
+            .disable(Feature.WRITE_DOC_START_MARKER)
+            .enable(Feature.MINIMIZE_QUOTES)
+            .enable(Feature.SPLIT_LINES)
+            .enable(Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
+            .build();
+
+        return create(factory, openapi31);
+    }
+
+    public static ObjectMapper createYaml() {
+        return createYaml(false);
+    }
+
+    public static ObjectMapper createJson31() {
+        return create(null, true);
+    }
+
+    public static ObjectMapper createYaml31() {
+        return createYaml(true);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ObjectMapper create(JsonFactory jsonFactory, boolean openapi31) {
+        ObjectMapper mapper = jsonFactory == null ? new ObjectMapper() : new ObjectMapper(jsonFactory);
+
+        if (!openapi31) {
+            // handle ref schema serialization skipping all other props
+            mapper.registerModule(new SimpleModule() {
+                @Override
+                public void setupModule(SetupContext context) {
+                    super.setupModule(context);
+                    context.addBeanSerializerModifier(new BeanSerializerModifier() {
+                        @Override
+                        public JsonSerializer<?> modifySerializer(
+                            SerializationConfig config, BeanDescription desc, JsonSerializer<?> serializer) {
+                            if (Schema.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new SchemaSerializer((JsonSerializer<Object>) serializer);
+                            } else if (MediaType.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new MediaTypeSerializer((JsonSerializer<Object>) serializer);
+                            } else if (MediaType.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new MediaTypeSerializer((JsonSerializer<Object>) serializer);
+                            } else if (Example.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new ExampleSerializer((JsonSerializer<Object>) serializer);
+                            }
+                            return serializer;
+                        }
+                    });
+                }
+            });
+        } else {
+            mapper.registerModule(new SimpleModule() {
+                @Override
+                public void setupModule(SetupContext context) {
+                    super.setupModule(context);
+                    context.addBeanSerializerModifier(new BeanSerializerModifier() {
+                        @Override
+                        public JsonSerializer<?> modifySerializer(
+                            SerializationConfig config, BeanDescription desc, JsonSerializer<?> serializer) {
+                            if (Schema.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new Schema31Serializer((JsonSerializer<Object>) serializer);
+                            } else if (MediaType.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new MediaTypeSerializer((JsonSerializer<Object>) serializer);
+                            } else if (Example.class.isAssignableFrom(desc.getBeanClass())) {
+                                return new ExampleSerializer((JsonSerializer<Object>) serializer);
+                            }
+                            return serializer;
+                        }
+                    });
+                }
+            });
+        }
+
+        if (!openapi31) {
+            Module deserializerModule = new DeserializationModule();
+            mapper.registerModule(deserializerModule);
+        } else {
+            Module deserializerModule = new DeserializationModule31();
+            mapper.registerModule(deserializerModule);
+        }
+        mapper.registerModule(new JavaTimeModule());
+
+        Map<Class<?>, Class<?>> sourceMixins = new LinkedHashMap<>();
+
+        sourceMixins.put(ApiResponses.class, ExtensionsMixin.class);
+        sourceMixins.put(Contact.class, ExtensionsMixin.class);
+        sourceMixins.put(Encoding.class, ExtensionsMixin.class);
+        sourceMixins.put(EncodingProperty.class, ExtensionsMixin.class);
+        sourceMixins.put(Example.class, ExampleMixin.class);
+        sourceMixins.put(ExternalDocumentation.class, ExtensionsMixin.class);
+        sourceMixins.put(Link.class, ExtensionsMixin.class);
+        sourceMixins.put(LinkParameter.class, ExtensionsMixin.class);
+        sourceMixins.put(MediaType.class, MediaTypeMixin.class);
+        sourceMixins.put(OAuthFlow.class, ExtensionsMixin.class);
+        sourceMixins.put(OAuthFlows.class, ExtensionsMixin.class);
+        sourceMixins.put(Operation.class, OperationMixin.class);
+        sourceMixins.put(PathItem.class, ExtensionsMixin.class);
+        sourceMixins.put(Paths.class, ExtensionsMixin.class);
+        sourceMixins.put(Scopes.class, ExtensionsMixin.class);
+        sourceMixins.put(Server.class, ExtensionsMixin.class);
+        sourceMixins.put(ServerVariable.class, ExtensionsMixin.class);
+        sourceMixins.put(ServerVariables.class, ExtensionsMixin.class);
+        sourceMixins.put(Tag.class, ExtensionsMixin.class);
+        sourceMixins.put(XML.class, ExtensionsMixin.class);
+        sourceMixins.put(ApiResponse.class, ExtensionsMixin.class);
+        sourceMixins.put(Parameter.class, ExtensionsMixin.class);
+        sourceMixins.put(RequestBody.class, ExtensionsMixin.class);
+        sourceMixins.put(Header.class, ExtensionsMixin.class);
+        sourceMixins.put(SecurityScheme.class, ExtensionsMixin.class);
+        sourceMixins.put(Callback.class, ExtensionsMixin.class);
+
+
+        if (!openapi31) {
+            sourceMixins.put(Schema.class, SchemaMixin.class);
+            sourceMixins.put(DateSchema.class, DateSchemaMixin.class);
+            sourceMixins.put(Components.class, ComponentsMixin.class);
+            sourceMixins.put(Info.class, InfoMixin.class);
+            sourceMixins.put(License.class, LicenseMixin.class);
+            sourceMixins.put(OpenAPI.class, OpenAPIMixin.class);
+            sourceMixins.put(Discriminator.class, DiscriminatorMixin.class);
+        } else {
+            sourceMixins.put(Info.class, ExtensionsMixin.class);
+            sourceMixins.put(Schema.class, Schema31Mixin.class);
+            sourceMixins.put(Components.class, Components31Mixin.class);
+            sourceMixins.put(OpenAPI.class, OpenAPI31Mixin.class);
+            sourceMixins.put(DateSchema.class, DateSchemaMixin.class);
+            sourceMixins.put(Discriminator.class, Discriminator31Mixin.class);
+        }
+        mapper.setMixIns(sourceMixins);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+        mapper.configure(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN, true);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+
+        return mapper;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static ObjectMapper buildStrictGenericObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+        mapper.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+        return mapper;
+    }
+
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/OpenAPI31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/OpenAPI31Deserializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public class OpenAPI31Deserializer extends StdDeserializer<OpenAPI> implements ResolvableDeserializer {
+
+    private final JsonDeserializer<?> defaultDeserializer;
+
+    public OpenAPI31Deserializer(JsonDeserializer<?> defaultDeserializer) {
+        super(OpenAPI.class);
+        this.defaultDeserializer = defaultDeserializer;
+    }
+
+    @Override
+    public OpenAPI deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        OpenAPI openAPI = (OpenAPI) defaultDeserializer.deserialize(jp, ctxt);
+        openAPI.setSpecVersion(SpecVersion.V31);
+        return openAPI;
+    }
+
+    @Override
+    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
+        ((ResolvableDeserializer) defaultDeserializer).resolve(ctxt);
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Parameter31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Parameter31Deserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class Parameter31Deserializer extends ParameterDeserializer {
+
+    public Parameter31Deserializer() {
+        openapi31 = true;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ParameterDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/ParameterDeserializer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.parameters.CookieParameter;
+import io.swagger.v3.oas.models.parameters.HeaderParameter;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.PathParameter;
+import io.swagger.v3.oas.models.parameters.QueryParameter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class ParameterDeserializer extends JsonDeserializer<Parameter> {
+
+    protected boolean openapi31;
+
+    @Override
+    public Parameter deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        Parameter result = null;
+
+        JsonNode node = jp.getCodec().readTree(jp);
+        JsonNode sub = node.get("$ref");
+        JsonNode inNode = node.get("in");
+        JsonNode desc = node.get("description");
+
+        if (sub != null) {
+            result = new Parameter().$ref(sub.asText());
+            if (desc != null && openapi31) {
+                result.description(desc.asText());
+            }
+
+        } else if (inNode != null) {
+            String in = inNode.asText();
+
+            ObjectReader reader = null;
+            ObjectMapper mapper;
+            if (openapi31) {
+                mapper = OpenApiUtils.getJsonMapper31();
+            } else {
+                mapper = OpenApiUtils.getJsonMapper();
+            }
+
+
+            if ("query".equals(in)) {
+                reader = mapper.readerFor(QueryParameter.class);
+            } else if ("header".equals(in)) {
+                reader = mapper.readerFor(HeaderParameter.class);
+            } else if ("path".equals(in)) {
+                reader = mapper.readerFor(PathParameter.class);
+            } else if ("cookie".equals(in)) {
+                reader = mapper.readerFor(CookieParameter.class);
+            }
+            if (reader != null) {
+                result = reader.with(DeserializationFeature.READ_ENUMS_USING_TO_STRING).readValue(node);
+            }
+        }
+
+        return result;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Paths31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/Paths31Deserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class Paths31Deserializer extends PathsDeserializer {
+
+    public Paths31Deserializer() {
+        openapi31 = true;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/PathsDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/PathsDeserializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class PathsDeserializer extends JsonDeserializer<Paths> {
+
+    protected boolean openapi31;
+
+    @Override
+    public Paths deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+
+        final ObjectMapper mapper;
+        if (openapi31) {
+            mapper = OpenApiUtils.getJsonMapper31();
+        } else {
+            mapper = OpenApiUtils.getJsonMapper();
+        }
+
+        Paths result = new Paths();
+        JsonNode node = jp.getCodec().readTree(jp);
+        ObjectNode objectNode = (ObjectNode) node;
+        Map<String, Object> extensions = new LinkedHashMap<>();
+        for (Iterator<String> it = objectNode.fieldNames(); it.hasNext(); ) {
+            String childName = it.next();
+            JsonNode child = objectNode.get(childName);
+            // if name start with `x-` consider it an extesion
+            if (childName.startsWith("x-")) {
+                extensions.put(childName, mapper.convertValue(child, Object.class));
+            } else {
+                result.put(childName, mapper.convertValue(child, PathItem.class));
+            }
+        }
+        if (!extensions.isEmpty()) {
+            result.setExtensions(extensions);
+        }
+        return result;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/PrimitiveType.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/PrimitiveType.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalTime;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.swagger.v3.oas.models.media.BinarySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.ByteArraySchema;
+import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.FileSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.UUIDSchema;
+
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import static java.util.Map.entry;
+
+/**
+ * The {@code PrimitiveType} enumeration defines a mapping of limited set
+ * of classes into Swagger primitive types.
+ * <p>
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public enum PrimitiveType {
+    STRING(String.class, "string") {
+        @Override
+        public Schema createProperty() {
+            return new StringSchema();
+        }
+    },
+    BOOLEAN(Boolean.class, "boolean") {
+        @Override
+        public Schema createProperty() {
+            return new BooleanSchema();
+        }
+    },
+    BYTE(Byte.class, "byte") {
+        @Override
+        public ByteArraySchema createProperty() {
+            return new ByteArraySchema();
+        }
+    },
+    BINARY(Byte.class, "binary") {
+        @Override
+        public BinarySchema createProperty() {
+            return new BinarySchema();
+        }
+    },
+    URI(java.net.URI.class, "uri") {
+        @Override
+        public Schema createProperty() {
+            return new StringSchema().format("uri");
+        }
+    },
+    URL(java.net.URL.class, "url") {
+        @Override
+        public Schema createProperty() {
+            return new StringSchema().format("url");
+        }
+    },
+    EMAIL(String.class, "email") {
+        @Override
+        public Schema createProperty() {
+            return new StringSchema().format("email");
+        }
+    },
+    UUID(java.util.UUID.class, "uuid") {
+        @Override
+        public UUIDSchema createProperty() {
+            return new UUIDSchema();
+        }
+    },
+    INT(Integer.class, "integer") {
+        @Override
+        public IntegerSchema createProperty() {
+            return new IntegerSchema();
+        }
+    },
+    LONG(Long.class, "long") {
+        @Override
+        public Schema createProperty() {
+            return new IntegerSchema().format("int64");
+        }
+    },
+    FLOAT(Float.class, "float") {
+        @Override
+        public Schema createProperty() {
+            return new NumberSchema().format("float");
+        }
+    },
+    DOUBLE(Double.class, "double") {
+        @Override
+        public Schema createProperty() {
+            return new NumberSchema().format("double");
+        }
+    },
+    INTEGER(BigInteger.class) {
+        @Override
+        public Schema createProperty() {
+            return new IntegerSchema().format(null);
+        }
+    },
+    DECIMAL(BigDecimal.class, "number") {
+        @Override
+        public Schema createProperty() {
+            return new NumberSchema();
+        }
+    },
+    NUMBER(Number.class, "number") {
+        @Override
+        public Schema createProperty() {
+            return new NumberSchema();
+        }
+    },
+    DATE(DateStub.class, "date") {
+        @Override
+        public DateSchema createProperty() {
+            return new DateSchema();
+        }
+    },
+    DATE_TIME(Date.class, "date-time") {
+        @Override
+        public DateTimeSchema createProperty() {
+            return new DateTimeSchema();
+        }
+    },
+    PARTIAL_TIME(LocalTime.class, "partial-time") {
+        @Override
+        public Schema createProperty() {
+            return new StringSchema().format("partial-time");
+        }
+    },
+    FILE(File.class, "file") {
+        @Override
+        public FileSchema createProperty() {
+            return new FileSchema();
+        }
+    },
+    OBJECT(Object.class) {
+        @Override
+        public Schema createProperty() {
+            return new Schema().type("object");
+        }
+    };
+
+    private static final Map<Class<?>, PrimitiveType> KEY_CLASSES;
+    private static final Map<Class<?>, PrimitiveType> BASE_CLASSES;
+    /**
+     * Adds support of a small number of "well-known" types, specifically for
+     * Joda lib.
+     */
+    private static final Map<String, PrimitiveType> EXTERNAL_CLASSES;
+
+    /**
+     * Allows to exclude specific classes from KEY_CLASSES mappings to primitive
+     */
+    private static Set<String> customExcludedClasses = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Allows to exclude specific classes from EXTERNAL_CLASSES mappings to primitive
+     */
+    private static Set<String> customExcludedExternalClasses = ConcurrentHashMap.newKeySet();
+
+
+    /**
+     * Adds support for custom mapping of classes to primitive types
+     */
+    private static Map<String, PrimitiveType> customClasses = new ConcurrentHashMap<>();
+
+    /**
+     * class qualified names prefixes to be considered as "system" types
+     */
+    private static Set<String> systemPrefixes = ConcurrentHashMap.newKeySet();
+    /**
+     * class qualified names NOT to be considered as "system" types
+     */
+    private static Set<String> nonSystemTypes = ConcurrentHashMap.newKeySet();
+    /**
+     * package names NOT to be considered as "system" types
+     */
+    private static Set<String> nonSystemTypePackages = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Alternative names for primitive types that have to be supported for
+     * backward compatibility.
+     */
+    private static final Map<String, PrimitiveType> NAMES;
+    private final Class<?> keyClass;
+    private final String commonName;
+
+    public static final Map<String, String> datatypeMappings;
+
+    static {
+        systemPrefixes.add("java.");
+        systemPrefixes.add("javax.");
+        nonSystemTypes.add("java.time.LocalTime");
+
+        datatypeMappings = Map.ofEntries(
+            entry("integer_int32", "integer"),
+            entry("integer_", "integer"),
+            entry("integer_int64", "long"),
+            entry("number_", "number"),
+            entry("number_float", "float"),
+            entry("number_double", "double"),
+            entry("string_", "string"),
+            entry("string_byte", "byte"),
+            entry("string_email", "email"),
+            entry("string_binary", "binary"),
+            entry("string_uri", "uri"),
+            entry("string_url", "url"),
+            entry("string_uuid", "uuid"),
+            entry("string_date", "date"),
+            entry("string_date-time", "date-time"),
+            entry("string_partial-time", "partial-time"),
+            entry("string_password", "password"),
+            entry("boolean_", "boolean"),
+            entry("object_", "object")
+        );
+
+        final Map<Class<?>, PrimitiveType> keyClasses = new HashMap<>();
+        addKeys(keyClasses, BOOLEAN, Boolean.class, Boolean.TYPE);
+        addKeys(keyClasses, STRING, String.class, Character.class, Character.TYPE);
+        addKeys(keyClasses, BYTE, Byte.class, Byte.TYPE);
+        addKeys(keyClasses, URL, java.net.URL.class);
+        addKeys(keyClasses, URI, java.net.URI.class);
+        addKeys(keyClasses, UUID, java.util.UUID.class);
+        addKeys(keyClasses, INT, Integer.class, Integer.TYPE, Short.class, Short.TYPE);
+        addKeys(keyClasses, LONG, Long.class, Long.TYPE);
+        addKeys(keyClasses, FLOAT, Float.class, Float.TYPE);
+        addKeys(keyClasses, DOUBLE, Double.class, Double.TYPE);
+        addKeys(keyClasses, INTEGER, BigInteger.class);
+        addKeys(keyClasses, DECIMAL, BigDecimal.class);
+        addKeys(keyClasses, NUMBER, Number.class);
+        addKeys(keyClasses, DATE, DateStub.class);
+        addKeys(keyClasses, DATE_TIME, Date.class);
+        addKeys(keyClasses, FILE, File.class);
+        addKeys(keyClasses, OBJECT, Object.class);
+        KEY_CLASSES = Collections.unmodifiableMap(keyClasses);
+
+        final Map<Class<?>, PrimitiveType> baseClasses = new HashMap<>();
+        addKeys(baseClasses, DATE_TIME, Date.class, Calendar.class);
+        BASE_CLASSES = Collections.unmodifiableMap(baseClasses);
+
+        final Map<String, PrimitiveType> externalClasses = new HashMap<>();
+        addKeys(externalClasses, DATE, "org.joda.time.LocalDate", "java.time.LocalDate");
+        addKeys(externalClasses, DATE_TIME,
+            "java.time.LocalDateTime",
+            "java.time.ZonedDateTime",
+            "java.time.OffsetDateTime",
+            "javax.xml.datatype.XMLGregorianCalendar",
+            "org.joda.time.LocalDateTime",
+            "org.joda.time.ReadableDateTime",
+            "org.joda.time.DateTime",
+            "java.time.Instant");
+        EXTERNAL_CLASSES = Collections.unmodifiableMap(externalClasses);
+
+        final Map<String, PrimitiveType> names = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (PrimitiveType item : values()) {
+            final String name = item.commonName;
+            if (name != null) {
+                addKeys(names, item, name);
+            }
+        }
+        addKeys(names, INT, "int");
+        addKeys(names, OBJECT, "object");
+        NAMES = Collections.unmodifiableMap(names);
+    }
+
+    PrimitiveType(Class<?> keyClass) {
+        this(keyClass, null);
+    }
+
+    PrimitiveType(Class<?> keyClass, String commonName) {
+        this.keyClass = keyClass;
+        this.commonName = commonName;
+    }
+
+
+    /**
+     * Adds support for custom mapping of classes to primitive types
+     *
+     * @return Set of custom classes to primitive type
+     *
+     * @since 2.0.6
+     */
+    public static Set<String> customExcludedClasses() {
+        return customExcludedClasses;
+    }
+
+    /**
+     * Adds support for custom mapping of classes to primitive types
+     *
+     * @return Set of custom classes to primitive type
+     *
+     * @since 2.1.2
+     */
+    public static Set<String> customExcludedExternalClasses() {
+        return customExcludedExternalClasses;
+    }
+
+    /**
+     * Adds support for custom mapping of classes to primitive types
+     *
+     * @return Map of custom classes to primitive type
+     *
+     * @since 2.0.6
+     */
+    public static Map<String, PrimitiveType> customClasses() {
+        return customClasses;
+    }
+
+    /**
+     * class qualified names prefixes to be considered as "system" types
+     *
+     * @return Mutable set of class qualified names prefixes to be considered as "system" types
+     *
+     * @since 2.0.6
+     */
+    public static Set<String> systemPrefixes() {
+        return systemPrefixes;
+    }
+
+    /**
+     * class qualified names NOT to be considered as "system" types
+     *
+     * @return Mutable set of class qualified names NOT to be considered as "system" types
+     *
+     * @since 2.0.6
+     */
+    public static Set<String> nonSystemTypes() {
+        return nonSystemTypes;
+    }
+
+    /**
+     * package names NOT to be considered as "system" types
+     *
+     * @return Mutable set of package names NOT to be considered as "system" types
+     *
+     * @since 2.0.6
+     */
+    public static Set<String> nonSystemTypePackages() {
+        return nonSystemTypePackages;
+    }
+
+    public static PrimitiveType fromType(Type type) {
+        final Class<?> raw = TypeFactory.defaultInstance().constructType(type).getRawClass();
+        final PrimitiveType key = KEY_CLASSES.get(raw);
+        if (key != null && !customExcludedClasses.contains(raw.getName())) {
+            return key;
+        }
+
+        final PrimitiveType custom = customClasses.get(raw.getName());
+        if (custom != null) {
+            return custom;
+        }
+
+        final PrimitiveType external = EXTERNAL_CLASSES.get(raw.getName());
+        if (external != null && !customExcludedExternalClasses().contains(raw.getName())) {
+            return external;
+        }
+
+        for (Map.Entry<Class<?>, PrimitiveType> entry : BASE_CLASSES.entrySet()) {
+            if (entry.getKey().isAssignableFrom(raw)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    public static PrimitiveType fromName(String name) {
+        if (name == null) {
+            return null;
+        }
+        PrimitiveType fromName = NAMES.get(name);
+        if (fromName == null) {
+            if (!customExcludedExternalClasses().contains(name)) {
+                fromName = EXTERNAL_CLASSES.get(name);
+            }
+        }
+        return fromName;
+    }
+
+    public static PrimitiveType fromTypeAndFormat(String type, String format) {
+        if (StringUtils.hasText(type) && type.equals("object")) {
+            return null;
+        }
+        return fromName(datatypeMappings.get(String.format("%s_%s", StringUtils.hasText(type) ? type : "", StringUtils.hasText(format) ? format : "")));
+    }
+
+    public static Schema createProperty(Type type) {
+        final PrimitiveType item = fromType(type);
+        return item == null ? null : item.createProperty();
+    }
+
+    public static Schema createProperty(String name) {
+        final PrimitiveType item = fromName(name);
+        return item == null ? null : item.createProperty();
+    }
+
+    public static String getCommonName(Type type) {
+        final PrimitiveType item = fromType(type);
+        return item == null ? null : item.commonName;
+    }
+
+    public Class<?> getKeyClass() {
+        return keyClass;
+    }
+
+    public String getCommonName() {
+        return commonName;
+    }
+
+    public abstract Schema createProperty();
+
+    @SafeVarargs
+    private static <K> void addKeys(Map<K, PrimitiveType> map, PrimitiveType type, K... keys) {
+        for (K key : keys) {
+            map.put(key, type);
+        }
+    }
+
+    private static class DateStub {
+
+    }
+
+    /**
+     * Convenience method to map LocalTime to string primitive with rfc3339 format partial-time.
+     * See <a href="https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14">link</a>
+     *
+     * @since 2.0.6
+     */
+    public static void enablePartialTime() {
+        customClasses().put("org.joda.time.LocalTime", PrimitiveType.PARTIAL_TIME);
+        customClasses().put("java.time.LocalTime", PrimitiveType.PARTIAL_TIME);
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/SecurityScheme31Deserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/SecurityScheme31Deserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class SecurityScheme31Deserializer extends SecuritySchemeDeserializer {
+
+    public SecurityScheme31Deserializer() {
+        openapi31 = true;
+    }
+}

--- a/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/SecuritySchemeDeserializer.java
+++ b/openapi-common/src/main/java/io/micronaut/openapi/swagger/core/util/SecuritySchemeDeserializer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.swagger.core.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.security.OAuthFlows;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This class is copied from swagger-core library.
+ *
+ * @since 4.6.0
+ */
+@Internal
+public class SecuritySchemeDeserializer extends JsonDeserializer<SecurityScheme> {
+
+    protected boolean openapi31;
+
+    @Override
+    public SecurityScheme deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        ObjectMapper mapper;
+        if (openapi31) {
+            mapper = OpenApiUtils.getJsonMapper31();
+        } else {
+            mapper = OpenApiUtils.getJsonMapper();
+        }
+        SecurityScheme result = null;
+
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        JsonNode inNode = node.get("type");
+
+        if (inNode != null) {
+            String type = inNode.asText();
+            if (Arrays.stream(SecurityScheme.Type.values()).noneMatch(t -> t.toString().equals(type))) {
+                // wrong type, throw exception
+                throw new JsonParseException(jp, String.format("SecurityScheme type %s not allowed", type));
+            }
+            result = new SecurityScheme()
+                .description(getFieldText("description", node));
+
+            if ("http".equals(type)) {
+                result
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme(getFieldText("scheme", node))
+                    .bearerFormat(getFieldText("bearerFormat", node));
+            } else if ("apiKey".equals(type)) {
+                result
+                    .type(SecurityScheme.Type.APIKEY)
+                    .name(getFieldText("name", node))
+                    .in(getIn(getFieldText("in", node)));
+            } else if ("openIdConnect".equals(type)) {
+                result
+                    .type(SecurityScheme.Type.OPENIDCONNECT)
+                    .openIdConnectUrl(getFieldText("openIdConnectUrl", node));
+            } else if ("oauth2".equals(type)) {
+                result
+                    .type(SecurityScheme.Type.OAUTH2)
+                    .flows(mapper.convertValue(node.get("flows"), OAuthFlows.class));
+            } else if ("mutualTLS".equals(type)) {
+                result
+                    .type(SecurityScheme.Type.MUTUALTLS);
+            }
+            final Iterator<String> fieldNames = node.fieldNames();
+            while (fieldNames.hasNext()) {
+                final String fieldName = fieldNames.next();
+                if (fieldName.startsWith("x-")) {
+                    final JsonNode fieldValue = node.get(fieldName);
+                    final Object value = OpenApiUtils.getJsonMapper().treeToValue(fieldValue, Object.class);
+                    result.addExtension(fieldName, value);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private SecurityScheme.In getIn(String value) {
+        return Arrays.stream(SecurityScheme.In.values()).filter(i -> i.toString().equals(value)).findFirst().orElse(null);
+    }
+
+    private String getFieldText(String fieldName, JsonNode node) {
+        JsonNode inNode = node.get(fieldName);
+        if (inNode != null) {
+            return inNode.asText();
+        }
+        return null;
+    }
+}

--- a/openapi-generator/src/test/resources/petstore.json
+++ b/openapi-generator/src/test/resources/petstore.json
@@ -208,7 +208,7 @@
           "pet"
         ],
         "summary": "Find pet by ID",
-        "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+        "description": "Returns a pet when ID < 10. ID > 10 or nonintegers will simulate API error conditions",
         "operationId": "getPetById",
         "produces": [
           "application/json",

--- a/openapi-to-adoc/build.gradle
+++ b/openapi-to-adoc/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id "io.micronaut.build.internal.binary-compatibility-check"
+    id 'io.micronaut.build.internal.module'
+    id 'io.micronaut.build.internal.openapi-base'
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = false
+    }
+}
+
+dependencies {
+
+    api libs.pegdown
+    api libs.managed.parboiled
+    api libs.managed.jsoup
+    api libs.managed.freemarker
+
+    implementation projects.micronautOpenapiCommon
+
+    testImplementation mnTest.micronaut.test.junit5
+
+    testRuntimeOnly libs.junit.jupiter.engine
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/ConfigProperty.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/ConfigProperty.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc;
+
+/**
+ * Configuration properties for Openapi-to-adoc converter.
+ *
+ * @since 5.2.0
+ */
+public interface ConfigProperty {
+
+    /**
+     * Prefix for custom sub-template names.
+     */
+    String OPENAPI_ADOC_TEMPLATE_PREFIX = "io.micronaut.openapi.adoc.template.";
+
+    /**
+     * Custom template directory.
+     */
+    String OPENAPI_ADOC_TEMPLATES_DIR_PATH = "io.micronaut.openapi.adoc.template-dir";
+    /**
+     * Custom final template filename.
+     */
+    String OPENAPI_ADOC_TEMPLATE_FILENAME = "io.micronaut.openapi.adoc.template-filename";
+    /**
+     * Result adoc file output directory.
+     */
+    String OPENAPI_ADOC_OUTPUT_DIR_PATH = "io.micronaut.openapi.adoc.output-dir";
+    /**
+     * Result adoc filename.
+     */
+    String OPENAPI_ADOC_OUTPUT_FILENAME = "io.micronaut.openapi.adoc.output-filename";
+    /**
+     * OpenAPI file path.
+     */
+    String OPENAPI_ADOC_OPENAPI_PATH = "io.micronaut.openapi.adoc.openapi-path";
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/OpenapiToAdocConverter.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/OpenapiToAdocConverter.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import io.micronaut.openapi.OpenApiUtils;
+import io.micronaut.openapi.adoc.md.Converter;
+import io.micronaut.openapi.adoc.utils.SwaggerUtils;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModelException;
+
+import static io.micronaut.openapi.adoc.TemplatePaths.CONTENT;
+import static io.micronaut.openapi.adoc.TemplatePaths.DEFINITIONS;
+import static io.micronaut.openapi.adoc.TemplatePaths.EXAMPLES;
+import static io.micronaut.openapi.adoc.TemplatePaths.EXTERNAL_DOCS;
+import static io.micronaut.openapi.adoc.TemplatePaths.HEADERS;
+import static io.micronaut.openapi.adoc.TemplatePaths.LINKS;
+import static io.micronaut.openapi.adoc.TemplatePaths.OVERVIEW;
+import static io.micronaut.openapi.adoc.TemplatePaths.PARAMETERS;
+import static io.micronaut.openapi.adoc.TemplatePaths.PATHS;
+import static io.micronaut.openapi.adoc.TemplatePaths.PROPERTIES;
+import static io.micronaut.openapi.adoc.TemplatePaths.PROPERTY_DESCRIPTION;
+import static io.micronaut.openapi.adoc.TemplatePaths.REQUEST_BODY;
+import static io.micronaut.openapi.adoc.TemplatePaths.RESPONSES;
+import static io.micronaut.openapi.adoc.TemplatePaths.SCHEMA_TYPE;
+import static io.micronaut.openapi.adoc.TemplatePaths.SECURITY_REQUIREMENTS;
+import static io.micronaut.openapi.adoc.TemplatePaths.SERVERS;
+import static io.micronaut.openapi.adoc.utils.FileUtils.CLASSPATH_SCHEME;
+import static io.micronaut.openapi.adoc.utils.FileUtils.FILE_SCHEME;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * OpenAPI to Asciidoc converter.
+ *
+ * @since 4.2.0
+ */
+public class OpenapiToAdocConverter {
+
+    private static final String TEMPLATE_PREFIX = "template_";
+    private static final String TEMPLATES_DIR = "/template";
+
+    /**
+     * Conversion from openAPI format to asciidoc format.
+     *
+     * @throws TemplateException som problems with freemarker templates
+     * @throws IOException some problems with files
+     */
+    public void convert() throws TemplateException, IOException {
+
+        var openApiFile = System.getProperty(ConfigProperty.OPENAPI_ADOC_OPENAPI_PATH);
+        if (openApiFile == null || openApiFile.isBlank()) {
+            throw new IllegalArgumentException("OpenAPI file path not set");
+        }
+        var openApi = SwaggerUtils.readOpenApiFromLocation(openApiFile);
+        Converter.convertMdToAdoc(openApi);
+
+        var model = new HashMap<String, Object>();
+        model.put("info", openApi.getInfo());
+        model.put("externalDocs", openApi.getExternalDocs());
+        model.put("servers", openApi.getServers());
+        model.put("tags", openApi.getTags());
+        model.put("openApi", openApi.getOpenapi());
+        model.put("globalSecurityRequirements", openApi.getSecurity());
+        model.put("paths", openApi.getPaths());
+        model.put("components", openApi.getComponents());
+
+        model.put(template(DEFINITIONS), "definitions.ftl");
+        model.put(template(OVERVIEW), "overview.ftl");
+        model.put(template(PATHS), "paths.ftl");
+        model.put(template(CONTENT), "content.ftl");
+        model.put(template(EXAMPLES), "examples.ftl");
+        model.put(template(EXTERNAL_DOCS), "externalDocs.ftl");
+        model.put(template(HEADERS), "headers.ftl");
+        model.put(template(LINKS), "links.ftl");
+        model.put(template(PARAMETERS), "parameters.ftl");
+        model.put(template(PROPERTIES), "properties.ftl");
+        model.put(template(PROPERTY_DESCRIPTION), "propertyDescription.ftl");
+        model.put(template(REQUEST_BODY), "requestBody.ftl");
+        model.put(template(RESPONSES), "responses.ftl");
+        model.put(template(SCHEMA_TYPE), "schemaType.ftl");
+        model.put(template(SECURITY_REQUIREMENTS), "securityRequirements.ftl");
+        model.put(template(SERVERS), "servers.ftl");
+
+        for (var entry : System.getProperties().entrySet()) {
+            var key = entry.getKey().toString();
+            if (key.startsWith(ConfigProperty.OPENAPI_ADOC_TEMPLATE_PREFIX)) {
+                model.put(key.replace(ConfigProperty.OPENAPI_ADOC_TEMPLATE_PREFIX, TEMPLATE_PREFIX), entry.getValue());
+            }
+        }
+
+        var templateFilename = System.getProperty(ConfigProperty.OPENAPI_ADOC_TEMPLATE_FILENAME, "openApiDoc.ftl");
+        var outputPath = Paths.get(System.getProperty(ConfigProperty.OPENAPI_ADOC_OUTPUT_DIR_PATH, "build/generated"))
+            .resolve(System.getProperty(ConfigProperty.OPENAPI_ADOC_OUTPUT_FILENAME, "openApiDoc.adoc"));
+        var customTemplatesDirsStr = System.getProperty(ConfigProperty.OPENAPI_ADOC_TEMPLATES_DIR_PATH);
+        String[] customTemplatesDirs = null;
+        if (customTemplatesDirsStr != null && !customTemplatesDirsStr.isBlank()) {
+            customTemplatesDirs = customTemplatesDirsStr.split(",");
+        }
+
+        var cfg = getFreemarkerConfig(customTemplatesDirs);
+        var template = cfg.getTemplate(templateFilename);
+
+        if (outputPath.getParent() != null) {
+            try {
+                Files.createDirectories(outputPath.getParent());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed create directory", e);
+            }
+        }
+
+        var fileExists = Files.exists(outputPath);
+        try (var writer = fileExists ? Files.newBufferedWriter(outputPath, UTF_8, StandardOpenOption.APPEND) : Files.newBufferedWriter(outputPath, UTF_8)) {
+            template.process(model, writer);
+        }
+    }
+
+    private Configuration getFreemarkerConfig(String[] customTemplatesDirs) throws IOException, TemplateModelException {
+        TemplateLoader templateLoader = new ClassTemplateLoader(getClass(), TEMPLATES_DIR);
+        if (customTemplatesDirs != null && customTemplatesDirs.length > 0) {
+            var templateLoaders = new ArrayList<TemplateLoader>();
+            for (var templateDir : customTemplatesDirs) {
+                templateDir = templateDir.strip();
+                if (templateDir.startsWith(CLASSPATH_SCHEME)) {
+                    templateLoaders.add(new ClassTemplateLoader(getClass(), templateDir.substring(CLASSPATH_SCHEME.length())));
+                } else {
+                    if (templateDir.startsWith(FILE_SCHEME)) {
+                        templateDir = templateDir.substring(FILE_SCHEME.length());
+                        if (templateDir.startsWith("//")) {
+                            templateDir = templateDir.substring(2);
+                        }
+                    }
+                    templateLoaders.add(new FileTemplateLoader(new File(templateDir)));
+                }
+            }
+            templateLoaders.add(templateLoader);
+            templateLoader = new MultiTemplateLoader(templateLoaders.toArray(new TemplateLoader[0]));
+        }
+
+        var cfg = new Configuration(Configuration.VERSION_2_3_32);
+        cfg.setTemplateLoader(templateLoader);
+        cfg.setDefaultEncoding(UTF_8.displayName());
+        cfg.setSharedVariable("JSON", OpenApiUtils.getJsonMapper());
+        return cfg;
+    }
+
+    private String template(String templateName) {
+        return TEMPLATE_PREFIX + templateName;
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/TemplatePaths.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/TemplatePaths.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc;
+
+/**
+ * Freemarker component template names.
+ *
+ * @since 5.2.0
+ */
+public interface TemplatePaths {
+
+    String DEFINITIONS = "definitions";
+    String OVERVIEW = "overview";
+    String PATHS = "paths";
+
+    String CONTENT = "content";
+    String EXAMPLES = "examples";
+    String EXTERNAL_DOCS = "externalDocs";
+    String HEADERS = "headers";
+    String LINKS = "links";
+    String PARAMETERS = "parameters";
+    String PROPERTIES = "properties";
+    String PROPERTY_DESCRIPTION = "propertyDescription";
+    String REQUEST_BODY = "requestBody";
+    String RESPONSES = "responses";
+    String SCHEMA_TYPE = "schemaType";
+    String SECURITY_REQUIREMENTS = "securityRequirements";
+    String SERVERS = "servers";
+
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/Converter.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/Converter.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.md;
+
+import java.util.Collection;
+import java.util.Map;
+
+import io.micronaut.openapi.adoc.utils.CollectionUtils;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.links.Link;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import org.pegdown.Extensions;
+import org.pegdown.PegDownProcessor;
+import org.pegdown.ast.RootNode;
+
+/**
+ * Convert-methods from MD format to AsciiDoc.
+ *
+ * @since 5.2.0
+ */
+public final class Converter {
+
+    private Converter() {
+    }
+
+    /**
+     * Convert Markdown text to Asciidoc.
+     *
+     * @param markdown Markdown text
+     *
+     * @return Asciidoc text
+     */
+    public static String convertMdToAdoc(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return markdown;
+        }
+        var processor = new PegDownProcessor(Extensions.ALL);
+        // insert blank line before fenced code block if necessary
+        if (markdown.contains("```")) {
+            markdown = markdown.replaceAll("(?m)(?<!\n\n)(\\s*)```(\\w*\n)((?:\\1[^\n]*\n)+)\\1```", "\n$1```$2$3$1```");
+        }
+        RootNode rootNode = processor.parseMarkdown(markdown.toCharArray());
+        return new ToAsciiDocSerializer(rootNode, markdown)
+            .toAsciiDoc();
+    }
+
+    /**
+     * Convert all OpenAPI description fields from Markdown format to Asciidoc format.
+     *
+     * @param openApi OpenAPI object
+     */
+    public static void convertMdToAdoc(OpenAPI openApi) {
+        var info = openApi.getInfo();
+        if (info != null) {
+            info.setDescription(convertMdToAdoc(info.getDescription()));
+            info.setTermsOfService(convertMdToAdoc(info.getTermsOfService()));
+        }
+        processExternalDocs(openApi.getExternalDocs());
+
+        var servers = openApi.getServers();
+        if (CollectionUtils.isNotEmpty(servers)) {
+            for (var server : servers) {
+                server.setDescription(convertMdToAdoc(server.getDescription()));
+                if (CollectionUtils.isNotEmpty(server.getVariables())) {
+                    for (var serverVar : server.getVariables().values()) {
+                        serverVar.setDescription(convertMdToAdoc(serverVar.getDescription()));
+                    }
+                }
+            }
+        }
+
+        var tags = openApi.getTags();
+        if (CollectionUtils.isNotEmpty(tags)) {
+            for (var tag : tags) {
+                tag.setDescription(convertMdToAdoc(tag.getDescription()));
+                processExternalDocs(tag.getExternalDocs());
+            }
+        }
+
+        var paths = openApi.getPaths();
+        if (CollectionUtils.isNotEmpty(paths)) {
+            for (var path : paths.values()) {
+                path.setSummary(convertMdToAdoc(path.getSummary()));
+                path.setDescription(convertMdToAdoc(path.getDescription()));
+                for (var operation : path.readOperations()) {
+                    operation.setSummary(convertMdToAdoc(operation.getSummary()));
+                    operation.setDescription(convertMdToAdoc(operation.getDescription()));
+                    processExternalDocs(operation.getExternalDocs());
+                    var requestBody = operation.getRequestBody();
+                    if (requestBody != null) {
+                        requestBody.setDescription(convertMdToAdoc(requestBody.getDescription()));
+                        processContent(requestBody.getContent());
+                    }
+                    if (CollectionUtils.isNotEmpty(operation.getParameters())) {
+                        for (var parameter : operation.getParameters()) {
+                            processSchema(parameter.getSchema());
+                            processExamples(parameter.getExamples());
+                            processContent(parameter.getContent());
+                            parameter.setDescription(convertMdToAdoc(parameter.getDescription()));
+                        }
+                    }
+                    processResponses(operation.getResponses());
+                }
+            }
+        }
+
+        if (openApi.getComponents() != null) {
+            processSchemas(openApi.getComponents().getSchemas());
+            processResponses(openApi.getComponents().getResponses());
+            if (CollectionUtils.isNotEmpty(openApi.getComponents().getParameters())) {
+                processParameters(openApi.getComponents().getParameters().values());
+            }
+            processExamples(openApi.getComponents().getExamples());
+            processRequestBodies(openApi.getComponents().getRequestBodies().values());
+            processHeaders(openApi.getComponents().getHeaders());
+            processSecuritySchemas(openApi.getComponents().getSecuritySchemes().values());
+            processLinks(openApi.getComponents().getLinks());
+        }
+    }
+
+    private static void processExternalDocs(ExternalDocumentation externalDocs) {
+        if (externalDocs == null) {
+            return;
+        }
+        externalDocs.setDescription(convertMdToAdoc(externalDocs.getDescription()));
+    }
+
+    private static void processSchemas(Map<String, Schema> schemas) {
+        if (CollectionUtils.isEmpty(schemas)) {
+            return;
+        }
+        for (var schema : schemas.values()) {
+            processSchema(schema);
+        }
+    }
+
+    private static void processSchema(Schema schema) {
+        if (schema == null) {
+            return;
+        }
+        processExternalDocs(schema.getExternalDocs());
+        schema.setDescription(convertMdToAdoc(schema.getDescription()));
+        processSchemas(schema.getProperties());
+        processSchema(schema.getItems());
+    }
+
+    private static void processHeaders(Map<String, Header> headers) {
+        if (CollectionUtils.isEmpty(headers)) {
+            return;
+        }
+        for (var header : headers.values()) {
+            header.setDescription(convertMdToAdoc(header.getDescription()));
+            processExamples(header.getExamples());
+            processSchema(header.getSchema());
+            processContent(header.getContent());
+        }
+    }
+
+    private static void processExamples(Map<String, Example> examples) {
+        if (CollectionUtils.isEmpty(examples)) {
+            return;
+        }
+        for (var example : examples.values()) {
+            example.setSummary(convertMdToAdoc(example.getSummary()));
+            example.setDescription(convertMdToAdoc(example.getDescription()));
+        }
+    }
+
+    private static void processContent(Content content) {
+        if (content == null) {
+            return;
+        }
+
+        for (var mediaType : content.values()) {
+            processSchema(mediaType.getSchema());
+            processExamples(mediaType.getExamples());
+            processSchema(mediaType.getSchema());
+            if (CollectionUtils.isNotEmpty(mediaType.getEncoding())) {
+                for (var encoding : mediaType.getEncoding().values()) {
+                    processHeaders(encoding.getHeaders());
+                }
+            }
+        }
+    }
+
+    private static void processResponses(Map<String, ApiResponse> responses) {
+        if (CollectionUtils.isEmpty(responses)) {
+            return;
+        }
+
+        for (var response : responses.values()) {
+            processHeaders(response.getHeaders());
+            processContent(response.getContent());
+            response.setDescription(convertMdToAdoc(response.getDescription()));
+            processLinks(response.getLinks());
+            if (CollectionUtils.isNotEmpty(response.getLinks())) {
+                for (var link : response.getLinks().values()) {
+                    link.setDescription(convertMdToAdoc(link.getDescription()));
+                }
+            }
+        }
+    }
+
+    private static void processLinks(Map<String, Link> links) {
+        if (CollectionUtils.isEmpty(links)) {
+            return;
+        }
+
+        for (var link : links.values()) {
+            link.setDescription(convertMdToAdoc(link.getDescription()));
+        }
+    }
+
+    private static void processParameters(Collection<Parameter> parameters) {
+        if (CollectionUtils.isEmpty(parameters)) {
+            return;
+        }
+
+        for (var parameter : parameters) {
+            processSchema(parameter.getSchema());
+            processExamples(parameter.getExamples());
+            processContent(parameter.getContent());
+            parameter.setDescription(convertMdToAdoc(parameter.getDescription()));
+        }
+    }
+
+    private static void processRequestBodies(Collection<RequestBody> requestBodies) {
+        if (CollectionUtils.isEmpty(requestBodies)) {
+            return;
+        }
+
+        for (var requestBody : requestBodies) {
+            requestBody.setDescription(convertMdToAdoc(requestBody.getDescription()));
+            processContent(requestBody.getContent());
+        }
+    }
+
+    private static void processSecuritySchemas(Collection<SecurityScheme> securitySchemes) {
+        if (CollectionUtils.isEmpty(securitySchemes)) {
+            return;
+        }
+
+        for (var securityScheme : securitySchemes) {
+            securityScheme.setDescription(convertMdToAdoc(securityScheme.getDescription()));
+        }
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/TableToAsciiDoc.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/TableToAsciiDoc.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.md;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Utilities methods to convert html table to adoc table.
+ *
+ * @since 5.2.0
+ */
+public final class TableToAsciiDoc {
+
+    private TableToAsciiDoc() {
+    }
+
+    /**
+     * Convert HTML table to adoc table.
+     *
+     * @param html HTML text
+     *
+     * @return adoc text
+     */
+    public static String convert(String html) {
+        if (!html.startsWith("<table")) {
+            throw new IllegalArgumentException("No table found in HTML: " + html);
+        }
+
+        Document doc = Jsoup.parse(html);
+        Element table = doc.select("table").get(0); //select the first table.
+
+        var result = new StringBuilder("|===\n");
+        Elements rows = table.select("tr");
+
+        for (Element row : rows) {
+            // table headers
+            result.append(buildAsciiDocRow(row, "th"));
+            if (!row.select("th").isEmpty()) {
+                result.append('\n');
+            }
+
+            // table data
+            result.append(buildAsciiDocRow(row, "td")).append('\n');
+        }
+
+        result.append("|===\n");
+
+        return result.toString();
+    }
+
+    private static String buildAsciiDocRow(Element row, String query) {
+        Elements columns = row.select(query);
+        var dataRow = new StringBuilder();
+        for (Element col : columns) {
+            dataRow.append('|').append(applyBasicFormatting(col)).append(' ');
+        }
+        return dataRow.toString().trim();
+    }
+
+    private static String applyBasicFormatting(Element element) {
+
+        String result = element.ownText();
+
+        for (Element child : element.children()) {
+            if ("code".equals(child.tagName())) {
+                result = "`" + child.ownText() + "`";
+            } else if ("b".equals(child.tagName()) || "strong".equals(child.tagName())) {
+                result = "*" + child.ownText() + "*";
+            } else if ("i".equals(child.tagName()) || "em".equals(child.tagName())) {
+                result = "_" + child.ownText() + "_";
+            } else if ("a".equals(child.tagName())) {
+                result = child.attr("href") + "[" + child.ownText() + "]";
+            }
+        }
+
+        return result;
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/ToAsciiDocSerializer.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/md/ToAsciiDocSerializer.java
@@ -1,0 +1,764 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.md;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.pegdown.LinkRenderer;
+import org.pegdown.Printer;
+import org.pegdown.ast.AbbreviationNode;
+import org.pegdown.ast.AbstractNode;
+import org.pegdown.ast.AnchorLinkNode;
+import org.pegdown.ast.AutoLinkNode;
+import org.pegdown.ast.BlockQuoteNode;
+import org.pegdown.ast.BulletListNode;
+import org.pegdown.ast.CodeNode;
+import org.pegdown.ast.DefinitionListNode;
+import org.pegdown.ast.DefinitionNode;
+import org.pegdown.ast.DefinitionTermNode;
+import org.pegdown.ast.ExpImageNode;
+import org.pegdown.ast.ExpLinkNode;
+import org.pegdown.ast.HeaderNode;
+import org.pegdown.ast.HtmlBlockNode;
+import org.pegdown.ast.InlineHtmlNode;
+import org.pegdown.ast.ListItemNode;
+import org.pegdown.ast.MailLinkNode;
+import org.pegdown.ast.Node;
+import org.pegdown.ast.OrderedListNode;
+import org.pegdown.ast.ParaNode;
+import org.pegdown.ast.QuotedNode;
+import org.pegdown.ast.RefImageNode;
+import org.pegdown.ast.RefLinkNode;
+import org.pegdown.ast.ReferenceNode;
+import org.pegdown.ast.RootNode;
+import org.pegdown.ast.SimpleNode;
+import org.pegdown.ast.SpecialTextNode;
+import org.pegdown.ast.StrikeNode;
+import org.pegdown.ast.StrongEmphSuperNode;
+import org.pegdown.ast.SuperNode;
+import org.pegdown.ast.TableBodyNode;
+import org.pegdown.ast.TableCaptionNode;
+import org.pegdown.ast.TableCellNode;
+import org.pegdown.ast.TableColumnNode;
+import org.pegdown.ast.TableHeaderNode;
+import org.pegdown.ast.TableNode;
+import org.pegdown.ast.TableRowNode;
+import org.pegdown.ast.TextNode;
+import org.pegdown.ast.VerbatimNode;
+import org.pegdown.ast.Visitor;
+import org.pegdown.ast.WikiLinkNode;
+
+import static org.parboiled.common.Preconditions.checkArgNotNull;
+
+public class ToAsciiDocSerializer implements Visitor {
+
+    public static final String HARD_LINE_BREAK_MARKDOWN = "  \n";
+
+    protected String source;
+    protected Printer printer;
+    protected final Map<String, ReferenceNode> references = new HashMap<>();
+    protected final Map<String, String> abbreviations = new HashMap<>();
+    protected final LinkRenderer linkRenderer = new LinkRenderer();
+
+    protected TableNode currentTableNode;
+    protected int currentTableColumn;
+    protected boolean inTableHeader;
+
+    protected char listMarker;
+    protected int listLevel;
+    protected int blockQuoteLevel;
+
+    protected boolean autoDetectLanguageType;
+
+    protected RootNode rootNode;
+
+    public ToAsciiDocSerializer(RootNode rootNode, String source) {
+        printer = new Printer();
+        autoDetectLanguageType = true;
+        checkArgNotNull(rootNode, "rootNode");
+        this.rootNode = rootNode;
+        this.source = source;
+    }
+
+    public String toAsciiDoc() {
+        cleanAst(rootNode);
+        rootNode.accept(this);
+        String result = normalizeWhitelines(printer.getString());
+        printer.clear();
+        return result;
+    }
+
+    @Override
+    public void visit(RootNode node) {
+        for (ReferenceNode refNode : node.getReferences()) {
+            visitChildren(refNode);
+            references.put(normalize(printer.getString()), refNode);
+            printer.clear();
+        }
+        for (AbbreviationNode abbrNode : node.getAbbreviations()) {
+            visitChildren(abbrNode);
+            String abbr = printer.getString();
+            printer.clear();
+            abbrNode.getExpansion().accept(this);
+            String expansion = printer.getString();
+            abbreviations.put(abbr, expansion);
+            printer.clear();
+        }
+        visitChildren(node);
+    }
+
+    @Override
+    public void visit(AbbreviationNode node) {
+    }
+
+    @Override
+    public void visit(AnchorLinkNode node) {
+        printer.print(node.getText());
+    }
+
+    @Override
+    public void visit(AutoLinkNode node) {
+        printLink(linkRenderer.render(node));
+    }
+
+    @Override
+    public void visit(BlockQuoteNode node) {
+        printer.println().println();
+
+        blockQuoteLevel += 4;
+
+        repeat('_', blockQuoteLevel);
+        printer.println();
+        visitChildren(node);
+        printer.println().println();
+        repeat('_', blockQuoteLevel);
+
+        blockQuoteLevel -= 4;
+
+        printer.println();
+    }
+
+    @Override
+    public void visit(BulletListNode node) {
+        char prevListMarker = listMarker;
+        listMarker = '*';
+
+        listLevel = listLevel + 1;
+        visitChildren(node);
+        listLevel = listLevel - 1;
+
+        listMarker = prevListMarker;
+    }
+
+    @Override
+    public void visit(CodeNode node) {
+        printer.print('`');
+        printer.printEncoded(node.getText());
+        printer.print('`');
+    }
+
+    @Override
+    public void visit(DefinitionListNode node) {
+        printer.println();
+        visitChildren(node);
+    }
+
+    @Override
+    public void visit(DefinitionTermNode node) {
+        visitChildren(node);
+        printer.indent(2);
+        printer.print("::").println();
+    }
+
+    @Override
+    public void visit(DefinitionNode node) {
+        visitChildren(node);
+        if (printer.indent > 0) {
+            printer.indent(-2);
+        }
+        printer.println();
+    }
+
+    @Override
+    public void visit(ExpImageNode node) {
+        String text = printChildrenToString(node);
+        LinkRenderer.Rendering imageRenderer = linkRenderer.render(node, text);
+        Node linkNode;
+        if ((linkNode = findParentNode(node, rootNode)) instanceof ExpLinkNode) {
+            printImageTagWithLink(imageRenderer, linkRenderer.render((ExpLinkNode) linkNode, null));
+        } else {
+            printImageTag(linkRenderer.render(node, text));
+        }
+    }
+
+    @Override
+    public void visit(ExpLinkNode node) {
+        String text = printChildrenToString(node);
+        if (text.startsWith("image:")) {
+            printer.print(text);
+        } else {
+            printLink(linkRenderer.render(node, text));
+        }
+    }
+
+    @Override
+    public void visit(HeaderNode node) {
+        printer.println().println();
+        repeat('=', node.getLevel());
+        printer.print(' ');
+        visitChildren(node);
+        printer.println().println();
+    }
+
+    private void repeat(char c, int times) {
+        for (int i = 0; i < times; i++) {
+            printer.print(c);
+        }
+    }
+
+    @Override
+    public void visit(HtmlBlockNode node) {
+        String text = node.getText();
+        if (!text.isEmpty()) {
+            printer.println();
+        }
+
+        if (text.startsWith("<table")) {
+            printer.print(TableToAsciiDoc.convert(text))
+                .println();
+        }
+    }
+
+    @Override
+    public void visit(InlineHtmlNode node) {
+        printer.print(node.getText());
+    }
+
+    @Override
+    public void visit(ListItemNode node) {
+        printer.println();
+        repeat(listMarker, listLevel);
+        printer.print(' ');
+
+        visitChildren(node);
+    }
+
+    @Override
+    public void visit(MailLinkNode node) {
+        printLink(linkRenderer.render(node));
+    }
+
+    @Override
+    public void visit(OrderedListNode node) {
+        char prevListMarker = listMarker;
+        listMarker = '.';
+
+        listLevel = listLevel + 1;
+        visitChildren(node);
+        listLevel = listLevel - 1;
+
+        listMarker = prevListMarker;
+    }
+
+    @Override
+    public void visit(ParaNode node) {
+        if (!isListItemText(node)) {
+            printer.println().println();
+        }
+        visitChildren(node);
+        printer.println().println();
+    }
+
+    @Override
+    public void visit(QuotedNode node) {
+        switch (node.getType()) {
+            case DoubleAngle -> {
+                printer.print("«");
+                visitChildren(node);
+                printer.print("»");
+            }
+            case Double -> {
+                printer.print('"');
+                visitChildren(node);
+                printer.print('"');
+            }
+            case Single -> {
+                printer.print('\'');
+                visitChildren(node);
+                printer.print('\'');
+            }
+        }
+    }
+
+    @Override
+    public void visit(ReferenceNode node) {
+        // reference nodes are not printed
+    }
+
+    @Override
+    public void visit(RefImageNode node) {
+        String text = printChildrenToString(node);
+        String key = node.referenceKey != null ? printChildrenToString(node.referenceKey) : text;
+        ReferenceNode refNode = references.get(normalize(key));
+        if (refNode == null) { // "fake" reference image link
+            printer.print("![").print(text).print(']');
+            if (node.separatorSpace != null) {
+                printer.print(node.separatorSpace).print('[');
+                if (node.referenceKey != null) {
+                    printer.print(key);
+                }
+                printer.print(']');
+            }
+        } else {
+            printImageTag(linkRenderer.render(node, refNode.getUrl(), refNode.getTitle(), text));
+        }
+    }
+
+    @Override
+    public void visit(RefLinkNode node) {
+        String text = printChildrenToString(node);
+        String key = node.referenceKey != null ? printChildrenToString(node.referenceKey) : text;
+        ReferenceNode refNode = references.get(normalize(key));
+        if (refNode == null) { // "fake" reference link
+            printer.print('[').print(text).print(']');
+            if (node.separatorSpace != null) {
+                printer.print(node.separatorSpace).print('[');
+                if (node.referenceKey != null) {
+                    printer.print(key);
+                }
+                printer.print(']');
+            }
+        } else {
+            printLink(linkRenderer.render(node, refNode.getUrl(), refNode.getTitle(), text));
+        }
+    }
+
+    @Override
+    public void visit(SimpleNode node) {
+        switch (node.getType()) {
+            case Apostrophe -> printer.print('\'');
+            case Ellipsis -> printer.print("…");
+            case Emdash -> printer.print("—");
+            case Endash -> printer.print("–");
+            case HRule -> printer.println().print("'''");
+            case Linebreak -> {
+                // look for length of span to detect hard line break (2 trailing spaces plus end-line)
+                // necessary because Pegdown doesn't distinguish between a hard line break and a normal line break
+                if (source != null && source.substring(node.getStartIndex(), node.getEndIndex()).startsWith(HARD_LINE_BREAK_MARKDOWN)) {
+                    printer.print(" +").println();
+                } else {
+                    // QUESTION should we fold or preserve soft line breaks? (pandoc emits a space here)
+                    printer.println();
+                }
+            }
+            case Nbsp -> printer.print("{nbsp}");
+            default -> throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public void visit(StrongEmphSuperNode node) {
+        if (node.isClosed()) {
+            if (node.isStrong()) {
+                printNodeSurroundedBy(node, "*");
+            } else {
+                printNodeSurroundedBy(node, "_");
+            }
+        } else {
+            //sequence was not closed, treat open chars as ordinary chars
+            printer.print(node.getChars());
+            visitChildren(node);
+        }
+    }
+
+    @Override
+    public void visit(StrikeNode node) {
+        printer.print("[line-through]").print('#');
+        visitChildren(node);
+        printer.print('#');
+    }
+
+    @Override
+    public void visit(TableBodyNode node) {
+        visitChildren(node);
+    }
+
+    @Override
+    public void visit(TableCaptionNode node) {
+        printer.println().print("<caption>");
+        visitChildren(node);
+        printer.print("</caption>");
+    }
+
+    @Override
+    public void visit(TableCellNode node) {
+//        String tag = inTableHeader ? "th" : "td";
+        List<TableColumnNode> columns = currentTableNode.getColumns();
+        TableColumnNode column = columns.get(Math.min(currentTableColumn, columns.size() - 1));
+
+        String pstr = printer.getString();
+        if (!pstr.isEmpty()) {
+            if (pstr.endsWith("\n") || pstr.endsWith(" ")) {
+                printer.print('|');
+            } else {
+                printer.print(" |");
+            }
+        } else {
+            printer.print('|');
+        }
+        column.accept(this);
+        if (node.getColSpan() > 1) {
+            printer.print(" colspan=\"").print(Integer.toString(node.getColSpan())).print('"');
+        }
+        visitChildren(node);
+
+        currentTableColumn += node.getColSpan();
+    }
+
+    @Override
+    public void visit(TableColumnNode node) {
+        // nothing here yet
+    }
+
+    @Override
+    public void visit(TableHeaderNode node) {
+        inTableHeader = true;
+//        printIndentedTag(node, "thead");
+
+        visitChildren(node);
+
+        inTableHeader = false;
+    }
+
+    private boolean ifColumnsHaveAlignmentSpecified(List<TableColumnNode> columns) {
+        for (TableColumnNode column : columns) {
+            if (column.getAlignment() != TableColumnNode.Alignment.None) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getColumnAlignment(List<TableColumnNode> columns) {
+
+        List<String> result = new ArrayList<>();
+
+        for (TableColumnNode column : columns) {
+            switch (column.getAlignment()) {
+                case None, Left -> result.add("<");
+                case Right -> result.add(">");
+                case Center -> result.add("^");
+                default -> throw new IllegalStateException();
+            }
+        }
+
+        return String.join(",", result);
+    }
+
+    @Override
+    public void visit(TableNode node) {
+        currentTableNode = node;
+
+        List<TableColumnNode> columns = node.getColumns();
+
+        if (ifColumnsHaveAlignmentSpecified(columns)) {
+            printer.println()
+                .print("[cols=\"").print(getColumnAlignment(columns)).print("\"]")
+                .println();
+        } else {
+            printer.println();
+        }
+
+        printer.print("|===");
+        visitChildren(node);
+        printer.println()
+            .print("|===")
+            .println();
+
+        currentTableNode = null;
+    }
+
+    @Override
+    public void visit(TableRowNode node) {
+        currentTableColumn = 0;
+
+        printer.println();
+
+        visitChildren(node);
+//        printIndentedTag(node, "tr");
+
+        if (inTableHeader) {
+            printer.println();
+        }
+    }
+
+    @Override
+    public void visit(VerbatimNode node) {
+        printer.println();
+
+        String type = node.getType();
+        String text = node.getText();
+
+        if ((type == null || type.isBlank()) && autoDetectLanguageType) {
+            type = detectLanguage(text);
+        }
+
+        if (type != null && !type.isEmpty()) {
+            printer.print("[source," + type + "]");
+        }
+
+        printer.println();
+        repeat('-', 4);
+        printer.println().print(text);
+        repeat('-', 4);
+        printer.println().println();
+    }
+
+    private String detectLanguage(String text) {
+        if (text.startsWith("<")) {
+            return "html";
+        } else if (text.endsWith(";")) {
+            return "java";
+        } else if (text.contains("fun ")) {
+            return "kotlin";
+        } else {
+            return "groovy";
+        }
+    }
+
+    @Override
+    public void visit(WikiLinkNode node) {
+        printLink(linkRenderer.render(node));
+    }
+
+    @Override
+    public void visit(TextNode node) {
+        if (abbreviations.isEmpty()) {
+            printer.print(node.getText());
+        } else {
+            printWithAbbreviations(node.getText());
+        }
+    }
+
+    @Override
+    public void visit(SpecialTextNode node) {
+        printer.printEncoded(node.getText());
+    }
+
+    @Override
+    public void visit(SuperNode node) {
+        visitChildren(node);
+    }
+
+    @Override
+    public void visit(Node node) {
+        throw new RuntimeException("Don't know how to handle node " + node);
+    }
+
+    // helpers
+
+    protected void visitChildren(AbstractNode node) {
+        for (Node child : node.getChildren()) {
+            child.accept(this);
+        }
+    }
+
+
+    /**
+     * Removes superfluous nodes from the tree.
+     *
+     * @param node The node to clean.
+     */
+    protected void cleanAst(Node node) {
+        List<Node> children = node.getChildren();
+        for (int i = 0, len = children.size(); i < len; i++) {
+            Node c = children.get(i);
+            if (c instanceof RootNode) {
+                children.set(i, c.getChildren().get(0));
+            } else if (c.getClass().equals(SuperNode.class) && c.getChildren().size() == 1) {
+                children.set(i, c.getChildren().get(0));
+            }
+
+            cleanAst(c);
+        }
+    }
+
+    protected void printNodeSurroundedBy(AbstractNode node, String token) {
+        printer.print(token);
+        visitChildren(node);
+        printer.print(token);
+    }
+
+    protected void printImageTag(LinkRenderer.Rendering rendering) {
+        printer.print("image:").print(rendering.href).print('[');
+        printTextWithQuotesIfNeeded(printer, rendering.text);
+        printer.print(']');
+    }
+
+    protected void printImageTagWithLink(LinkRenderer.Rendering image, LinkRenderer.Rendering link) {
+        printer.print("image:").print(image.href).print('[');
+        if (image.text != null && !image.text.isEmpty()) {
+            printTextWithQuotesIfNeeded(printer, image.text);
+            printer.print(',');
+        }
+
+        printer.print("link=").print(link.href).print(']');
+    }
+
+    protected void printLink(LinkRenderer.Rendering rendering) {
+        String uri = rendering.href;
+        String text = rendering.text;
+
+        if (uri.startsWith("#")) {
+            printer.print("<<").print(uri.substring(1)).print(',').print(text).print(">>");
+        } else {
+            if (!uri.contains("://")) {
+                uri = "link:" + uri;
+            }
+            printer.print(uri);
+            if (!uri.equals(text)) {
+                printer.print('[');
+                printTextWithQuotesIfNeeded(printer, rendering.text);
+                printer.print(']');
+            }
+        }
+    }
+
+    protected String printChildrenToString(SuperNode node) {
+        Printer priorPrinter = printer;
+        printer = new Printer();
+        visitChildren(node);
+        String result = printer.getString();
+        printer = priorPrinter;
+        return result;
+    }
+
+    protected String normalize(String string) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == ' ' || c == '\n' || c == '\t') {
+                continue;
+            }
+            sb.append(Character.toLowerCase(c));
+        }
+        return sb.toString();
+    }
+
+    protected String normalizeWhitelines(String text) {
+        // replace all double or more empty lines with single empty lines
+        return text.replaceAll("(?m)^[ \t]*\r?\n{2,}", "\n").trim();
+    }
+
+    protected void printTextWithQuotesIfNeeded(Printer p, String text) {
+        if (text != null && !text.isEmpty()) {
+            if (text.contains(",")) {
+                p.print('"').print(text).print('"');
+            } else {
+                p.print(text);
+            }
+        }
+    }
+
+    protected void printWithAbbreviations(String string) {
+        Map<Integer, Map.Entry<String, String>> expansions = null;
+
+        for (Map.Entry<String, String> entry : abbreviations.entrySet()) {
+            // first check, whether we have a legal match
+            String abbr = entry.getKey();
+
+            int ix = 0;
+            while (true) {
+                int sx = string.indexOf(abbr, ix);
+                if (sx == -1) {
+                    break;
+                }
+
+                // only allow whole word matches
+                ix = sx + abbr.length();
+
+                if (sx > 0 && Character.isLetterOrDigit(string.charAt(sx - 1))) {
+                    continue;
+                }
+                if (ix < string.length() && Character.isLetterOrDigit(string.charAt(ix))) {
+                    continue;
+                }
+
+                // ok, legal match so save an expansions "task" for all matches
+                if (expansions == null) {
+                    expansions = new TreeMap<>();
+                }
+                expansions.put(sx, entry);
+            }
+        }
+
+        if (expansions != null) {
+            int ix = 0;
+            for (Map.Entry<Integer, Map.Entry<String, String>> entry : expansions.entrySet()) {
+                int sx = entry.getKey();
+                String abbr = entry.getValue().getKey();
+                String expansion = entry.getValue().getValue();
+
+                printer.printEncoded(string.substring(ix, sx))
+                    .print("<abbr");
+                if (expansion != null && !expansion.isEmpty()) {
+                    printer.print(" title=\"").printEncoded(expansion).print('"');
+                }
+                printer.print('>')
+                    .printEncoded(abbr)
+                    .print("</abbr>");
+                ix = sx + abbr.length();
+            }
+            printer.print(string.substring(ix));
+        } else {
+            printer.print(string);
+        }
+    }
+
+    protected Node findParentNode(Node target, Node from) {
+        if (target.equals(rootNode)) {
+            return null;
+        }
+
+        Node candidate;
+
+        for (Node c : from.getChildren()) {
+            if (target.equals(c)) {
+                return from;
+            } else if ((candidate = findParentNode(target, c)) != null) {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    protected boolean isFirstChild(Node parent, Node child) {
+        return child.equals(parent.getChildren().get(0));
+    }
+
+    protected boolean isListItemText(Node node) {
+        if (listLevel == 0) {
+            return false;
+        }
+        Node parent = findParentNode(node, rootNode);
+        return parent instanceof ListItemNode && isFirstChild(parent, node);
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/CollectionUtils.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/CollectionUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.utils;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * CollectionUtils.
+ *
+ * @since 5.2.0
+ */
+public final class CollectionUtils {
+
+    private CollectionUtils() {
+    }
+
+    public static <T, R> boolean isNotEmpty(Map<T, R> map) {
+        return !isEmpty(map);
+    }
+
+    public static <T, R> boolean isEmpty(Map<T, R> map) {
+        return map == null || map.isEmpty();
+    }
+
+    public static <T> boolean isNotEmpty(Collection<T> collection) {
+        return !isEmpty(collection);
+    }
+
+    public static <T> boolean isEmpty(Collection<T> collection) {
+        return collection == null || collection.isEmpty();
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/FileUtils.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/FileUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * File utilities methods.
+ *
+ * @since 5.2.0
+ */
+public final class FileUtils {
+
+    public static final String FILE_SCHEME = "file:";
+    public static final String CLASSPATH_SCHEME = "classpath:";
+
+    private FileUtils() {
+    }
+
+    public static String loadFileFromClasspath(String location) {
+        String file = location.replaceAll("\\\\", "/");
+
+        var inputStream = FileUtils.class.getResourceAsStream(file);
+        if (inputStream == null) {
+            inputStream = FileUtils.class.getClassLoader().getResourceAsStream(file);
+        }
+        if (inputStream == null) {
+            inputStream = ClassLoader.getSystemResourceAsStream(file);
+        }
+
+        if (inputStream != null) {
+            try {
+                return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not read " + file + " from the classpath", e);
+            } finally {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    //
+                }
+            }
+        }
+        throw new RuntimeException("Could not find " + file + " on the classpath");
+    }
+}

--- a/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/SwaggerUtils.java
+++ b/openapi-to-adoc/src/main/java/io/micronaut/openapi/adoc/utils/SwaggerUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.adoc.utils;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.openapi.OpenApiUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static io.micronaut.openapi.adoc.utils.FileUtils.FILE_SCHEME;
+import static io.micronaut.openapi.adoc.utils.FileUtils.loadFileFromClasspath;
+
+/**
+ * File utilities methods.
+ *
+ * @since 5.2.0
+ */
+@Internal
+public final class SwaggerUtils {
+
+    private SwaggerUtils() {
+    }
+
+    public static OpenAPI readOpenApi(String swaggerFileContent, boolean isJson) {
+
+        ObjectMapper mapper;
+        if (isJson) {
+            mapper = OpenApiUtils.getJsonMapper();
+        } else {
+            mapper = OpenApiUtils.getYamlMapper();
+        }
+
+        try {
+            return mapper.readValue(swaggerFileContent, OpenAPI.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Can't parse swagger file", e);
+        }
+    }
+
+    public static OpenAPI readOpenApiFromLocation(String location) {
+
+        var isJson = location.endsWith(".json");
+        var adjustedLocation = location.replaceAll("\\\\", "/").toLowerCase();
+        try {
+            if (adjustedLocation.startsWith("jar:")) {
+                try (var in = new URI(adjustedLocation).toURL().openStream()) {
+                    return readOpenApi(new String(in.readAllBytes(), StandardCharsets.UTF_8), isJson);
+                }
+            } else {
+                var path = adjustedLocation.startsWith(FILE_SCHEME) ?
+                    Paths.get(URI.create(adjustedLocation)) : Paths.get(adjustedLocation);
+                if (Files.exists(path)) {
+                    return readOpenApi(Files.readString(path), isJson);
+                } else {
+                    return readOpenApi(loadFileFromClasspath(adjustedLocation), isJson);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to read location `%s`".formatted(adjustedLocation), e);
+        }
+    }
+}

--- a/openapi-to-adoc/src/main/resources/template/content.ftl
+++ b/openapi-to-adoc/src/main/resources/template/content.ftl
@@ -1,0 +1,34 @@
+<#if content??>
+.Content
+  <#list content as mediaTypeName, mediaType>
+      <#if mediaType.getExample()?has_content><#assign example = mediaType.getExample() /><#include template_examples /></#if>
+      <#assign schemaType = mediaType.getSchema() />
+${mediaTypeName}:: <#include template_schemaType />
+
+      <#assign propSchema = schemaType />
+      <#include template_propertyDescription />
+      <#if mediaType.getEncoding()?has_content>
+        <#list mediaType.getEncoding() as encodingName, encoding>
+
+==== ${encodingName}
+          <#if encoding.getContentType()?has_content>
+*Content-Type:* ${encoding.getContentType()} +
+          </#if>
+          <#if encoding.getExplode()?? && encoding.getExplode()>
+*Style:* ${encoding.getStyle()} +
+          </#if>
+          <#if encoding.getExplode()?? && encoding.getExplode()>
+__explode__ +
+          </#if>
+          <#if encoding.getAllowReserved()?? && encoding.getAllowReserved()>
+__allow reserved__ +
+          </#if>
+          <#if encoding.getHeaders()?has_content>
+
+            <#assign headers = encoding.getHeaders() />
+            <#include template_headers />
+          </#if>
+        </#list>
+      </#if>
+  </#list>
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/definitions.ftl
+++ b/openapi-to-adoc/src/main/resources/template/definitions.ftl
@@ -1,0 +1,79 @@
+<#if components?? && (components.getSchemas()?has_content || components.getSecuritySchemes()?has_content)>
+[[_components]]
+== Components
+  <#if components.getSchemas()?has_content>
+
+[[_components_schemas]]
+=== Schemas
+    <#list components.getSchemas() as schemaName, schema>
+
+[[_components_schemas_${schemaName}]]
+==== ${schemaName}
+      <#if schema.getProperties()?has_content>
+        <#assign schemaProperties = schema.getProperties() />
+        <#include template_properties />
+      </#if>
+    </#list>
+  </#if>
+
+  <#if components.getSecuritySchemes()?has_content>
+
+[[_components_securitySchemes]]
+=== Security Schemes
+[%header,caption=,cols=".^2a,.^4a,.^4a,.^16a"]
+|===
+<.<|Name
+<.<|Type
+<.<|In
+<.<|Description
+    <#list components.getSecuritySchemes() as securitySchemaName, securitySchema>
+
+<.<|*${securitySchemaName}*
+<.<|${securitySchema.getType()?has_content?then(securitySchema.getType(), '')}
+<.<|${securitySchema.getIn()?has_content?then(securitySchema.getIn(), '')}
+<.<|${securitySchema.getDescription()?has_content?then(securitySchema.getDescription(), '')} +
+      <#if securitySchema.getOpenIdConnectUrl()?has_content>
+${securitySchema.getOpenIdConnectUrl()}[OpenID connect URL]
+      </#if>
+      <#if securitySchema.getBearerFormat()?has_content>
+*Bearer format:* ${securitySchema.getBearerFormat()}
+      </#if>
+      <#if securitySchema.getFlows()??>
+        <#if securitySchema.getFlows().getImplicit()??>
+          <#assign oauthType = "implicit" />
+          <#assign flow = securitySchema.getFlows().getImplicit() />
+        <#elseif securitySchema.getFlows().getPassword()??>
+          <#assign oauthType = "password" />
+          <#assign flow = securitySchema.getFlows().getPassword() />
+        <#elseif securitySchema.getFlows().getClientCredentials()??>
+          <#assign oauthType = "client-credential" />
+          <#assign flow = securitySchema.getFlows().getClientCredentials() />
+        <#elseif securitySchema.getFlows().getAuthorizationCode()??>
+          <#assign oauthType = "authorization_code" />
+          <#assign flow = securitySchema.getFlows().getAuthorizationCode() />
+        </#if>
+OAuth flow: __${oauthType}__ +
+        <#if flow??>
+          <#if flow.getAuthorizationUrl()?has_content>
+${flow.getAuthorizationUrl()}[Authorization URL] +
+          </#if>
+          <#if flow.getTokenUrl()?has_content>
+${flow.getTokenUrl()}[Token URL] +
+          </#if>
+          <#if flow.getRefreshUrl()?has_content>
+${flow.getRefreshUrl()}[Refresh URL] +
+          </#if>
+          <#if flow.getScopes()?has_content>
+
+*Scopes:*
+
+            <#list flow.getScopes() as scope, description>
+. `${scope}` : ${description}
+            </#list>
+          </#if>
+        </#if>
+      </#if>
+    </#list>
+|===
+  </#if>
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/examples.ftl
+++ b/openapi-to-adoc/src/main/resources/template/examples.ftl
@@ -1,0 +1,37 @@
+<#if examples?has_content>
+*Examples:*
+  <#list examples as exampleName, ex>
+
+.${exampleName}
+    <#if ex.get$ref()?has_content>
+      <#assign example = components.getExamples()[ex.get$ref()?remove_beginning("#/components/examples/")] />
+    <#else>
+      <#assign example = ex />
+    </#if>
+    <#if example.getSummary()?has_content>
+
+${example.getSummary()}
+    </#if>
+    <#if example.getDescription()?has_content>
+
+${example.getDescription()}
+    </#if>
+    <#if example.getExternalValue()?has_content>
+
+${example.getExternalValue()}[Link]
+    </#if>
+    <#if example.getValue()??>
+[source]
+----
+${JSON.writeValueAsString(example.getValue())}
+----
+    </#if>
+<#--    <#if example.get$ref()?has_content><<${example.get$ref()?replace("#", "")?replace("/", "_")},${example.get$ref()?remove_beginning("#/components/examples/")}>></#if>-->
+  </#list>
+<#elseif example??>
+*Example:*
+[source]
+----
+${example}
+----
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/externalDocs.ftl
+++ b/openapi-to-adoc/src/main/resources/template/externalDocs.ftl
@@ -1,0 +1,3 @@
+<#if externalDocs?has_content>
+${externalDocs.getUrl()?has_content?then(externalDocs.getUrl() + '[' + externalDocs.getDescription() + ']', externalDocs.getDescription())} +
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/headers.ftl
+++ b/openapi-to-adoc/src/main/resources/template/headers.ftl
@@ -1,0 +1,41 @@
+<#if headers?has_content>
+
+.Headers
+[%header,caption=,cols=".^2a,.^14a,.^4a"]
+!===
+<.<!Name
+<.<!Description
+<.<!Schema
+  <#list headers as headerName, h>
+
+    <#if h.get$ref()?has_content>
+        <#assign header = components.getHeaders()[h.get$ref()?remove_beginning("#/components/headers/")] />
+    <#else>
+        <#assign header = h />
+    </#if>
+<.<!${headerName}
+    <#if header.getRequired()?? && header.getRequired()>
+__required__
+    </#if>
+    <#if header.getDeprecated()?? && header.getDeprecated()>
+__deprecated__
+    </#if>
+    <#if header.getExplode()?? && header.getExplode()>
+__explode__
+    </#if>
+<.<!<#compress>
+      <#if header.getDescription()?has_content>${header.getDescription()}</#if>
+      <#if header.getExample()?has_content || header.getExamples()?has_content>
+        <#if header.getExample()?has_content>
+            <#assign example = header.getExample() />
+        <#else>
+            <#assign examples = header.getExamples() />
+        </#if>
+        <#include template_examples />
+      </#if>
+    </#compress>
+
+<.<!<#assign schemaType = header.getSchema() /><#include template_schemaType />
+  </#list>
+!===
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/links.ftl
+++ b/openapi-to-adoc/src/main/resources/template/links.ftl
@@ -1,0 +1,28 @@
+<#if links?has_content>
+  <#list links as name, link>
+    <#if link.get$ref()?has_content && components?? && components.getLinks()?has_content>
+        <#assign l = components.getLinks()[link.get$ref()?remove_beginning("#/components/links/")] />
+    <#else>
+        <#assign l = link />
+    </#if>
+*${name}* +
+      <#if l.getDescription()?has_content>
+
+${l.getDescription()}
+      </#if>
+      <#if l.getOperationId()?has_content>
+
+__Operation__: `${l.getOperationId()}` +
+      </#if>
+      <#if l.getParameters()?has_content>
+
+__Parameters__: { +
+          <#list l.getParameters() as name, value>
+"${name}": "${value}"${name?has_next?then(',', '')} +
+          </#list>
+} +
+      </#if>
+  </#list>
+<#else>
+No links
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/openApiDoc.ftl
+++ b/openapi-to-adoc/src/main/resources/template/openApiDoc.ftl
@@ -1,0 +1,3 @@
+<#include template_overview />
+<#include template_paths />
+<#include template_definitions />

--- a/openapi-to-adoc/src/main/resources/template/overview.ftl
+++ b/openapi-to-adoc/src/main/resources/template/overview.ftl
@@ -1,0 +1,62 @@
+<#if info??>
+    <#if info.getTitle()?has_content>
+= ${info.getTitle()}
+    </#if>
+    <#if info.getContact()?? && info.getContact().getName()?has_content>
+${info.getContact().getName()}
+    </#if>
+    <#if info.getVersion()?has_content>
+${info.getVersion()}
+:revnumber: ${info.getVersion()}
+    </#if>
+    <#if info.getContact()??>
+        <#if info.getContact().getEmail()?has_content>
+:email: ${info.getContact().getEmail()}
+        </#if>
+        <#if info.getContact().getName()?has_content>
+:author: ${info.getContact().getName()}
+        </#if>
+:authorcount: 1
+    </#if>
+</#if>
+<#if openApi?has_content>
+:openapi: ${openApi}
+</#if>
+<#if info??>
+
+== Overview
+    <#if info.getDescription()?has_content>
+
+${info.getDescription()?trim}
+    </#if>
+    <#if info.getTermsOfService()?has_content>
+        <#if info.getDescription()?has_content>
+
+        </#if>
+${info.getTermsOfService()}[Terms Of Service] +
+    </#if>
+    <#if info.getLicense()?has_content>
+        <#if info.getDescription()?has_content && !info.getTermsOfService()?has_content>
+
+        </#if>
+${info.getLicense().getUrl()?has_content?then(info.getLicense().getUrl() + '[', '')}${info.getLicense().getName()}${info.getLicense().getUrl()?has_content?then(']', '')} +
+    </#if>
+    <#if externalDocs?has_content>
+      <#if info.getDescription()?has_content && !info.getTermsOfService()?has_content && !info.getLicense()?has_content>
+
+      </#if>
+      <#include template_externalDocs />
+    </#if>
+</#if>
+<#if tags?has_content>
+
+== Tags
+
+    <#list tags as tag>
+${tag.getName()}::
+        <#if tag.getDescription()?has_content>
+${tag.getDescription()}
+        </#if>
+    </#list>
+</#if>
+<#include template_servers />

--- a/openapi-to-adoc/src/main/resources/template/parameters.ftl
+++ b/openapi-to-adoc/src/main/resources/template/parameters.ftl
@@ -1,0 +1,56 @@
+<#if parameters?has_content>
+.Parameters
+[%header,caption=,cols=".^2a,.^3a,.^10a,.^5a"]
+|===
+<.<|In
+<.<|Name
+<.<|Description
+<.<|Type
+  <#list parameters as p>
+
+    <#if p.get$ref()?has_content>
+      <#assign parameter = components.getParameters()[p.get$ref()?remove_beginning("#/components/parameters/")] />
+    <#else>
+      <#assign parameter = p />
+    </#if>
+<.<|**${parameter.getIn()}**
+<.<|**${parameter.getName()}** +
+    <#if parameter.getDeprecated()?? && parameter.getDeprecated()>
+__deprecated__ +
+    </#if>
+    <#if parameter.getRequired()?? && parameter.getRequired()>
+__required__ +
+    </#if>
+    <#if parameter.getAllowEmptyValue()?? && parameter.getAllowEmptyValue()>
+__allow empty value__ +
+    </#if>
+    <#if parameter.getExplode()?? && parameter.getExplode()>
+__explode__ +
+    </#if>
+    <#if parameter.getAllowReserved()?? && parameter.getAllowReserved()>
+__allow reserved__ +
+    </#if>
+<.<|
+<#if parameter.getDescription()?has_content>
+${parameter.getDescription()}
+
+    </#if>
+    <#if parameter.getStyle()??>
+Style: ${parameter.getStyle()} +
+    </#if>
+    <#if parameter.getExample()?has_content || parameter.getExamples()?has_content>
+        <#if parameter.getExample()?has_content>
+          <#assign example = parameter.getExample() />
+        <#else>
+          <#assign examples = parameter.getExamples() />
+        </#if>
+        <#include template_examples />
+    </#if>
+    <#if parameter.getContent()??>
+      <#assign content = parameter.getContent() />
+      <#include template_content />
+    </#if>
+<.<|<#if parameter.getSchema()??><#assign schemaType = parameter.getSchema() /><#include template_schemaType /></#if>
+  </#list>
+|===
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/paths.ftl
+++ b/openapi-to-adoc/src/main/resources/template/paths.ftl
@@ -1,0 +1,28 @@
+<#if paths?has_content>
+
+== Paths
+  <#list paths as pathsStr, path>
+    <#list path.readOperationsMap() as method, operation>
+
+=== __${method}__ `${pathsStr}` ${operation.getSummary()?trim}
+      <#if operation.getDescription()?has_content>
+${operation.getDescription()?trim}
+
+      </#if>
+      <#if operation.getRequestBody()??>
+        <#assign requestBody = operation.getRequestBody() />
+        <#include template_requestBody />
+      </#if>
+      <#if operation.getParameters()?has_content>
+        <#assign parameters = operation.getParameters() />
+        <#include template_parameters />
+      </#if>
+      <#if operation.getResponses()?has_content>
+        <#assign responses = operation.getResponses() />
+        <#include template_responses />
+      </#if>
+      <#assign securityReqs = operation.getSecurity()?has_content?then(operation.getSecurity(), []) />
+      <#include template_securityRequirements />
+    </#list>
+  </#list>
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/properties.ftl
+++ b/openapi-to-adoc/src/main/resources/template/properties.ftl
@@ -1,0 +1,18 @@
+<#if schemaProperties?has_content>
+.Properties
+[%header,caption=,cols=".^4a,.^16a,.^4a"]
+|===
+<.<|Name
+<.<|Description
+<.<|Type
+<#list schemaProperties as propName, propSchema>
+
+<.<|${propName}
+<#if propSchema.getRequired()?has_content && propSchema.getRequired()?seq_contains(propName)>
+__required__
+</#if>
+<.<|<#include template_propertyDescription />
+<.<|<#assign schemaType = propSchema /><#include template_schemaType />
+</#list>
+|===
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/propertyDescription.ftl
+++ b/openapi-to-adoc/src/main/resources/template/propertyDescription.ftl
@@ -1,0 +1,73 @@
+<#if propSchema.getDescription()?has_content>
+${propSchema.getDescription()}
+
+</#if>
+<#if propSchema.getExclusiveMinimum()?? && propSchema.getExclusiveMinimum()>
+  __exclusive minimum__ +
+</#if>
+<#if propSchema.getExclusiveMaximum()?? && propSchema.getExclusiveMaximum()>
+  __exclusive maximum__ +
+</#if>
+<#if propSchema.getWriteOnly()?? && propSchema.getWriteOnly()>
+  __write-only__ +
+</#if>
+<#if propSchema.getReadOnly()?? && propSchema.getReadOnly()>
+  __read-only__ +
+</#if>
+<#if propSchema.getDeprecated()?? && propSchema.getDeprecated()>
+  __deprecated__ +
+</#if>
+<#if propSchema.getUniqueItems()?? && propSchema.getUniqueItems()>
+  __unique items__ +
+</#if>
+<#if propSchema.getNullable()?? && propSchema.getNullable()>
+  __nullable__ +
+</#if>
+<#if propSchema.getTitle()?has_content>
+  **Title**: ${propSchema.getTitle()} +
+</#if>
+<#if propSchema.getDefault()?has_content>
+  **Default**: ${propSchema.getDefault()} +
+</#if>
+<#if propSchema.getPattern()?has_content>
+  **Pattern**: ${propSchema.getPattern()} +
+</#if>
+<#if propSchema.getMinProperties()??>
+  **Multiple Of**: ${propSchema.getMultipleOf()} +
+</#if>
+<#if propSchema.getMaximum()??>
+  **Maximum**: ${propSchema.getMaximum()} +
+</#if>
+<#if propSchema.getMinimum()??>
+  **Minimum**: ${propSchema.getMinimum()} +
+</#if>
+<#if propSchema.getMaxLength()??>
+  **Max. length**: ${propSchema.getMaxLength()} +
+</#if>
+<#if propSchema.getMinLength()??>
+  **Min. length**: ${propSchema.getMinLength()} +
+</#if>
+<#if propSchema.getMaxItems()??>
+  **Max. items**: ${propSchema.getMaxItems()} +
+</#if>
+<#if propSchema.getMinItems()??>
+  **Min. items**: ${propSchema.getMinItems()} +
+</#if>
+<#if propSchema.getMaxProperties()??>
+  **Max. properties**: ${propSchema.getMaxProperties()} +
+</#if>
+<#if propSchema.getMinProperties()??>
+  **Min. properties**: ${propSchema.getMinProperties()} +
+</#if>
+<#if propSchema.getExample()?has_content || propSchema.getExamples()?has_content>
+  <#if propSchema.getExample()?has_content>
+    <#assign example = propSchema.getExample() />
+  <#else>
+    <#assign examples = propSchema.getExamples() />
+  </#if>
+  <#include template_examples />
+</#if>
+<#if propSchema.getProperties()?has_content>
+  <#assign schemaProperties = propSchema.getProperties() />
+  <#include template_properties />
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/requestBody.ftl
+++ b/openapi-to-adoc/src/main/resources/template/requestBody.ftl
@@ -1,0 +1,21 @@
+<#if requestBody??>
+  <#if requestBody.get$ref()?has_content>
+    <#assign request = components.getRequestBodies()[requestBody.get$ref()?remove_beginning("#/components/requestBodies/")] />
+  <#else>
+    <#assign request = requestBody />
+  </#if>
+==== Request
+  <#if request.getDescription()?has_content>
+
+${request.getDescription()}
+  </#if>
+  <#if request.getRequired()?? && request.getRequired()>
+
+__required__
+  </#if>
+  <#if request.getContent()?has_content>
+
+    <#assign content = request.getContent() />
+    <#include template_content />
+  </#if>
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/responses.ftl
+++ b/openapi-to-adoc/src/main/resources/template/responses.ftl
@@ -1,0 +1,31 @@
+<#if responses?has_content>
+
+.Responses
+[%header,caption=,cols=".^2a,.^14a,.^4a"]
+|===
+<.<|Code
+<.<|Description
+<.<|Links
+
+  <#list responses as code, response>
+<.<|${code}
+<.<|<#compress>
+    <#if response.get$ref()?has_content>
+      <#assign response = response.get$ref()?remove_beginning("#/components/responses/") />
+    </#if>
+    <#if response.getDescription()?has_content>${response.getDescription()}</#if>
+    </#compress>
+    <#if response.getHeaders()?has_content>
+
+      <#assign headers = response.getHeaders() />
+      <#include template_headers />
+    </#if>
+    <#if response.getContent()?has_content>
+      <#assign content = response.getContent() />
+      <#include template_content />
+    </#if>
+
+<.<|<#assign links = response.getLinks()?has_content?then(response.getLinks(), []) /><#include template_links />
+  </#list>
+|===
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/schemaType.ftl
+++ b/openapi-to-adoc/src/main/resources/template/schemaType.ftl
@@ -1,0 +1,22 @@
+<#compress>
+<#if schemaType.getItems()??>
+  <#if schemaType.getItems().getType()??>
+< ${schemaType.getItems().getType()} > array
+  <#elseif schemaType.getItems().get$ref()?has_content>
+< <<${schemaType.getItems().get$ref()?replace("#", "")?replace("/", "_")},${schemaType.getItems().get$ref()?remove_beginning("#/components/schemas/")}>> > array
+  <#else>
+< object > array
+  </#if>
+<#elseif schemaType.getEnum()?has_content>
+enum (${schemaType.getEnum()?join(", ")})
+<#else>
+  <#if schemaType.getType()??>
+${schemaType.getType()}
+  <#else>
+<<${schemaType.get$ref()?replace("#", "")?replace("/", "_")},${schemaType.get$ref()?remove_beginning("#/components/schemas/")}>>
+  </#if>
+  <#if schemaType.getFormat()?has_content>
+(${schemaType.getFormat()})
+  </#if>
+</#if>
+</#compress>

--- a/openapi-to-adoc/src/main/resources/template/securityRequirements.ftl
+++ b/openapi-to-adoc/src/main/resources/template/securityRequirements.ftl
@@ -1,0 +1,20 @@
+<#assign allSecurityReqs = globalSecurityRequirements?has_content?then(globalSecurityRequirements, []) />
+<#assign allSecurityReqs += securityReqs />
+<#if allSecurityReqs?has_content>
+
+.Security
+[%header,caption=,cols=".^3a,.^4a,.^13a"]
+|===
+<.<|Name
+<.<|Type
+<.<|Scopes
+  <#list allSecurityReqs as securityReq>
+    <#list securityReq as securityReqName, securityReqScopes>
+
+<.<|${securityReqName}
+<.<|**${securityReqScopes?has_content?then("oauth2", "apiKey")}**
+<.<|${securityReqScopes?join(", ")}
+    </#list>
+  </#list>
+|===
+</#if>

--- a/openapi-to-adoc/src/main/resources/template/servers.ftl
+++ b/openapi-to-adoc/src/main/resources/template/servers.ftl
@@ -1,0 +1,30 @@
+<#if servers?has_content>
+
+== Servers
+  <#list servers as server>
+
+=== __Server__: ${server.getUrl()}
+    <#if server.getDescription()?has_content>
+
+${server.getDescription()}
+    </#if>
+    <#if server.getVariables()?has_content>
+
+.Server Variables
+[%header,caption=,cols=".^2a,.^9a,.^3a,.^4a"]
+|===
+<.<|Variable
+<.<|Description
+<.<|Possible Values
+<.<|Default
+      <#list server.getVariables() as varName, var>
+
+<.<|${varName}
+<.<|${var.getDescription()}
+<.<|${var.getEnum()?has_content?then(var.getEnum()?join(", "), "Any")}
+<.<|${var.getDefault()}
+      </#list>
+|===
+    </#if>
+  </#list>
+</#if>

--- a/openapi-to-adoc/src/test/java/io/micronaut/openapi/adoc/OpenapiToAdocConverterTest.java
+++ b/openapi-to-adoc/src/test/java/io/micronaut/openapi/adoc/OpenapiToAdocConverterTest.java
@@ -1,0 +1,48 @@
+package io.micronaut.openapi.adoc;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import freemarker.template.TemplateException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenapiToAdocConverterTest {
+
+    final Path outputDir = Paths.get("build/test/freemarker");
+
+    @BeforeEach
+    void setup() throws IOException {
+        if (Files.exists(outputDir)) {
+            Files.walk(outputDir)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
+    }
+
+    @Test
+    void testFreemarker() throws IOException, TemplateException {
+
+        System.setProperty(ConfigProperty.OPENAPI_ADOC_OPENAPI_PATH, "/yaml/swagger_petstore.yaml");
+        System.setProperty(ConfigProperty.OPENAPI_ADOC_OUTPUT_FILENAME, "myresult.adoc");
+        System.setProperty(ConfigProperty.OPENAPI_ADOC_OUTPUT_DIR_PATH, outputDir.toString());
+        System.setProperty(ConfigProperty.OPENAPI_ADOC_TEMPLATES_DIR_PATH, "classpath:/customDir");
+        System.setProperty(ConfigProperty.OPENAPI_ADOC_TEMPLATE_PREFIX + "links", "links1.ftl");
+        var converter = new OpenapiToAdocConverter();
+        converter.convert();
+
+        var resultFile = outputDir.resolve("myresult.adoc");
+        assertTrue(Files.exists(resultFile));
+
+        var adoc = Files.readString(resultFile);
+        assertTrue(adoc.contains("!!!!!!test custom template"));
+    }
+}

--- a/openapi-to-adoc/src/test/resources/customDir/links1.ftl
+++ b/openapi-to-adoc/src/test/resources/customDir/links1.ftl
@@ -1,0 +1,1 @@
+!!!!!!test custom template

--- a/openapi-to-adoc/src/test/resources/yaml/swagger_petstore.yaml
+++ b/openapi-to-adoc/src/test/resources/yaml/swagger_petstore.yaml
@@ -1,0 +1,763 @@
+openapi: 3.0.0
+info:
+  description: >
+    This is a sample server Petstore server.
+
+
+    [Learn about Swagger](https://swagger.io) or join the IRC channel `#swagger` on irc.freenode.net.
+
+
+    For this sample, you can use the api key `special-key` to test the authorization filters
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: https://helloreverb.com/terms/
+  contact:
+    name: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Pet resource
+  - name: store
+    description: Store resource
+  - name: user
+    description: User resource
+security:
+  - global_auth:
+    - global_pets
+    - read_pets
+paths:
+  /pets:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      responses:
+        "400":
+          $ref: "#/components/responses/InvalidId"
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+  /pets/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      parameters:
+        - in: query
+          name: status
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+          links:
+            address:
+              $ref: "#/components/links/address"
+            address-232323232323:
+              # the target link operationId
+              operationId: findPetsByTags
+              description: This is address-232323232323 description
+              parameters:
+                # get the `tags` field from the request path parameter named `tags`
+                tags: $request.path.tags
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+  /pets/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma seperated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - in: query
+          name: tags
+          description: Tags to filter by
+          required: false
+          example: adorable
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+  "/pets/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a pet when ID < 10. ID > 10 or nonintegers will simulate API
+        error conditions
+      operationId: getPetById
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be fetched
+          required: true
+          example: 30
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          $ref: "#/components/responses/InvalidId"
+        "404":
+          description: Pet not found
+      security:
+        - api_key: [ ]
+        - petstore_auth:
+            - write_pets
+            - read_pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+              required:
+                - name
+                - status
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      parameters:
+        - in: header
+          name: api_key
+          description: ""
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: petId
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "400":
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - write_pets
+            - read_pets
+  /stores/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid Order
+  "/stores/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values
+        will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          $ref: "#/components/responses/InvalidId"
+        "404":
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          $ref: "#/components/responses/InvalidId"
+        "404":
+          description: Order not found
+  /users:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Created user object
+      responses:
+        default:
+          description: successful operation
+  /users/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+      responses:
+        default:
+          description: successful operation
+  /users/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      parameters:
+        - in: query
+          name: username
+          description: The user name for login
+          required: false
+          examples:
+            testExample:
+              $ref: '#/components/examples/testExample'
+          schema:
+            type: string
+        - in: query
+          name: password
+          description: The password for login in clear text
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: string
+            application/xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid username/password supplied
+  /users/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  "/users/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+              description: The number of seconds left in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - in: path
+          name: username
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Updated user object
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: https://swagger.io
+servers:
+  - url: https://petstore.swagger.io/v2
+    description: This is server description
+    variables:
+      var1:
+        description: Var1 desc
+        default: def value for var1
+        enum:
+          - '1'
+          - '2'
+          - '3'
+      var2:
+        description: Var2 desc
+        default: def value for var2
+components:
+  examples:
+    testExample:
+      description: my first example
+      summary: ssdsdsdsdd
+      externalValue: https://mydomain.com
+      value: {
+               "1": "2",
+               "3": "4"
+      }
+  links:
+    address:
+      # the target link operationId
+      operationId: findPetsByTags
+      description: This is link description
+      parameters:
+        # get the `tags` field from the request path parameter named `tags`
+        tags: $request.path.tags
+  responses:
+    InvalidId:
+      description: Invalid ID supplied
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+      description: List of user object
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+      description: This is another description
+    petstore_auth:
+      type: oauth2
+      description: This is a standard oauth flow
+      flows:
+        implicit:
+          authorizationUrl: https://petstore.swagger.io/api/oauth/dialog
+          scopes:
+            write_pets: modify pets in your account
+            read_pets: read your pets
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          description: The name of the category
+          minLength: 0
+          maxLength: 255
+          pattern: "[A-Za-zäöüÄÖÜß]{0,255}"
+          default: DefaultCategory
+          example: FoobarCategory
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store,
+          enum:
+            - Dead
+            - Alive
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: id description
+          readOnly: true
+          writeOnly: true
+          deprecated: true
+          nullable: true
+          exclusiveMinimum: true
+          exclusiveMaximum: true
+          uniqueItems: true
+
+          example: 1
+
+          maximum: 100
+          minimum: 10
+
+          maxLength: 100
+          minLength: 10
+
+          maxItems: 999
+          minItems: 99
+
+          maxProperties: 12212
+          minProperties: 12
+
+          multipleOf: 12.34
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+          default: 0
+          example: 10
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - Ordered
+            - Cancelled
+        complete:
+          type: boolean

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,9 @@ rootProject.name = "openapi-parent"
 include "openapi"
 include "openapi-annotations"
 include "openapi-bom"
+include "openapi-common"
 include "openapi-generator"
+include "openapi-to-adoc"
 include 'docs-examples:example-groovy'
 include 'docs-examples:example-java'
 include 'docs-examples:example-kotlin'

--- a/test-suite-client-generator/petstore.json
+++ b/test-suite-client-generator/petstore.json
@@ -208,7 +208,7 @@
           "pet"
         ],
         "summary": "Find pet by ID",
-        "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+        "description": "Returns a pet when ID < 10. ID > 10 or nonintegers will simulate API error conditions",
         "operationId": "getPetById",
         "produces": [
           "application/json",


### PR DESCRIPTION
Introduce new module to convert openAPI json and yml format to Asciidoc format. After it you can convert it to `Markdown`, `HTML`, `PDF` or `DOCX`.

Base template looks like this (PDF format):

![изображение](https://github.com/micronaut-projects/micronaut-openapi/assets/48474279/62049ba5-5b79-402d-947a-4dee1ac4e576)

![изображение](https://github.com/micronaut-projects/micronaut-openapi/assets/48474279/66a2567e-97db-4fbd-96ab-bd371b74b8b9)

You can customize full template or only part of it.

I think, we need to integrate it with gradle plugin.