### PR TITLE
Fix Kotlin useAuth runtime errors

### DIFF
--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/AuthorizationBinder.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/AuthorizationBinder.mustache
@@ -34,7 +34,7 @@ open class AuthorizationBinder : AnnotatedClientRequestBinder<Authorization> {
         if (annotations.isNotEmpty()) {
             val authorizationNames = ArrayList<String>()
             for (ann in annotations) {
-                ann.stringValue("name")
+                ann.stringValue("value")
                         .filter{ s -> !s.isNullOrEmpty() }
                         .ifPresent { v -> authorizationNames.add(configurationName(v)) }
             }

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
@@ -15,7 +15,8 @@ import {{javaxPackage}}.annotation.Generated
 {{>common/generatedAnnotation}}
 {{/generatedAnnotation}}
 @EachProperty("security.api-key-auth")
-data class ApiKeyAuthConfiguration(
+data class ApiKeyAuthConfiguration @ConfigurationInject
+constructor(
     @Parameter override val name: String,
     @NonNull var location: AuthKeyLocation,
     @NonNull var paramName: String,


### PR DESCRIPTION
Fixes: #1668


I'm having a hard time figuring out the best way to test Client Auth. These bugs do not happen until you populate your application configuration and things 
1. fail to load when you specify `ApiKeyAuthConfiguration` due to the NoBeanError
2. Doesn't find your tokens because the Authorization Class in Kotlin doesn't have a name member. I tried to do the alias thing like in the Java version, but I couldn't get it working.

Note: Followed guide for Immutable Data class option https://docs.micronaut.io/latest/guide/index.html#immutableConfig