### PR TITLE
Add support extra annotations for kotlin generated code

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -59,7 +59,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.micronaut.openapi.generator.Utils.DEFAULT_BODY_PARAM_NAME;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_CLASS;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_FIELD;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_OPERATION;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_SETTER;
 import static io.micronaut.openapi.generator.Utils.addStrValueToEnum;
+import static io.micronaut.openapi.generator.Utils.normalizeExtraAnnotations;
 import static io.micronaut.openapi.generator.Utils.processGenericAnnotations;
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -795,6 +800,8 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
                     || op.httpMethod.equals("DELETE")
             );
 
+            normalizeExtraAnnotations(EXT_ANNOTATIONS_OPERATION, false, op.vendorExtensions);
+
             // Set response example
             if (op.returnType != null) {
                 String example;
@@ -1199,6 +1206,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             model.vendorExtensions.put("areRequiredVarsAndReadOnlyVars", !requiredVarsWithoutDiscriminator.isEmpty() && !model.readOnlyVars.isEmpty());
             model.vendorExtensions.put("serialId", random.nextLong());
             model.vendorExtensions.put("withRequiredVars", !model.requiredVars.isEmpty());
+            normalizeExtraAnnotations(EXT_ANNOTATIONS_CLASS, false, model.vendorExtensions);
             if (model.discriminator != null) {
                 model.vendorExtensions.put("hasMappedModels", !model.discriminator.getMappedModels().isEmpty());
                 model.vendorExtensions.put("hasMultipleMappedModels", model.discriminator.getMappedModels().size() > 1);
@@ -1235,6 +1243,9 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         }
 
         processGenericAnnotations(property, useBeanValidation, isGenerateHardNullable(), false, false, false, false);
+
+        normalizeExtraAnnotations(EXT_ANNOTATIONS_FIELD, false, property.vendorExtensions);
+        normalizeExtraAnnotations(EXT_ANNOTATIONS_SETTER, false, property.vendorExtensions);
     }
 
     public boolean isGenerateHardNullable() {

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
@@ -68,7 +68,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.micronaut.openapi.generator.Utils.DEFAULT_BODY_PARAM_NAME;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_CLASS;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_FIELD;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_OPERATION;
+import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_SETTER;
 import static io.micronaut.openapi.generator.Utils.addStrValueToEnum;
+import static io.micronaut.openapi.generator.Utils.normalizeExtraAnnotations;
 import static io.micronaut.openapi.generator.Utils.processGenericAnnotations;
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 import static org.openapitools.codegen.languages.KotlinClientCodegen.DATE_LIBRARY;
@@ -790,6 +795,8 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 || op.httpMethod.equals("DELETE")
             );
 
