### PR TITLE
fix group properties not being read from openapi.properties

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -545,7 +545,7 @@ public final class ConfigUtils {
             String groupName = prop.substring(MICRONAUT_OPENAPI_GROUPS.length() + 1, groupNameIndexEnd);
             String propertyName = prop.substring(groupNameIndexEnd + 1);
             String value = props.getProperty(prop);
-            setGroupProperty(groupName, prop, value, groupPropertiesMap, context);
+            setGroupProperty(groupName, propertyName, value, groupPropertiesMap, context);
         }
     }
 


### PR DESCRIPTION
Group properties such as `micronaut.openapi.groups.*.packages=***` are not being read from the `openapi.properties` file, and therefore the properties are not being respected. The `readGroupsProperties` function passes the property name, to `setGroupProperty` but it is currently passing the full name, i.e. `micronaut.openapi.groups.*.packages`, when it should just be passing the key after the group name, i.e. `packages`. 

Fixes #1267 