### PR TITLE
Fix inline resolver for open api generator

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -691,6 +691,11 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
     }
 
     @Override
+    public String toApiName(String name) {
+        return Utils.toApiName(name, apiNamePrefix, apiNameSuffix);
+    }
+
+    @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co,
                                     Map<String, List<CodegenOperation>> operations) {
         if (generateOperationOnlyForFirstTag && !co.tags.get(0).getName().equals(tag)) {
@@ -732,7 +737,9 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         }
 
         var inlineModelResolver = new MicronautInlineModelResolver(openAPI);
-        inlineModelResolver.flattenPaths();
+        inlineModelResolver.setInlineSchemaNameMapping(inlineSchemaNameMapping);
+        inlineModelResolver.setInlineSchemaOptions(inlineSchemaOption);
+        inlineModelResolver.flatten();
 
         super.preprocessOpenAPI(openAPI);
     }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
@@ -73,6 +73,7 @@ import static io.micronaut.openapi.generator.Utils.processGenericAnnotations;
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 import static org.openapitools.codegen.languages.KotlinClientCodegen.DATE_LIBRARY;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
+import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
  * Base generator for Micronaut.
@@ -675,6 +676,21 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         return tag;
     }
 
+    public String superSanitizeTag(String tag) {
+        tag = camelize(underscore(sanitizeName(tag)));
+
+        // tag starts with numbers
+        if (tag.matches("^\\d.*")) {
+            tag = "Class" + tag;
+        }
+        return tag;
+    }
+
+    @Override
+    public String toApiName(String name) {
+        return Utils.toApiName(name, apiNamePrefix, apiNameSuffix);
+    }
+
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co,
                                     Map<String, List<CodegenOperation>> operations) {
@@ -683,7 +699,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             return;
         }
 
-        super.addOperationToGroup(super.sanitizeTag(tag), resourcePath, operation, co, operations);
+        super.addOperationToGroup(superSanitizeTag(tag), resourcePath, operation, co, operations);
     }
 
     @Override
@@ -717,7 +733,9 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         }
 
         var inlineModelResolver = new MicronautInlineModelResolver(openAPI);
-        inlineModelResolver.flattenPaths();
+        inlineModelResolver.setInlineSchemaNameMapping(inlineSchemaNameMapping);
+        inlineModelResolver.setInlineSchemaOptions(inlineSchemaOption);
+        inlineModelResolver.flatten();
 
         super.preprocessOpenAPI(openAPI);
     }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
@@ -248,4 +248,11 @@ public final class Utils {
             varMap.put("strValue", value);
         }
     }
+
+    public static String toApiName(String name, String prefix, String suffix) {
+        if (name.isEmpty()) {
+            return "DefaultApi";
+        }
+        return prefix + name + suffix;
+    }
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
@@ -4,12 +4,6 @@ package {{package}};
 import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.*;
 import io.micronaut.http.client.annotation.Client;
