### PR TITLE
Update link to Redoc config documentation

### DIFF
--- a/src/main/docs/guide/openApiViews/redoc.adoc
+++ b/src/main/docs/guide/openApiViews/redoc.adoc
@@ -31,7 +31,7 @@ The views will be generated to the `META-INF/swagger/views/redoc` directory of y
 | `redoc.hide-loading` |
 |===
 
-See https://github.com/Redocly/redoc#redoc-options-object[Redoc Options] for a description of the above properties.
+See https://github.com/Redocly/redoc/blob/main/docs/config.md[Redoc config] for a description of the above properties.
 
 To expose the `redoc` views, you also must expose the generated `yaml`:
 


### PR DESCRIPTION
Hi,

It seems that the link https://github.com/Redocly/redoc#redoc-options-object is no longer working, so I updated it