+            normalizeExtraAnnotations(EXT_ANNOTATIONS_OPERATION, true, op.vendorExtensions);
+
             // Set response example
             if (op.returnType != null) {
                 String example;
@@ -1300,6 +1307,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             model.vendorExtensions.put("optionalVars", optionalVars);
             model.vendorExtensions.put("serialId", random.nextLong());
             model.vendorExtensions.put("withRequiredVars", !model.requiredVars.isEmpty());
+            normalizeExtraAnnotations(EXT_ANNOTATIONS_CLASS, true, model.vendorExtensions);
             if (model.discriminator != null) {
                 model.vendorExtensions.put("hasMappedModels", !model.discriminator.getMappedModels().isEmpty());
                 model.discriminator.getVendorExtensions().put("hasMappedModels", !model.discriminator.getMappedModels().isEmpty());
@@ -1335,6 +1343,9 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
 
         processGenericAnnotations(property, useBeanValidation, false, property.isNullable || property.isDiscriminator,
             property.required, property.isReadOnly, true);
+
+        normalizeExtraAnnotations(EXT_ANNOTATIONS_FIELD, true, property.vendorExtensions);
+        normalizeExtraAnnotations(EXT_ANNOTATIONS_SETTER, true, property.vendorExtensions);
     }
 
     private void processParentModel(CodegenModel model, List<CodegenProperty> requiredVarsWithoutDiscriminator,

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
@@ -71,6 +71,9 @@ public interface {{classname}} {
             {{/authMethods}}
         {{/configureAuth}}
     {{!the method definition}}
+    {{#vendorExtensions.x-operation-extra-annotation}}
+    {{{.}}}
+    {{/vendorExtensions.x-operation-extra-annotation}}
     {{^returnType}}void{{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}} {{nickname}}({{#allParams}}
         {{#formatSingleLine}}{{>client/params/queryParams}}{{>client/params/pathParams}}{{>client/params/headerParams}}{{>client/params/bodyParams}}{{>client/params/formParams}}{{>client/params/cookieParams}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}});

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/model/pojo.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/model/pojo.mustache
@@ -49,7 +49,7 @@
     {{/micronaut_serde_jackson}}
 {{/useBeanValidation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 {{!Declare the class with extends and implements}}
 public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
@@ -110,7 +110,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
             {{/jackson}}
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
         {{#vendorExtensions.x-field-extra-annotation}}
-    {{{vendorExtensions.x-field-extra-annotation}}}
+    {{{.}}}
         {{/vendorExtensions.x-field-extra-annotation}}
         {{#vendorExtensions.x-is-jackson-optional-nullable}}
             {{#isContainer}}
@@ -173,7 +173,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
      * @return the {{name}} property value
      */
     {{#vendorExtensions.x-extra-annotation}}
-        {{{vendorExtensions.x-extra-annotation}}}
+    {{{.}}}
     {{/vendorExtensions.x-extra-annotation}}
     public {{{datatypeWithEnum}}} {{getter}}() {
         {{#vendorExtensions.x-is-jackson-optional-nullable}}
@@ -219,7 +219,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
      * Set the {{name}} property value
      */
         {{#vendorExtensions.x-setter-extra-annotation}}
-    {{{vendorExtensions.x-setter-extra-annotation}}}
+    {{{.}}}
         {{/vendorExtensions.x-setter-extra-annotation}}
     public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
             {{#vendorExtensions.x-is-jackson-optional-nullable}}

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
@@ -72,6 +72,9 @@ public interface {{classname}} {
     @Secured({{#vendorExtensions.x-roles.1}}{{openbrace}}{{/vendorExtensions.x-roles.1}}{{#vendorExtensions.x-roles}}{{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-roles}}{{#vendorExtensions.x-roles.1}}{{closebrace}}{{/vendorExtensions.x-roles.1}})
     {{/useAuth}}
     {{!the method definition}}
+    {{#vendorExtensions.x-operation-extra-annotation}}
+    {{{.}}}
+    {{/vendorExtensions.x-operation-extra-annotation}}
     {{^returnType}}void{{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}} {{nickname}}({{#allParams}}
         {{#formatSingleLine}}{{>server/params/annotations}}{{#indent}}{{>common/params/validation}}{{/indent}}{{>server/params/type}} {{paramName}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}});

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
@@ -63,6 +63,9 @@ interface {{classname}} {
             {{/authMethods}}
         {{/configureAuth}}
     {{!the method definition}}
+    {{#vendorExtensions.x-operation-extra-annotation}}
+    {{{.}}}
+    {{/vendorExtensions.x-operation-extra-annotation}}
     fun {{nickname}}({{#allParams}}
         {{#formatSingleLine}}{{>client/params/queryParams}}{{>client/params/pathParams}}{{>client/params/headerParams}}{{>client/params/bodyParams}}{{>client/params/formParams}}{{>client/params/cookieParams}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}}){{#returnType}}: {{{returnType}}}{{/returnType}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/field_annotations.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/field_annotations.mustache
@@ -32,3 +32,9 @@
 {{>common/model/jackson_annotations}}
     {{/jackson}}
 {{/vendorExtensions.x-is-jackson-optional-nullable}}
+{{#vendorExtensions.x-field-extra-annotation}}
+    {{{.}}}
+{{/vendorExtensions.x-field-extra-annotation}}
+{{#vendorExtensions.x-setter-extra-annotation}}
+    {{{.}}}
+{{/vendorExtensions.x-setter-extra-annotation}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/pojo.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/pojo.mustache
@@ -43,7 +43,7 @@
     {{/micronaut_serde_jackson}}
 {{/useBeanValidation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 {{/formatNoEmptyLines}}
 {{!Declare the class with extends and implements}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
@@ -61,6 +61,9 @@ interface {{classname}} {
     @Secured({{#vendorExtensions.x-roles}}{{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-roles}})
     {{/useAuth}}
     {{!the method definition}}
+    {{#vendorExtensions.x-operation-extra-annotation}}
+    {{{.}}}
+    {{/vendorExtensions.x-operation-extra-annotation}}
     fun {{nickname}}({{#allParams}}
         {{#formatSingleLine}}{{>server/params/annotations}}{{#indent}}{{>common/params/validation}}{{/indent}}{{#isDateTime}}{{#dateFormat}}@Format("{{{datetimeFormat}}}"){{/dateFormat}}{{/isDateTime}}{{#isDate}}{{#dateTimeFormat}}@Format("{{{dateFormat}}}"){{/dateTimeFormat}}{{/isDate}} {{{paramName}}}: {{#isEnum}}{{{vendorExtensions.typeWithEnumWithGenericAnnotations}}}{{/isEnum}}{{^isEnum}}{{{vendorExtensions.typeWithGenericAnnotations}}}{{/isEnum}}{{^-last}},{{/-last}}{{/formatSingleLine}}
     {{/allParams}}){{#returnType}}: {{{returnType}}}{{/returnType}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -20,9 +20,9 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void clientOptsUnicity() {
         var codegen = new JavaMicronautClientCodegen();
         codegen.cliOptions()
-            .stream()
-            .collect(groupingBy(CliOption::getOpt))
-            .forEach((k, v) -> assertEquals(v.size(), 1, k + " is described multiple times"));
+                .stream()
+                .collect(groupingBy(CliOption::getOpt))
+                .forEach((k, v) -> assertEquals(v.size(), 1, k + " is described multiple times"));
     }
 
     @Test
@@ -52,9 +52,9 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "org.test.test.model");
         codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "org.test.test.api");
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.APIS,
-            CodegenConstants.MODELS);
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.APIS,
+                CodegenConstants.MODELS);
 
         String apiFolder = outputPath + "src/main/java/org/test/test/api/";
         assertFileExists(apiFolder + "PetApi.java");
@@ -75,8 +75,8 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.OPT_CONFIGURE_AUTH, "true");
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.APIS);
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.APIS);
 
         // Files generated
         assertFileExists(outputPath + "/src/main/java/org/openapitools/auth/Authorization.java");
@@ -89,8 +89,8 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.OPT_CONFIGURE_AUTH, "false");
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.APIS);
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.APIS);
 
         // Files are not generated
         assertFileNotExists(outputPath + "/src/main/java/org/openapitools/auth/");
@@ -102,7 +102,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.USE_BEANVALIDATION, "true");
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.APIS);
+                CodegenConstants.APIS);
 
         // Files are not generated
         assertFileContains(outputPath + "/src/main/java/org/openapitools/api/PetApi.java", "@Valid");
@@ -114,7 +114,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.USE_BEANVALIDATION, "false");
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.APIS);
+                CodegenConstants.APIS);
 
         // Files are not generated
         assertFileNotContains(outputPath + "/src/main/java/org/openapitools/api/PetApi.java", "@Valid");
@@ -125,10 +125,10 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void doGenerateForTestJUnit() {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.OPT_TEST,
-            JavaMicronautClientCodegen.OPT_TEST_JUNIT);
+                JavaMicronautClientCodegen.OPT_TEST_JUNIT);
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.API_TESTS, CodegenConstants.APIS, CodegenConstants.MODELS);
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.API_TESTS, CodegenConstants.APIS, CodegenConstants.MODELS);
 
         // Files are not generated
         assertFileExists(outputPath + "src/test/java/");
@@ -140,10 +140,10 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void doGenerateForTestSpock() {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.OPT_TEST,
-            JavaMicronautClientCodegen.OPT_TEST_SPOCK);
+                JavaMicronautClientCodegen.OPT_TEST_SPOCK);
         String outputPath = generateFiles(codegen, PETSTORE_PATH,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.API_TESTS, CodegenConstants.APIS, CodegenConstants.MODELS);
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.API_TESTS, CodegenConstants.APIS, CodegenConstants.MODELS);
 
         // Files are not generated
         assertFileExists(outputPath + "src/test/groovy");
@@ -208,7 +208,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         // Micronaut declarative http client should contain custom added annotations
         assertFileContains(outputPath + "/src/main/java/org/openapitools/api/PetApi.java",
-            "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
+                "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
     }
 
     @Test
@@ -219,7 +219,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         // Micronaut declarative http client should contain custom added annotations
         assertFileContains(outputPath + "/src/main/java/org/openapitools/api/PetApi.java",
-            "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
+                "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
     }
 
     @Test
@@ -312,10 +312,10 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String apiPath = outputPath + "src/main/java/org/openapitools/model/";
 
         assertFileContains(apiPath + "BooksContainer.java",
-            """
-                    @JsonProperty(JSON_PROPERTY_BOOKS)
-                    private List<@Valid Book> books;
-                """);
+                """
+                            @JsonProperty(JSON_PROPERTY_BOOKS)
+                            private List<@Valid Book> books;
+                        """);
     }
 
     @Test
@@ -337,7 +337,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(JavaMicronautClientCodegen.OPT_CONFIGURE_AUTH, "true");
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/discriminatorconstructorbug.yml",
-            CodegenConstants.MODELS
+                CodegenConstants.MODELS
         );
         String apiPath = outputPath + "src/main/java/org/openapitools/model/";
 
@@ -363,15 +363,15 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
 
         assertFileContains(
-            modelPath + "Book.java",
-            "public static final String JSON_PROPERTY_TITLE = \"tItle\";",
-            "public static final String JSON_PROPERTY_I_S_B_N = \"ISBN\";",
-            "private String title;",
-            "public String getTitle()",
-            "public void setTitle(String title)",
-            "private String ISBN;",
-            "public String getISBN()",
-            "public void setISBN(String ISBN)"
+                modelPath + "Book.java",
+                "public static final String JSON_PROPERTY_TITLE = \"tItle\";",
+                "public static final String JSON_PROPERTY_I_S_B_N = \"ISBN\";",
+                "private String title;",
+                "public String getTitle()",
+                "public void setTitle(String title)",
+                "private String ISBN;",
+                "public String getISBN()",
+                "public void setISBN(String ISBN)"
         );
     }
 
@@ -396,9 +396,9 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String modelPath = outputPath + "src/main/java/org/openapitools/model/";
 
         assertFileContains(modelPath + "MyModel.java", "private BigDecimal _default;",
-            "public static final String JSON_PROPERTY_DEFAULT = \"_default\";",
-            "public BigDecimal get_default() {",
-            "public void set_default(BigDecimal _default) {");
+                "public static final String JSON_PROPERTY_DEFAULT = \"_default\";",
+                "public BigDecimal get_default() {",
+                "public void set_default(BigDecimal _default) {");
     }
 
     @Test
@@ -406,25 +406,25 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         var codegen = new JavaMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/javaReservedWords.yml",
-            CodegenConstants.APIS,
-            CodegenConstants.MODELS,
-            CodegenConstants.SUPPORTING_FILES,
-            CodegenConstants.MODEL_TESTS,
-            CodegenConstants.MODEL_DOCS,
-            CodegenConstants.API_TESTS,
-            CodegenConstants.API_DOCS
+                CodegenConstants.APIS,
+                CodegenConstants.MODELS,
+                CodegenConstants.SUPPORTING_FILES,
+                CodegenConstants.MODEL_TESTS,
+                CodegenConstants.MODEL_DOCS,
+                CodegenConstants.API_TESTS,
+                CodegenConstants.API_DOCS
         );
         String path = outputPath + "src/main/java/org/openapitools/";
 
         assertFileContains(path + "api/ParametersApi.java", "Mono<Void> callInterface(",
-            "@QueryValue(\"class\") @NotNull @Valid Package propertyClass,",
-            "@QueryValue(\"while\") @NotNull String _while");
+                "@QueryValue(\"class\") @NotNull @Valid Package propertyClass,",
+                "@QueryValue(\"while\") @NotNull String _while");
         assertFileContains(path + "model/Package.java",
-            "public static final String JSON_PROPERTY_FOR = \"for\";",
-            "@JsonProperty(JSON_PROPERTY_FOR)",
-            "private String _for;",
-            "public String get_for() {",
-            "public void set_for(String _for) {");
+                "public static final String JSON_PROPERTY_FOR = \"for\";",
+                "@JsonProperty(JSON_PROPERTY_FOR)",
+                "private String _for;",
+                "public String get_for() {",
+                "public void set_for(String _for) {");
     }
 
     @Test
@@ -442,5 +442,40 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 "public enum V1ForecastIdGetHourlyParameterInner {",
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
+    }
+
+    @Test
+    void testExtraAnnotations() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
+        String path = outputPath + "src/main/java/org/openapitools/";
+
+        assertFileContains(path + "api/BooksApi.java",
+                """
+                            @Post("/add-book")
+                            @NotBlank
+                            Mono<@Valid Book> addBook(
+                        """);
+
+        assertFileContains(path + "model/Book.java",
+                """
+                        @Serializable
+                        public class Book {
+                        """,
+                """
+                            @NotNull
+                            @Size(max = 10)
+                            @JsonProperty(JSON_PROPERTY_TITLE)
+                            @jakarta.validation.constraints.NotBlank
+                            private String title;
+                        """,
+                """
+                            @NotEmpty
+                            public void setTitle(String title) {
+                                this.title = title;
+                            }
+                        """
+        );
     }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -164,7 +164,7 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
     }
 
     @Test
-    void testExtraAnnotations() {
+    void testExtraAnnotations1() {
         var codegen = new JavaMicronautServerCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/issue_11772.yml", CodegenConstants.MODELS);
 
@@ -444,5 +444,42 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
         String path = outputPath + "src/main/java/org/openapitools/";
 
         assertFileContains(path + "api/ResponseBodyApi.java", "@ApiResponse(responseCode = \"default\", description = \"An unexpected error has occurred\")");
+    }
+
+    @Test
+    void testExtraAnnotations() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
+        String path = outputPath + "src/main/java/org/openapitools/";
+
+        assertFileContains(path + "api/BooksApi.java",
+                """
+                            @Post("/add-book")
+                            @Secured(SecurityRule.IS_ANONYMOUS)
+                            @NotBlank
+                            Mono<@Valid Book> addBook(
+                        """);
+
+        assertFileContains(path + "model/Book.java",
+                """
+                        @Serializable
+                        public class Book {
+                        """,
+                """
+                            @NotNull
+                            @Size(max = 10)
+                            @Schema(name = "title", requiredMode = Schema.RequiredMode.REQUIRED)
+                            @JsonProperty(JSON_PROPERTY_TITLE)
+                            @jakarta.validation.constraints.NotBlank
+                            private String title;
+                        """,
+                """
+                            @NotEmpty
+                            public void setTitle(String title) {
+                                this.title = title;
+                            }
+                        """
+        );
     }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -500,4 +500,31 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 "@JsonProperty(\"temperature_2m\")",
                 "TEMPERATURE_2M(\"temperature_2m\"),");
     }
+
+    @Test
+    void testExtraAnnotations() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
+        String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFileContains(path + "api/BooksApi.kt",
+                """
+                            @Post("/add-book")
+                            @NotBlank
+                            fun addBook(
+                        """);
+
+        assertFileContains(path + "model/Book.kt",
+                """
+                        @Serializable
+                        data class Book(
+                            @field:NotNull
+                            @field:Size(max = 10)
+                            @field:JsonProperty(JSON_PROPERTY_TITLE)
+                            @field:jakarta.validation.constraints.NotBlank
+                            @set:NotEmpty
+                            var title: String,
+                        """);
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -537,4 +537,33 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "api/ResponseBodyApi.kt", "ApiResponse(responseCode = \"default\", description = \"An unexpected error has occurred\")");
     }
+
+    @Test
+    void testExtraAnnotations() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
+        String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFileContains(path + "api/BooksApi.kt",
+        """
+                    @Post("/add-book")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    @NotBlank
+                    fun addBook(
+                """);
+
+        assertFileContains(path + "model/Book.kt",
+        """
+                @Serializable
+                data class Book(
+                    @field:NotNull
+                    @field:Size(max = 10)
+                    @field:Schema(name = "title", requiredMode = Schema.RequiredMode.REQUIRED)
+                    @field:JsonProperty(JSON_PROPERTY_TITLE)
+                    @field:jakarta.validation.constraints.NotBlank
+                    @set:NotEmpty
+                    var title: String,
+                """);
+    }
 }

--- a/openapi-generator/src/test/resources/3_0/extra-annotations.yml
+++ b/openapi-generator/src/test/resources/3_0/extra-annotations.yml
@@ -1,0 +1,72 @@
+openapi: 3.0.0
+info:
+  description: This is a library API
+  version: 1.0.0
+  title: Library
+  license:
+    name: Apache-2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+tags:
+  - name: books
+    description: Add books
+paths:
+  /add-book:
+    post:
+      x-operation-extra-annotation:
+        - "@NotBlank"
+      tags: [books]
+      summary: Add a new book
+      operationId: addBook
+      requestBody:
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Book"
+      responses:
+        "200":
+          description: Success
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Book"
+        "400":
+          description: Bad Request
+components:
+  schemas:
+    Book:
+      type: object
+      x-class-extra-annotation:
+        - "@Serializable"
+      properties:
+        title:
+          x-field-extra-annotation: |-
+            @jakarta.validation.constraints.NotBlank
+          x-setter-extra-annotation:
+            - "@NotEmpty"
+          type: string
+          maxLength: 10
+      required:
+        - title
+    Books:
+      type: array
+      items:
+        $ref: "#/components/schemas/Book"
+    BookContainer:
+      type: object
+      properties:
+        book:
+          $ref: "#/components/schemas/Book"
+      required:
+        - book
+    BooksContainer:
+      type: object
+      properties:
+        books:
+          $ref: "#/components/schemas/Books"
+        strings:
+          type: array
+          items:
+            type: string
+      required:
+        - books


### PR DESCRIPTION
Supported options:
```
x-class-extra-annotation
x-operation-extra-annotation
x-field-extra-annotation
x-setter-extra-annotation
```

Fixed #1604