### PR TITLE
Fixed OOM and Stream closed for openapi-generator

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -109,6 +109,7 @@ public final class MicronautCodeGeneratorEntryPoint {
 
         // Generate
         var generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
         for (OutputKind outputKind : OutputKind.values()) {
             generator.setGeneratorPropertyDefault(outputKind.generatorProperty, "false");
         }


### PR DESCRIPTION
Disable generating openapi-generator metadata.

Fixed #1997
Fixed #https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1070