### PR TITLE
Added schema duplication resolution mode

### DIFF
--- a/openapi/openapi-custom-schema-for-class.properties
+++ b/openapi/openapi-custom-schema-for-class.properties
@@ -1,5 +1,5 @@
-micronaut.openapi.schema.io.micronaut.openapi.ObjectId=java.lang.String
-micronaut.openapi.schema.io.micronaut.openapi.JAXBElement=io.micronaut.openapi.MyJaxbElement
-micronaut.openapi.schema.io.micronaut.openapi.JAXBElement<test.XmlElement2>=io.micronaut.openapi.MyJaxbElement2
-micronaut.openapi.schema.io.micronaut.openapi.JAXBElement<test.XmlElement3>=io.micronaut.openapi.MyJaxbElement3
-micronaut.openapi.schema.io.micronaut.openapi.JAXBElement<test.XmlElement4>=io.micronaut.openapi.MyJaxbElement4
+micronaut.openapi.schema.mapping.io.micronaut.openapi.ObjectId=java.lang.String
+micronaut.openapi.schema.mapping.io.micronaut.openapi.JAXBElement=io.micronaut.openapi.MyJaxbElement
+micronaut.openapi.schema.mapping.io.micronaut.openapi.JAXBElement<test.XmlElement2>=io.micronaut.openapi.MyJaxbElement2
+micronaut.openapi.schema.mapping.io.micronaut.openapi.JAXBElement<test.XmlElement3>=io.micronaut.openapi.MyJaxbElement3
+micronaut.openapi.schema.mapping.io.micronaut.openapi.JAXBElement<test.XmlElement4>=io.micronaut.openapi.MyJaxbElement4

--- a/openapi/openapi-custom-schema-for-iterable-class.properties
+++ b/openapi/openapi-custom-schema-for-iterable-class.properties
@@ -1,1 +1,1 @@
-micronaut.openapi.schema.io.micronaut.data.model.Page=io.micronaut.openapi.SwaggerPage
+micronaut.openapi.schema.mapping.io.micronaut.data.model.Page=io.micronaut.openapi.SwaggerPage

