### PR TITLE
Fix setting generateHttpResponseWhereRequired option

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -310,7 +310,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             private boolean optional;
             private boolean reactive = true;
             private boolean generateHttpResponseAlways;
-            private boolean generateHttpResponseWhereRequired;
+            private boolean generateHttpResponseWhereRequired = true;
             private TestFramework testFramework = TestFramework.JUNIT5;
             private SerializationLibraryKind serializationLibraryKind = SerializationLibraryKind.MICRONAUT_SERDE_JACKSON;
             private DateTimeFormat dateTimeFormat = DateTimeFormat.ZONED_DATETIME;

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -128,6 +128,7 @@ public final class MicronautCodeGeneratorEntryPoint {
         }
         codeGenerator.setReactive(options.reactive);
         codeGenerator.setGenerateHttpResponseAlways(options.generateHttpResponseAlways);
+        codeGenerator.setGenerateHttpResponseWhereRequired(options.generateHttpResponseWhereRequired);
         codeGenerator.setUseOptional(options.optional);
         codeGenerator.setUseBeanValidation(options.beanValidation);
         codeGenerator.setTestTool(options.testFramework.value);


### PR DESCRIPTION
Setting generateHttpResponseWhereRequired option does not work because it is not passed to codeGenerator.