### PR TITLE
Fix typo on OpenAPI explorer hide-components option

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/OpenApiExplorerConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/OpenApiExplorerConfig.java
@@ -65,7 +65,7 @@ final class OpenApiExplorerConfig extends AbstractViewConfig {
         VALID_OPTIONS.put("hide-console", AbstractViewConfig::asBoolean);
         VALID_OPTIONS.put("hide-authentication", AbstractViewConfig::asBoolean);
         VALID_OPTIONS.put("hide-server-selection", AbstractViewConfig::asBoolean);
-        VALID_OPTIONS.put("hide-component", AbstractViewConfig::asBoolean);
+        VALID_OPTIONS.put("hide-components", AbstractViewConfig::asBoolean);
 
         // Custom configuration
         VALID_OPTIONS.put("default-schema-tab", new EnumConverter<>(DefaultSchemaTab.class));


### PR DESCRIPTION
Fixes #1411 

After reviewing the `openapi-explorer` documentation [Hide/Show Sections](https://github.com/Authress-Engineering/openapi-explorer/blob/release/2.1/docs/documentation.md#hideshow-sections), I identified a missing character in the `hide-components` option.

After applying the fix, I successfully ran the application locally and confirmed that the expected behavior of hiding the Components section was achieved:

![image](https://github.com/micronaut-projects/micronaut-openapi/assets/2984131/0c77fe72-9a77-48d0-a9ac-0e69bacb0fbc)

