### PR TITLE
Add @Retention(RUNTIME) annotation to HardNullable

### DIFF
--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/HardNullable.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/HardNullable.mustache
@@ -4,7 +4,10 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * An annotation specifying that a parameter is nullable, that is also inherited.
@@ -14,6 +17,7 @@ import java.lang.annotation.Target;
 @Nullable
 @Inherited
 @Target({ElementType.PARAMETER, ElementType.TYPE_PARAMETER, ElementType.FIELD})
+@Retention(RUNTIME)
 public @interface HardNullable {
 
 }


### PR DESCRIPTION
Currently, the `@HardNullable` annotation is missing the `@Retention(RUNTIME)` specification.  By adding `@Retention(RUNTIME)`, we unlock the full potential of the `@HardNullable` annotation, allowing it to be utilized more effectively in Micronaut applications and libraries that depend on runtime annotation processing.

Thank you to all the maintainers for your dedication and hard work that make contributions like mine possible.