### PR TITLE
Custom serializers should inherit generic types

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -857,7 +857,19 @@ abstract class AbstractOpenApiVisitor {
                 String typeName = type.getName();
                 ClassElement customTypeSchema = getCustomSchema(typeName, typeArgs, context);
                 if (customTypeSchema != null) {
-                    type = customTypeSchema;
+                    Map<String, ClassElement> customTypeArgs = customTypeSchema.getTypeArguments();
+                    if (customTypeArgs.isEmpty()) {
+                        type = customTypeSchema;
+                    } else {
+                        Map<String, ClassElement> inheritedTypeArgs = new HashMap<>(customTypeArgs);
+                        for (String generic : customTypeArgs.keySet()) {
+                            ClassElement element = typeArgs.get(generic);
+                            if (element != null) {
+                                inheritedTypeArgs.put(generic, element);
+                            }
+                        }
+                        type = customTypeSchema.withTypeArguments(inheritedTypeArgs);
+                    }
                 }
 
                 if (isArray == null) {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenapiCustomSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenapiCustomSchemaSpec.groovy
@@ -320,12 +320,12 @@ class MyBean {}
         swaggerPageSchema.type == 'object'
         swaggerPageSchema.properties.content
         swaggerPageSchema.properties.content.type == 'array'
-        swaggerPageSchema.properties.content.items.type == 'object'
+        swaggerPageSchema.properties.content.items.type == 'string'
         swaggerPageSchema.properties.num
         swaggerPageSchema.properties.num.type == 'integer'
         swaggerPageSchema.properties.num.format == 'int32'
 
         cleanup:
-        System.clearProperty(OpenApiConfigProperty.MICRONAUT_CONFIG_FILE_LOCATIONS)
+        System.clearProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_CONFIG_FILE)
     }
 }


### PR DESCRIPTION
Generic update derived from #1276 

```kotlin
@Get("{?pageable*}")
@ApiResponse(responseCode = "200")
suspend fun hello(pageable: Pageable): Page<String> = Page.of(listOf("Hello, World!"), pageable, 2)

interface SwaggerPage<T> {
  @get:Schema(description = "The content.") val content: List<T>
  @get:Schema(description = "The pageable for this slice.") val pageable: Pageable
}
```

Current the items type was `object`, which was lost the generic type

```yml
content:
  type: array
  description: The content.
  items:
    type: object
```

Expected it should be inherit the generic type if it had generics

```
content:
  type: array
  description: The content.
  items:
    type: string
```