--- a/openapi/openapi-schema-decorators.properties
+++ b/openapi/openapi-schema-decorators.properties
@@ -1,2 +1,2 @@
-micronaut.openapi.schema-postfix.io.micronaut.openapi.api.v1_0_0=1_0_0
-micronaut.openapi.schema-postfix.io.micronaut.openapi.api.v2_0_1=2_0_1
+micronaut.openapi.schema.decorator.postfix.io.micronaut.openapi.api.v1_0_0=1_0_0
+micronaut.openapi.schema.decorator.postfix.io.micronaut.openapi.api.v2_0_1=2_0_1

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ContextProperty.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ContextProperty.java
@@ -112,7 +112,7 @@ public interface ContextProperty {
      */
     String MICRONAUT_INTERNAL_GENERATION_SPEC_ENABLED = "micronaut.internal.generation.spec.enabled";
     /**
-     * Loaded micronaut.openapi.extra.schema.enabled value.
+     * Loaded micronaut.openapi.schema.extra.enabled value.
      * <br>
      * Default: true
      */

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
@@ -28,32 +28,55 @@ import java.util.Set;
 public interface OpenApiConfigProperty {
 
     /**
+     * Properties prefix to set custom schema implementations for selected classes.
+     * For example, if you want to set simple 'java.lang.String' class to some complex 'org.somepackage.MyComplexType' class you need to write:
+     * <p>
+     * micronaut.openapi.schema.org.somepackage.MyComplexType=java.lang.String
+     * <p>
+     * Also, you can set it in your application.yml file like this:
+     * <p>
+     * micronaut:
+     * openapi:
+     * schema:
+     * org.somepackage.MyComplexType: java.lang.String
+     * org.somepackage.MyComplexType2: java.lang.Integer
+     * ...
+     *
+     * @deprecated Use `micronaut.openapi.schema.mapping` property instead
+     */
+    @Deprecated(forRemoval = true)
+    String MICRONAUT_OPENAPI_SCHEMA = "micronaut.openapi.schema";
+    /**
+     * Properties prefix to set schema name prefix or postfix by package.
+     * For example, if you have some classes with same names in different packages you can set postfix like this:
+     * <p>
+     * micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0
+     * micronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
+     * <p>
+     * Also, you can set it in your application.yml file like this:
+     * <p>
+     * micronaut:
+     * openapi:
+     * schema-postfix:
+     * org.api.v1_0_0: 1_0_0
+     * org.api.v2_0_0: 2_0_0
+     * ...
+     * @deprecated Use `micronaut.openapi.schema.decorator.prefix` property instead
+     */
+    @Deprecated(forRemoval = true)
+    String MICRONAUT_OPENAPI_SCHEMA_PREFIX = "micronaut.openapi.schema-prefix";
+    /**
+     * @deprecated Use `micronaut.openapi.schema.decorator.postfix` property instead
+     */
+    @Deprecated(forRemoval = true)
+    String MICRONAUT_OPENAPI_SCHEMA_POSTFIX = "micronaut.openapi.schema-postfix";
+
+    /**
      * System property that enables or disables open api annotation processing.
      * <br>
      * Default: true
      */
     String MICRONAUT_OPENAPI_ENABLED = "micronaut.openapi.enabled";
-    /**
-     * System property that enables or disables schema name separator for generics and inner classes.
-     * If it's true separators will be skipped. For example, schema name for class with name
-     * {@code MyClass.MyInnerClass<MyGeneric1, MyGeneric2>} will be
-     * {@code MyClassMyInnerClassMyGeneric1MyGeneric2}
-     * <br>
-     * Default: false
-     */
-    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_EMPTY = "micronaut.openapi.schema.name.separator.empty";
-    /**
-     * System property to set custom separator for generic classes. By default, it is "_".
-     * <br>
-     * Default: _
-     */
-    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_GENERIC = "micronaut.openapi.schema.name.separator.generic";
-    /**
-     * System property to set custom separator for inner classes. By default, it is ".".
-     * <br>
-     * Default: .
-     */
-    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_INNER_CLASS = "micronaut.openapi.schema.name.separator.inner-class";
     /**
      * System property that enables generating OpenAPI version 3.1.
      * <br>
@@ -68,10 +91,6 @@ public interface OpenApiConfigProperty {
      * System property that enables setting the open api config file.
      */
     String MICRONAUT_OPENAPI_CONFIG_FILE = "micronaut.openapi.config.file";
-    /**
-     * System property that enables extra schema processing.
-     */
-    String MICRONAUT_OPENAPI_EXTRA_SCHEMA_ENABLED = "micronaut.openapi.extra.schema.enabled";
     /**
      * Prefix for expandable properties.
      */
@@ -181,39 +200,79 @@ public interface OpenApiConfigProperty {
     String MICRONAUT_JACKSON_JSON_VIEW_ENABLED = "jackson.json-view.enabled";
 
     /**
+     * System property that enables extra schema processing.
+     */
+    String MICRONAUT_OPENAPI_SCHEMA_EXTRA_ENABLED = "micronaut.openapi.schema.extra.enabled";
+    /**
+     * System property to set schema duplicate resolution. Available values:
+     *  - auto - micronaut-openapi automatically add index suffix to duplicate schema.
+     *  - error - micronaut-openapi throws an exception when found duplicate schema.
+     * <br>
+     * Default: auto
+     */
+    String MICRONAUT_OPENAPI_SCHEMA_DUPLICATE_RESOLUTION = "micronaut.openapi.schema.duplicate-resolution";
+    /**
+     * System property that enables or disables schema name separator for generics and inner classes.
+     * If it's true separators will be skipped. For example, schema name for class with name
+     * {@code MyClass.MyInnerClass<MyGeneric1, MyGeneric2>} will be
+     * {@code MyClassMyInnerClassMyGeneric1MyGeneric2}
+     * <br>
+     * Default: false
+     */
+    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_EMPTY = "micronaut.openapi.schema.name.separator.empty";
+    /**
+     * System property to set custom separator for generic classes. By default, it is "_".
+     * <br>
+     * Default: _
+     */
+    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_GENERIC = "micronaut.openapi.schema.name.separator.generic";
+    /**
+     * System property to set custom separator for inner classes. By default, it is ".".
+     * <br>
+     * Default: .
+     */
+    String MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_INNER_CLASS = "micronaut.openapi.schema.name.separator.inner-class";
+
+    /**
      * Properties prefix to set custom schema implementations for selected classes.
      * For example, if you want to set simple 'java.lang.String' class to some complex 'org.somepackage.MyComplexType' class you need to write:
      * <p>
-     * micronaut.openapi.schema.org.somepackage.MyComplexType=java.lang.String
+     * micronaut.openapi.schema.mapping.org.somepackage.MyComplexType=java.lang.String
      * <p>
      * Also, you can set it in your application.yml file like this:
      * <p>
+     * <pre>
      * micronaut:
-     * openapi:
-     * schema:
-     * org.somepackage.MyComplexType: java.lang.String
-     * org.somepackage.MyComplexType2: java.lang.Integer
+     *   openapi:
+     *     schema:
+     *       mapping:
+     *         org.somepackage.MyComplexType: java.lang.String
+     *         org.somepackage.MyComplexType2: java.lang.Integer
+     * </pre>
      * ...
      */
-    String MICRONAUT_OPENAPI_SCHEMA = "micronaut.openapi.schema";
+    String MICRONAUT_OPENAPI_SCHEMA_MAPPING = "micronaut.openapi.schema.mapping";
     /**
      * Properties prefix to set schema name prefix or postfix by package.
      * For example, if you have some classes with same names in different packages you can set postfix like this:
      * <p>
-     * micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0
-     * micronaut.openapi.schema-postfix.org.api.v2_0_0=2_0_0
+     * micronaut.openapi.schema.decorator.postfix.org.api.v1_0_0=1_0_0
+     * micronaut.openapi.schema.decorator.postfix.org.api.v2_0_0=2_0_0
      * <p>
      * Also, you can set it in your application.yml file like this:
      * <p>
+     * <pre>
      * micronaut:
-     * openapi:
-     * schema-postfix:
-     * org.api.v1_0_0: 1_0_0
-     * org.api.v2_0_0: 2_0_0
-     * ...
+     *   openapi:
+     *     schema:
+     *       decorator:
+     *         postfix:
+     *           org.api.v1_0_0: 1_0_0
+     *           org.api.v2_0_0: 2_0_0
+     * </pre>
      */
-    String MICRONAUT_OPENAPI_SCHEMA_PREFIX = "micronaut.openapi.schema-prefix";
-    String MICRONAUT_OPENAPI_SCHEMA_POSTFIX = "micronaut.openapi.schema-postfix";
+    String MICRONAUT_OPENAPI_SCHEMA_DECORATOR_PREFIX = "micronaut.openapi.schema.decorator.prefix";
+    String MICRONAUT_OPENAPI_SCHEMA_DECORATOR_POSTFIX = "micronaut.openapi.schema.decorator.postfix";
     /**
      * Properties prefix to set custom schema implementations for selected classes.
      * For example, if you want to set simple 'java.lang.String' class to some complex 'org.somepackage.MyComplexType' class you need to write:
@@ -222,15 +281,16 @@ public interface OpenApiConfigProperty {
      * <p>
      * Also, you can set it in your application.yml file like this:
      * <p>
+     * <pre>
      * micronaut:
-     * openapi:
-     * group:
-     * my-group1:
-     * title: Title 1
-     * filename: swagger-${group}-${apiVersion}-${version}.yml
-     * my-group2:
-     * title: Title 2
-     * ...
+     *   openapi:
+     *     group:
+     *       my-group1:
+     *         title: Title 1
+     *         filename: swagger-${group}-${apiVersion}-${version}.yml
+     *       my-group2:
+     *         title: Title 2
+     * </pre>
      */
     String MICRONAUT_OPENAPI_GROUPS = "micronaut.openapi.groups";
 
@@ -275,31 +335,33 @@ public interface OpenApiConfigProperty {
      * All supported annotation processor properties.
      */
     Set<String> ALL = Set.of(
-            MICRONAUT_OPENAPI_ENABLED,
-            MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH,
-            MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY,
-            MICRONAUT_OPENAPI_VIEWS_SPEC,
-            MICRONAUT_OPENAPI_FILENAME,
-            MICRONAUT_OPENAPI_JSON_FORMAT,
-            MICRONAUT_OPENAPI_ENVIRONMENTS,
-            MICRONAUT_ENVIRONMENT_ENABLED,
-            MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL,
-            MICRONAUT_CONFIG_FILE_LOCATIONS,
-            MICRONAUT_OPENAPI_TARGET_FILE,
-            MICRONAUT_OPENAPI_VIEWS_DEST_DIR,
-            MICRONAUT_OPENAPI_ADDITIONAL_FILES,
-            MICRONAUT_OPENAPI_CONFIG_FILE,
-            MICRONAUT_OPENAPI_SECURITY_ENABLED,
-            MICRONAUT_OPENAPI_VERSIONING_ENABLED,
-            MICRONAUT_OPENAPI_JSON_VIEW_DEFAULT_INCLUSION,
-            MICRONAUT_OPENAPI_PROJECT_DIR,
-            MICRONAUT_OPENAPI_ADOC_ENABLED,
-            MICRONAUT_OPENAPI_ADOC_TEMPLATES_DIR_PATH,
-            MICRONAUT_OPENAPI_ADOC_TEMPLATE_FILENAME,
-            MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH,
-            MICRONAUT_OPENAPI_ADOC_OUTPUT_FILENAME,
-            MICRONAUT_OPENAPI_ADOC_OPENAPI_PATH,
-            MICRONAUT_OPENAPI_SWAGGER_FILE_GENERATION_ENABLED,
-            MICRONAUT_OPENAPI_EXTRA_SCHEMA_ENABLED
+        MICRONAUT_OPENAPI_ENABLED,
+        MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH,
+        MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY,
+        MICRONAUT_OPENAPI_VIEWS_SPEC,
+        MICRONAUT_OPENAPI_FILENAME,
+        MICRONAUT_OPENAPI_JSON_FORMAT,
+        MICRONAUT_OPENAPI_ENVIRONMENTS,
+        MICRONAUT_ENVIRONMENT_ENABLED,
+        MICRONAUT_OPENAPI_FIELD_VISIBILITY_LEVEL,
+        MICRONAUT_CONFIG_FILE_LOCATIONS,
+        MICRONAUT_OPENAPI_TARGET_FILE,
+        MICRONAUT_OPENAPI_VIEWS_DEST_DIR,
+        MICRONAUT_OPENAPI_ADDITIONAL_FILES,
+        MICRONAUT_OPENAPI_CONFIG_FILE,
+        MICRONAUT_OPENAPI_SECURITY_ENABLED,
+        MICRONAUT_OPENAPI_VERSIONING_ENABLED,
+        MICRONAUT_OPENAPI_JSON_VIEW_DEFAULT_INCLUSION,
+        MICRONAUT_OPENAPI_PROJECT_DIR,
+        MICRONAUT_OPENAPI_ADOC_ENABLED,
+        MICRONAUT_OPENAPI_ADOC_TEMPLATES_DIR_PATH,
+        MICRONAUT_OPENAPI_ADOC_TEMPLATE_FILENAME,
+        MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH,
+        MICRONAUT_OPENAPI_ADOC_OUTPUT_FILENAME,
+        MICRONAUT_OPENAPI_ADOC_OPENAPI_PATH,
+        MICRONAUT_OPENAPI_SWAGGER_FILE_GENERATION_ENABLED,
+        MICRONAUT_OPENAPI_SCHEMA_EXTRA_ENABLED,
+        MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_EMPTY,
+        MICRONAUT_OPENAPI_SCHEMA_NAME_SEPARATOR_GENERIC
     );
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitor.java
@@ -181,8 +181,8 @@ public class OpenApiExtraSchemaVisitor implements TypeElementVisitor<OpenAPIExtr
         if (classEl == null) {
             return;
         }
-        String schemaName = stringValue(classEl, io.swagger.v3.oas.annotations.media.Schema.class, PROP_NAME)
-                .orElse(computeDefaultSchemaName(null, classEl, classEl.getTypeArguments(), context, null));
+        String schemaName = computeDefaultSchemaName(stringValue(classEl, io.swagger.v3.oas.annotations.media.Schema.class, PROP_NAME).orElse(null),
+            null, classEl, classEl.getTypeArguments(), context, null);
         var schema = getSchemaDefinition(resolveOpenApi(context), context, classEl, classEl.getTypeArguments(), null, Collections.emptyList(), null);
         if (schema == null) {
             return;

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerRequiresVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerRequiresVisitorSpec.groovy
@@ -115,15 +115,10 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.micronaut.http.annotation.*;
-import io.micronaut.http.*;
-import java.util.List;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 
 @Requires(env="env1",notEnv="env3")
 @Controller
@@ -170,15 +165,10 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.micronaut.http.annotation.*;
-import io.micronaut.http.*;
-import java.util.List;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 
 @Requires(env={"env1","env2"})
 @Controller
@@ -236,15 +226,10 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.micronaut.http.annotation.*;
-import io.micronaut.http.*;
-import java.util.List;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 
 @Requires(notEnv={"env1","env2"})
 @Controller
@@ -291,15 +276,10 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Requires;import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.micronaut.http.annotation.*;
-import io.micronaut.http.*;
-import java.util.List;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 
 @Requires(env="env1")
 @Requires(env={"env2","env3"})

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
@@ -1133,7 +1133,8 @@ class MyBean {}
 package test;
 
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MediaType;import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -1183,7 +1184,8 @@ class MyBean {}
 package test;
 
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MediaType;import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -1650,8 +1652,8 @@ package test;
 
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;import io.swagger.v3.oas.annotations.responses.ApiResponses;
-
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.reactivestreams.Publisher;
 
 @ApiResponses({
@@ -2327,7 +2329,8 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
 import io.micronaut.serde.annotation.Serdeable;
-import io.swagger.v3.oas.annotations.Parameter;import jakarta.inject.Singleton;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.inject.Singleton;
 
 import java.util.Optional;
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiDecoratorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiDecoratorSpec.groovy
@@ -13,7 +13,8 @@ package test;
 
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.openapi.annotation.OpenAPIDecorator;import io.swagger.v3.oas.annotations.Operation;
+import io.micronaut.openapi.annotation.OpenAPIDecorator;
+import io.swagger.v3.oas.annotations.Operation;
 
 @OpenAPIDecorator(opIdPrefix = "cats-", opIdSuffix = "-suffix")
 @Controller("/cats")

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiEnumSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiEnumSpec.groovy
@@ -540,12 +540,12 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.swagger.v3.oas.annotations.Hidden;import io.swagger.v3.oas.annotations.media.Schema;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Controller
 class OpenApiController {
@@ -606,9 +606,7 @@ package test;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.swagger.v3.oas.annotations.Hidden;import io.swagger.v3.oas.annotations.media.Schema;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Controller
 class OpenApiController {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitorSpec.groovy
@@ -210,7 +210,7 @@ class MyBean {}
     void "test disable OpenAPI extra schemas"() {
 
         given:
-        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_EXTRA_SCHEMA_ENABLED, "false")
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_SCHEMA_EXTRA_ENABLED, "false")
 
         when:
         buildBeanDefinition('test.MyBean', '''
@@ -218,7 +218,7 @@ package test;
 
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Post;import io.micronaut.openapi.annotation.OpenAPIExtraSchema;
+import io.micronaut.openapi.annotation.OpenAPIExtraSchema;
 import jakarta.inject.Singleton;
 
 @OpenAPIExtraSchema(

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadBodyParameterSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadBodyParameterSpec.groovy
@@ -16,10 +16,8 @@ class OpenApiFileUploadBodyParameterSpec extends AbstractOpenApiTypeElementSpec 
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import jakarta.inject.Singleton;
-
 import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Body;import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.multipart.PartData;
@@ -30,6 +28,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Singleton;
 
 @Singleton
 @Controller("/")

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiIncludeVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiIncludeVisitorSpec.groovy
@@ -128,8 +128,8 @@ import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;import io.swagger.v3.oas.annotations.tags.Tag;
-
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 
 @OpenAPIDefinition(

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiInheritedPojoControllerSpec.groovy
@@ -545,18 +545,17 @@ class MyBean {}
         buildBeanDefinition('test.MyBean', '''
 package test;
 
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Positive;import jakarta.validation.constraints.PositiveOrZero;import jakarta.validation.constraints.Size;
-
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-
 import jakarta.inject.Singleton;
-
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 @Controller("/pets")
 interface PetOperations {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiNullableTypesSpec.groovy
@@ -177,12 +177,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Put;
 import io.micronaut.http.annotation.Post;
-import io.micronaut.http.annotation.Status;import io.swagger.v3.oas.annotations.Parameter;import io.swagger.v3.oas.annotations.enums.ParameterIn;
-
-import java.util.List;
-import java.util.Optional;
 
 class Pet {
     private String name;

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationHeadersSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiOperationHeadersSpec.groovy
@@ -121,7 +121,7 @@ package test;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Schema;import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @Controller("/")
 class MyController {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiParameterSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiParameterSchemaSpec.groovy
@@ -15,9 +15,10 @@ package test;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Patch;import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Put;
-import io.micronaut.http.annotation.QueryValue;import io.swagger.v3.oas.annotations.Parameter;
+import io.micronaut.http.annotation.QueryValue;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Period;

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaFieldSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaFieldSpec.groovy
@@ -172,12 +172,12 @@ class MyBean {}
 
 package test;
 
-import java.util.List;
-import java.time.Instant;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
-import io.swagger.v3.oas.annotations.extensions.Extension;import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Controller
 class OpenApiController {

--- a/openapi/src/test/resources/application-schemadecorator.yml
+++ b/openapi/src/test/resources/application-schemadecorator.yml
@@ -1,5 +1,7 @@
 micronaut:
   openapi:
-    schema-postfix:
-      io.micronaut.openapi.api.v1_0_0: '1_0_0'
-      io.micronaut.openapi.api.v2_0_1: '2_0_1'
+    schema:
+      decorator:
+        postfix:
+          io.micronaut.openapi.api.v1_0_0: '1_0_0'
+          io.micronaut.openapi.api.v2_0_1: '2_0_1'

--- a/openapi/src/test/resources/application-schemaforclass.yml
+++ b/openapi/src/test/resources/application-schemaforclass.yml
@@ -1,5 +1,6 @@
 micronaut:
   openapi:
     schema:
-      io.micronaut.openapi.ObjectId: java.lang.String
-      io.micronaut.openapi.JAXBElement: io.micronaut.openapi.MyJaxbElement
+      mapping:
+        io.micronaut.openapi.ObjectId: java.lang.String
+        io.micronaut.openapi.JAXBElement: io.micronaut.openapi.MyJaxbElement

--- a/src/main/docs/guide/configuration/availableOptions.adoc
+++ b/src/main/docs/guide/configuration/availableOptions.adoc
@@ -2,9 +2,6 @@
 |`*micronaut.openapi.enabled*` | System property that enables or disables open api annotation processing. | Default: `true`
 |`*micronaut.openapi.openapi31.enabled*` | System property that enables or disables OpenAPI 3.1.0 format. | Default: `false`
 |`*micronaut.openapi.openapi31.json-schema-dialect*` | System property that set JSON Schema Dialect for OpenAPI 3.1.0 format. | Default: ``
-|`*micronaut.openapi.schema.name.separator.empty*` | If this property true, generic separators and inner class separators in schema name will be empty string. | Default: `false`
-|`*micronaut.openapi.schema.name.separator.generic*` | System property that set generic class separator for schema name generation. | Default: `_`
-|`*micronaut.openapi.schema.name.separator.inner-class*` | System property that set inner class separator for schema name generation. | Default: `.`
 |`*micronaut.openapi.swagger.file.generation.enabled*` | System property that enables or disables generation of a swagger (OpenAPI) specification file. This can be used whenever you already have a specification file and that you only need the Swagger UI. | Default: `true`
 |`*micronaut.openapi.config.file*` | System property that enables setting the open api config file. |
 |`*micronaut.openapi.server.context.path*` | System property for server context path. |
@@ -38,7 +35,51 @@ PUBLIC | Default: `PUBLIC`
 You can set your custom paths separated by `,`. To set absolute paths use prefix `file:`,
 classpath paths use prefix `classpath:` or use prefix `project:` to set paths from project
 directory. |
-|`*micronaut.openapi.schema.**` | Properties prefix to set custom schema implementations for selected classes. +
+|`*micronaut.openapi.schema.extra.enable*` | If this property true, you can add some extra schemas to final openapi spec file. | Default: `false`
+|`*micronaut.openapi.schema.duplicate-resolution*` | System property to set schema duplicate resolution. Available values: +
+`*auto*` - micronaut-openapi automatically add index suffix to duplicate schema. +
+`*error*` - micronaut-openapi throws an exception when found duplicate schema. | Default: `auto`
+|`*micronaut.openapi.schema.name.separator.empty*` | If this property true, generic separators and inner class separators in schema name will be empty string. | Default: `false`
+|`*micronaut.openapi.schema.name.separator.generic*` | System property that set generic class separator for schema name generation. | Default: `_`
+|`*micronaut.openapi.schema.name.separator.inner-class*` | System property that set inner class separator for schema name generation. | Default: `.`
+|`*micronaut.openapi.schema.mapping.**` | Properties prefix to set custom schema implementations for selected classes. +
+For example, if you want to set simple `java.lang.String` class to some complex `org.somepackage.MyComplexType` class you need to write: +
+{nbsp} +
+micronaut.openapi.schema.org.somepackage.MyComplexType=java.lang.String +
+{nbsp} +
+Also, you can set it in your `application.yml` file like this: +
+{nbsp} +
+micronaut: +
+{nbsp}{nbsp}openapi: +
+{nbsp}{nbsp}{nbsp}{nbsp}schema: +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}mapping: +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.somepackage.MyComplexType: java.lang.String +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.somepackage.MyComplexType2: java.lang.Integer
+|
+|`*micronaut.openapi.schema.decorator.prefix*` +
+`*micronaut.openapi.schema.decorator.postfix.**` | Properties prefix to set schema name prefix or postfix by package. +
+For example, if you have some classes with same names in different packages you can set postfix like this: +
+{nbsp} +
+micronaut.openapi.schema.decorator.postfix.org.api.v1_0_0=1_0_0 +
+micronaut.openapi.schema.decorator.postfix.org.api.v2_0_0=2_0_0 +
+{nbsp} +
+Also, you can set it in your `application.yml` file like this: +
+{nbsp} +
+micronaut: +
+{nbsp}{nbsp}openapi: +
+{nbsp}{nbsp}{nbsp}{nbsp}schema: +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}decorator:
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}postfix: +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.api.v1_0_0: 1_0_0 +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.api.v2_0_0: 2_0_0 +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}decorator:
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}prefix: +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.api.v1_0_0: public +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.api.v2_0_0: private +
+{nbsp} +
+|
+|`*micronaut.openapi.schema.**` +
+**DEPRECATED**: Use `*micronaut.openapi.schema.mapping.**` instead | Properties prefix to set custom schema implementations for selected classes. +
 For example, if you want to set simple `java.lang.String` class to some complex `org.somepackage.MyComplexType` class you need to write: +
 {nbsp} +
 micronaut.openapi.schema.org.somepackage.MyComplexType=java.lang.String +
@@ -51,8 +92,9 @@ micronaut: +
 {nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.somepackage.MyComplexType: java.lang.String +
 {nbsp}{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}org.somepackage.MyComplexType2: java.lang.Integer
 |
-|`*micronaut.openapi.schema-prefix*` +
-`*micronaut.openapi.schema-postfix.**` | Properties prefix to set schema name prefix or postfix by package. +
+|`*micronaut.openapi.schema-prefix.**` +
+`*micronaut.openapi.schema-postfix.**` +
+**DEPRECATED**: Use `*micronaut.openapi.schema.decorator.prefix.*` and `*micronaut.openapi.schema.decorator.postfix.*` instead | Properties prefix to set schema name prefix or postfix by package. +
 For example, if you have some classes with same names in different packages you can set postfix like this: +
 {nbsp} +
 micronaut.openapi.schema-postfix.org.api.v1_0_0=1_0_0 +


### PR DESCRIPTION
Fixed #1698

Deprecated configuration properties:

`micronaut.openapi.schema-prefix`
`micronaut.openapi.schema-postfix`
`micronaut.openapi.schema`

New configuration properties to replace deprecated:

`micronaut.openapi.schema.decorator.prefix`
`micronaut.openapi.schema.decorator.postfix`
`micronaut.openapi.schema.mapping`