### PR TITLE
Add tests for kotlin codegen with useAuth=true

### DIFF
--- a/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-kotlin-kapt-generator-test-suite.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.openapi-kotlin-kapt-generator-test-suite.gradle
@@ -26,6 +26,7 @@ def openapiGenerate = tasks.register("generateOpenApi", OpenApiGeneratorTask) {
     clientPath = true
     ksp = false
     useOneOfInterfaces = false
+    auth = true
     classpath.from(configurations.openapiGenerator)
     openApiDefinition.convention(layout.projectDirectory.file("petstore.json"))
     outputDirectory.convention(layout.buildDirectory.dir("generated/openapi"))

--- a/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
+++ b/build-logic/src/main/groovy/io/micronaut/build/internal/openapi/OpenApiGeneratorTask.java
@@ -76,6 +76,10 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
     @Input
     public abstract Property<String> getClientId();
 
+    @Input
+    @Optional
+    public abstract Property<Boolean> getAuth();
+
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
 
@@ -154,6 +158,7 @@ public abstract class OpenApiGeneratorTask extends DefaultTask {
             args.add(getApiNameSuffix().getOrElse(""));
             args.add(getModelNamePrefix().getOrElse(""));
             args.add(getModelNameSuffix().getOrElse(""));
+            args.add(Boolean.toString(getAuth().getOrElse(false)));
             javaexec.args(args);
         });
     }

--- a/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
+++ b/test-suite-generator-util/src/main/java/io/micronaut/openapi/testsuite/GeneratorMain.java
@@ -77,6 +77,7 @@ public class GeneratorMain {
         String apiSuffix = args[14];
         String modelPrefix = args[15];
         String modelSuffix = args[16];
+        var auth = Boolean.parseBoolean(args[17]);
 
         var builder = MicronautCodeGeneratorEntryPoint.builder()
             .withDefinitionFile(definitionFile)
@@ -108,7 +109,7 @@ public class GeneratorMain {
                         // commented out because currently this would prevent the test project from compiling
                         // because we generate both abstract classes _and_ dummy implementations
                         .withGenerateImplementationFiles(false)
-                        .withAuthentication(false)
+                        .withAuthentication(auth)
                         .withKsp(ksp)
                         .withGeneratedAnnotation(generatedAnnotation)
                 );
@@ -119,7 +120,7 @@ public class GeneratorMain {
                         // commented out because currently this would prevent the test project from compiling
                         // because we generate both abstract classes _and_ dummy implementations
                         .withGenerateImplementationFiles(false)
-                        .withAuthentication(false)
+                        .withAuthentication(auth)
                         .withGeneratedAnnotation(generatedAnnotation)
                 );
             }
@@ -129,6 +130,7 @@ public class GeneratorMain {
                     clientOptions
                         .withGeneratedAnnotation(generatedAnnotation)
                         .withKsp(ksp)
+                        .withAuthorization(auth)
                         .withClientPath(clientPath)
                         .withClientId(clientId)
                 );
@@ -137,6 +139,7 @@ public class GeneratorMain {
                     clientOptions
                         .withGeneratedAnnotation(generatedAnnotation)
                         .withClientPath(clientPath)
+                        .withAuthorization(auth)
                         .withClientId(clientId)
                 );
             }

--- a/test-suite-kotlin-kapt-client-generator/build.gradle
+++ b/test-suite-kotlin-kapt-client-generator/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation(mnReactor.micronaut.reactor)
     implementation(mn.kotlin.stdlib.jdk8)
     implementation(mn.kotlin.reflect)
+    // Required when using useAuth=true
+    implementation(mnSecurity.micronaut.security.oauth2)
 
     runtimeOnly(mnLogging.logback.classic)
 
@@ -31,7 +33,6 @@ dependencies {
     kaptTest(mn.micronaut.inject.kotlin)
 
     testImplementation(mnTest.micronaut.test.junit5)
-
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     testRuntimeOnly(mnTest.junit.jupiter.engine)
     testRuntimeOnly(mnLogging.logback.classic)

--- a/test-suite-kotlin-kapt-server-generator/build.gradle
+++ b/test-suite-kotlin-kapt-server-generator/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation(mnData.micronaut.data.runtime)
     implementation(mn.kotlin.stdlib.jdk8)
     implementation(mn.kotlin.reflect)
+    // Required when using useAuth=true
+    implementation(mnSecurity.micronaut.security.oauth2)
 
     runtimeOnly(mnLogging.logback.classic)
     runtimeOnly(mnSerde.micronaut.serde.jackson)

--- a/test-suite-kotlin-ksp-client-generator/build.gradle
+++ b/test-suite-kotlin-ksp-client-generator/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation(mnReactor.micronaut.reactor)
     implementation(mn.kotlin.stdlib.jdk8)
     implementation(mn.kotlin.reflect)
+    // Required when using useAuth=true
+    implementation(mnSecurity.micronaut.security.oauth2)
 
     runtimeOnly(mnLogging.logback.classic)
 


### PR DESCRIPTION
It appears I mistakenly thought useAuth was an issue still, but it was fixed in a snapshot version here https://github.com/micronaut-projects/micronaut-openapi/commit/67d070cbdca5ca64843852407ccc73450fbda30d#diff-7cfb23613bf087752f599c9d16a611129cea5cf45fbe23f22bafe3e0d6cbd750L35

For now tho, I'll keep my pr for adding Auth Based tests.

Fixes: #1665