-{{#micronaut_serde_jackson}}
-import io.micronaut.serde.annotation.Serdeable;
-{{/micronaut_serde_jackson}}
-{{#jackson}}
-import com.fasterxml.jackson.annotation.*;
-{{/jackson}}
 {{#configureAuth}}
 import {{invokerPackage}}.auth.Authorization;
 {{/configureAuth}}
@@ -28,12 +22,9 @@ import {{import}};
 import {{javaxPackage}}.annotation.Generated;
 {{/generatedAnnotation}}
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.validation.constraints.*;
@@ -84,29 +75,6 @@ public interface {{classname}} {
         {{#formatSingleLine}}{{>client/params/queryParams}}{{>client/params/pathParams}}{{>client/params/headerParams}}{{>client/params/bodyParams}}{{>client/params/formParams}}{{>client/params/cookieParams}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}});
     {{/formatNoEmptyLines}}
-    {{/operation}}
-{{/operations}}
-
-{{#operations}}
-    {{#operation}}
-        {{#allParams}}
-            {{#items}}
-                {{#isEnum}}
-                    {{^isContainer}}
-                        {{#indent}}
-                            {{>common/model/enum}}
-                        {{/indent}}
-                    {{/isContainer}}
-                    {{#isContainer}}
-                        {{#mostInnerItems}}
-                            {{#indent}}
-                                {{>common/model/enum}}
-                            {{/indent}}
-                        {{/mostInnerItems}}
-                    {{/isContainer}}
-                {{/isEnum}}
-            {{/items}}
-        {{/allParams}}
     {{/operation}}
 {{/operations}}
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
@@ -4,12 +4,6 @@ package {{apiPackage}};
 import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
-{{#micronaut_serde_jackson}}
-import io.micronaut.serde.annotation.Serdeable;
-{{/micronaut_serde_jackson}}
-{{#jackson}}
-import com.fasterxml.jackson.annotation.*;
-{{/jackson}}
 {{#useAuth}}
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
@@ -28,12 +22,9 @@ import {{import}};
 import {{javaxPackage}}.annotation.Generated;
 {{/generatedAnnotation}}
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.Valid;
 import {{javaxPackage}}.validation.constraints.*;
@@ -86,29 +77,6 @@ public interface {{classname}} {
     {{/allParams}});
         {{/formatNoEmptyLines}}
 
-    {{/operation}}
-{{/operations}}
-
-{{#operations}}
-    {{#operation}}
-        {{#allParams}}
-            {{#items}}
-                {{#isEnum}}
-                    {{^isContainer}}
-                        {{#indent}}
-                            {{>common/model/enum}}
-                        {{/indent}}
-                    {{/isContainer}}
-                    {{#isContainer}}
-                        {{#mostInnerItems}}
-                            {{#indent}}
-                                {{>common/model/enum}}
-                            {{/indent}}
-                        {{/mostInnerItems}}
-                    {{/isContainer}}
-                {{/isEnum}}
-            {{/items}}
-        {{/allParams}}
     {{/operation}}
 {{/operations}}
 }

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
@@ -4,12 +4,6 @@ package {{package}}
 import io.micronaut.http.annotation.*
 import io.micronaut.core.annotation.*
 import io.micronaut.http.client.annotation.Client
-{{#micronaut_serde_jackson}}
-import io.micronaut.serde.annotation.Serdeable
-{{/micronaut_serde_jackson}}
-{{#jackson}}
-import com.fasterxml.jackson.annotation.*
-{{/jackson}}
 {{#configureAuth}}
 import {{invokerPackage}}.auth.Authorization
 {{/configureAuth}}
@@ -73,29 +67,6 @@ interface {{classname}} {
         {{#formatSingleLine}}{{>client/params/queryParams}}{{>client/params/pathParams}}{{>client/params/headerParams}}{{>client/params/bodyParams}}{{>client/params/formParams}}{{>client/params/cookieParams}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}}){{#returnType}}: {{{returnType}}}{{/returnType}}
     {{/formatNoEmptyLines}}
-    {{/operation}}
-{{/operations}}
-
-{{#operations}}
-    {{#operation}}
-        {{#allParams}}
-            {{#items}}
-                {{#isEnum}}
-                    {{^isContainer}}
-                        {{#indent}}
-                            {{>common/model/enum}}
-                        {{/indent}}
-                    {{/isContainer}}
-                    {{#isContainer}}
-                        {{#mostInnerItems}}
-                            {{#indent}}
-                                {{>common/model/enum}}
-                            {{/indent}}
-                        {{/mostInnerItems}}
-                    {{/isContainer}}
-                {{/isEnum}}
-            {{/items}}
-        {{/allParams}}
     {{/operation}}
 {{/operations}}
 }

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/enum.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/enum.mustache
@@ -16,7 +16,7 @@
 {{#additionalEnumTypeAnnotations}}
 {{{.}}}
 {{/additionalEnumTypeAnnotations}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{#formatSingleLine}}enum class {{>common/model/enumName}}{{/formatSingleLine}} (
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#formatSingleLine}}enum class {{>common/model/enumName}}{{/formatSingleLine}}(
     @get:JsonValue val value: {{{dataType}}}
 ) {
 

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
@@ -4,19 +4,10 @@ package {{apiPackage}}
 import io.micronaut.http.annotation.*
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.convert.format.Format
-{{#micronaut_serde_jackson}}
-import io.micronaut.serde.annotation.Serdeable
-{{/micronaut_serde_jackson}}
-{{#jackson}}
-import com.fasterxml.jackson.annotation.*
-{{/jackson}}
 {{#useAuth}}
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 {{/useAuth}}
-{{#reactive}}
-import reactor.core.publisher.Flux
-{{/reactive}}
 {{#wrapInHttpResponse}}
 import io.micronaut.http.HttpResponse
 {{/wrapInHttpResponse}}
@@ -75,29 +66,6 @@ interface {{classname}} {
     {{/allParams}}){{#returnType}}: {{{returnType}}}{{/returnType}}
         {{/formatNoEmptyLines}}
 
-    {{/operation}}
-{{/operations}}
-
-{{#operations}}
-    {{#operation}}
-        {{#allParams}}
-            {{#items}}
-                {{#isEnum}}
-                    {{^isContainer}}
-                        {{#indent}}
-                            {{>common/model/enum}}
-                        {{/indent}}
-                    {{/isContainer}}
-                    {{#isContainer}}
-                        {{#mostInnerItems}}
-                            {{#indent}}
-                                {{>common/model/enum}}
-                            {{/indent}}
-                        {{/mostInnerItems}}
-                    {{/isContainer}}
-                {{/isEnum}}
-            {{/items}}
-        {{/allParams}}
     {{/operation}}
 {{/operations}}
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -436,8 +436,10 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "api/WeatherForecastApisApi.java", "@Get(\"/v1/forecast/{id}\")",
                 "@PathVariable(\"id\") @NotNull String id,",
-                "@QueryValue(\"hourly\") @Nullable List<@NotNull HourlyEnum> hourly,",
-                "public enum HourlyEnum {",
+                "@QueryValue(\"hourly\") @Nullable List<V1ForecastIdGetHourlyParameterInner> hourly,");
+
+        assertFileContains(path + "model/V1ForecastIdGetHourlyParameterInner.java",
+                "public enum V1ForecastIdGetHourlyParameterInner {",
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
     }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -428,8 +428,10 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "api/WeatherForecastApisApi.java", "@Get(\"/v1/forecast/{id}\")",
                 "@PathVariable(\"id\") @NotNull String id,",
-                "@QueryValue(\"hourly\") @Nullable(inherited = true) List<@NotNull HourlyEnum> hourly,",
-                "public enum HourlyEnum {",
+                "@QueryValue(\"hourly\") @Nullable(inherited = true) List<V1ForecastIdGetHourlyParameterInner> hourly,");
+
+        assertFileContains(path + "model/V1ForecastIdGetHourlyParameterInner.java",
+                "public enum V1ForecastIdGetHourlyParameterInner {",
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
     }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -491,10 +491,12 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/openmeteo.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
-        assertFileContains(path + "api/WeatherForecastAPIsApi.kt", "@Get(\"/v1/forecast/{id}\")",
+        assertFileContains(path + "api/WeatherForecastApisApi.kt", "@Get(\"/v1/forecast/{id}\")",
                 "@PathVariable(\"id\") @NotNull id: String,",
-                "@QueryValue(\"hourly\") @Nullable hourly: List<@NotNull Hourly>?,",
-                "enum class Hourly (",
+                "@QueryValue(\"hourly\") @Nullable hourly: List<V1ForecastIdGetHourlyParameterInner>?,");
+
+        assertFileContains(path + "model/V1ForecastIdGetHourlyParameterInner.kt",
+                "enum class V1ForecastIdGetHourlyParameterInner(",
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
     }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -518,10 +518,12 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/openmeteo.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
-        assertFileContains(path + "api/WeatherForecastAPIsApi.kt", "@Get(\"/v1/forecast/{id}\")",
+        assertFileContains(path + "api/WeatherForecastApisApi.kt", "@Get(\"/v1/forecast/{id}\")",
                 "@PathVariable(\"id\") @NotNull id: String,",
-                "@QueryValue(\"hourly\") @Nullable hourly: List<@NotNull Hourly>?,",
-                "enum class Hourly (",
+                "@QueryValue(\"hourly\") @Nullable hourly: List<V1ForecastIdGetHourlyParameterInner>?,");
+
+        assertFileContains(path + "model/V1ForecastIdGetHourlyParameterInner.kt",
+                "enum class V1ForecastIdGetHourlyParameterInner(",
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
     }


### PR DESCRIPTION
This is more corect solution for openapi generator problem. This is fix for bug in openap genertor: problem with parameters, when it collection of enum - openapi generator lost this enum and don't generate it. Yesterday I fixed it with internal enums inside client interfaces and controller interfaces, this solution works, but it's not entirely correct. It is necessary to create separate files for such enums so that this logic does not differ from the rest. Today I fixed` openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautInlineModelResolver.java` - Now it handles this case correctly.