### PR TITLE
filter properties of type class

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -54,6 +54,7 @@ import io.micronaut.inject.ast.GenericElement;
 import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.inject.ast.PropertyElementQuery;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.ast.WildcardElement;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -2721,7 +2722,13 @@ abstract class AbstractOpenApiVisitor {
         if (classElement != null && !ClassUtils.isJavaLangType(classElement.getName())) {
             List<PropertyElement> beanProperties;
             try {
-                beanProperties = classElement.getBeanProperties().stream()
+                beanProperties = classElement.getBeanProperties(
+                        PropertyElementQuery.of(classElement)
+                            .excludedAnnotations(Set.of(
+                                Hidden.class.getName(),
+                                JsonIgnore.class.getName()
+                            ))
+                    ).stream()
                     .filter(p -> !"groovy.lang.MetaClass".equals(p.getType().getName()))
                     .toList();
             } catch (Exception e) {
@@ -2794,14 +2801,7 @@ abstract class AbstractOpenApiVisitor {
         }
 
         for (TypedElement publicField : publicFields) {
-            boolean isHidden = getAnnotationMetadata(publicField).booleanValue(io.swagger.v3.oas.annotations.media.Schema.class, PROP_HIDDEN).orElse(false);
-            var jsonAnySetterAnn = getAnnotation(publicField, JsonAnySetter.class);
-            if (isAnnotationPresent(publicField, JsonIgnore.class)
-                || isAnnotationPresent(publicField, Hidden.class)
-                || (jsonAnySetterAnn != null && jsonAnySetterAnn.booleanValue("enabled").orElse(true))
-                || isHidden) {
-                continue;
-            }
+            if (isHiddenElement(publicField)) continue;
 
             var isGetterOverridden = false;
             JavadocDescription fieldJavadoc = null;
@@ -2847,6 +2847,17 @@ abstract class AbstractOpenApiVisitor {
                 );
             }
         }
+    }
+
+    private static boolean isHiddenElement(TypedElement elementType) {
+        boolean isHidden = getAnnotationMetadata(elementType)
+            .booleanValue(io.swagger.v3.oas.annotations.media.Schema.class, PROP_HIDDEN).orElse(false);
+        var jsonAnySetterAnn = getAnnotation(elementType, JsonAnySetter.class);
+        return elementType.getType().isAssignable(Class.class)
+                || isAnnotationPresent(elementType, JsonIgnore.class)
+                || isAnnotationPresent(elementType, Hidden.class)
+                || (jsonAnySetterAnn != null && jsonAnySetterAnn.booleanValue("enabled").orElse(true))
+                || isHidden;
     }
 
     private boolean allowedByJsonView(TypedElement publicField, String[] classLvlJsonViewClasses, ClassElement jsonViewClassEl, VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiVisitor.java
@@ -2729,7 +2729,10 @@ abstract class AbstractOpenApiVisitor {
                                 JsonIgnore.class.getName()
                             ))
                     ).stream()
-                    .filter(p -> !"groovy.lang.MetaClass".equals(p.getType().getName()))
+                    .filter(p ->
+                        !"groovy.lang.MetaClass".equals(p.getType().getName())
+                            && !"java.lang.Class".equals(p.getType().getName())
+                    )
                     .toList();
             } catch (Exception e) {
                 warn("Error with getting properties for class " + classElement.getName() + ": " + e + "\n" + Utils.printStackTrace(e), context, classElement);

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiClassPropertySpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiClassPropertySpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.swagger.v3.oas.models.OpenAPI
+
+class OpenApiClassPropertySpec extends AbstractOpenApiTypeElementSpec {
+    void "test class property is not exposed"() {
+
+        when:
+        buildBeanDefinition("test.MyBean", '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import jakarta.validation.constraints.*;
+
+@Controller
+class PersonController {
+
+    @Get("/person/{name}")
+    HttpResponse<Person> get(@NotBlank String name) {
+        return HttpResponse.ok();
+    }
+}
+
+/**
+ * The person information.
+ */
+@Introspected
+class Person {
+
+    private String name;
+    private Class<?> personClass;
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setPersonClass(Class<?> personClass) {
+        this.personClass = personClass;
+    }
+
+    public Class<?> getPersonClass() {
+        return personClass;
+    }
+}
+
+@jakarta.inject.Singleton
+public class MyBean {}
+
+''')
+
+        then:
+        OpenAPI openAPI = Utils.testReference
+        openAPI?.paths?.get("/person/{name}")?.get
+        openAPI.components.schemas["Person"]
+        openAPI.components.schemas["Person"].type == "object"
+
+        openAPI.components.schemas["Person"].properties
+        openAPI.components.schemas["Person"].properties.size() == 1
+
+        openAPI.components.schemas["Person"].properties["name"]
+    }
+}


### PR DESCRIPTION
exclude all properties of type `java.lang.Class` and filter `Hidden/JsonIgnore` earlier in property query.

Note this does not fix https://github.com/micronaut-projects/micronaut-core/issues/10955 but does correct the behaviour of attempting to expose a type that can never be supported.