### PR TITLE
Fix "Invalid Swagger UI index.html for versioned API" #1321

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/SwaggerUIConfig.java
@@ -295,7 +295,7 @@ final class SwaggerUIConfig extends AbstractViewConfig {
                 result.append(',');
             }
             result.append("{url: contextPath + '").append(url.url())
-                .append(", name: '").append(url.name()).append("'}");
+                .append("', name: '").append(url.name()).append("'}");
             isFirst = false;
         }
         result.append("],");

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiOperationViewRenderSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiOperationViewRenderSpec.groovy
@@ -385,6 +385,6 @@ class OpenApiOperationViewRenderSpec extends Specification {
 
         then:
         indexText.contains(cfg.getSpecURL(cfg.swaggerUIConfig, null))
-        indexText.contains("urls: [{url: contextPath + '/swagger/swagger.yml, name: '1'}],")
+        indexText.contains("urls: [{url: contextPath + '/swagger/swagger.yml', name: '1'}],")
     }
 }


### PR DESCRIPTION
Add missing apostrophe for `urls` property of `SwaggerUIBundle` in `SwaggerUiConfig` to fix #1321 .