### PR TITLE
Improving Spring Boot support: Correctly interpret endpoints with multipart form data

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -132,6 +132,10 @@ import static io.micronaut.openapi.visitor.ElementUtils.isDeprecated;
 import static io.micronaut.openapi.visitor.ElementUtils.isExtraBodyParameter;
 import static io.micronaut.openapi.visitor.ElementUtils.isFileUpload;
 import static io.micronaut.openapi.visitor.ElementUtils.isIgnoredParameter;
+import static io.micronaut.openapi.visitor.ElementUtils.isIterableOfMultipartFiles;
+import static io.micronaut.openapi.visitor.ElementUtils.isMapOfListOfMultipartFiles;
+import static io.micronaut.openapi.visitor.ElementUtils.isMapOfMultipartFiles;
+import static io.micronaut.openapi.visitor.ElementUtils.isMapOfStrings;
 import static io.micronaut.openapi.visitor.ElementUtils.isNotNullable;
 import static io.micronaut.openapi.visitor.ElementUtils.isNullable;
 import static io.micronaut.openapi.visitor.ElementUtils.isResponseType;
@@ -667,11 +671,21 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                                 // if content type doesn't set by annotation,
                                 // we can set application/octet-stream for file upload classes
                                 Encoding encoding = encodings.get(prop);
-                                if (encoding == null && isFileUpload(parameter.getType())) {
-                                    encoding = new Encoding();
-                                    encodings.put(prop, encoding);
+                                if (encoding == null) {
+                                    if (isFileUpload(parameter.getType())
+                                        || isMapOfMultipartFiles(parameter)
+                                        || isMapOfListOfMultipartFiles(parameter)
+                                        || isIterableOfMultipartFiles(parameter)) {
 
-                                    encoding.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+                                        encodings.put(prop, new Encoding()
+                                            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                                            .explode(isIterableOfMultipartFiles(parameter) || isMapOfListOfMultipartFiles(parameter)));
+                                    } else if (isMapOfStrings(parameter)) {
+                                        encodings.put(parameter.getName(), new Encoding()
+                                            .contentType(MediaType.TEXT_PLAIN));
+                                        // also need to replace ObjectSchema to StringSchema
+                                        schema.getProperties().put(prop, PrimitiveType.STRING.createProperty());
+                                    }
                                 }
                             }
                         }
@@ -940,6 +954,9 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         if (propertySchema == null) {
             return;
         }
+        if (isMapOfMultipartFiles(parameter) || isMapOfListOfMultipartFiles(parameter)) {
+            propertySchema = (Schema) propertySchema.getAdditionalProperties();
+        }
 
         parameter.stringValue(io.swagger.v3.oas.annotations.Parameter.class, PROP_DESCRIPTION)
             .ifPresent(propertySchema::setDescription);
@@ -1018,9 +1035,30 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             newParameter = new CookieParameter();
             newParameter.setName(cookieName);
         } else if (parameter.isAnnotationPresent(QueryValue.class)) {
-            String queryVar = parameter.stringValue(QueryValue.class).orElse(parameterName);
-            newParameter = new QueryParameter();
-            newParameter.setName(queryVar);
+
+            var isExtraBodyParam = false;
+            // Fix for Spring boot controller endpoints for Map with MultipartFile like this:
+            // @PostMapping(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+            // public void endpoint2(@RequestParam Map<String, MultipartFile> files)
+            // because, `@RequestParam` annotation mapped to `@QueryValue`, but it's required for Spring Boot
+            // fix only for Map<String, MultipartFile>
+            if (isMapOfMultipartFiles(parameter) || isMapOfListOfMultipartFiles(parameter) || isIterableOfMultipartFiles(parameter)) {
+                extraBodyParameters.add(parameter);
+                isExtraBodyParam = true;
+            } else if (isMapOfStrings(parameter)) {
+                var parameterAnn = parameter.getAnnotation(io.swagger.v3.oas.annotations.Parameter.class);
+                var paramIn = parameterAnn != null ? parameterAnn.stringValue(PROP_IN).orElse(null) : null;
+                if (paramIn != null) {
+                    return null;
+                }
+                extraBodyParameters.add(parameter);
+                isExtraBodyParam = true;
+            }
+            if (!isExtraBodyParam) {
+                String queryVar = parameter.stringValue(QueryValue.class).orElse(parameterName);
+                newParameter = new QueryParameter();
+                newParameter.setName(queryVar);
+            }
         } else if (parameter.isAnnotationPresent(Part.class) && permitsRequestBody) {
             extraBodyParameters.add(parameter);
             isBodyParameter = true;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
@@ -80,6 +80,9 @@ import static io.micronaut.openapi.visitor.OpenApiModelProp.PROP_HIDDEN;
 @Internal
 public final class ElementUtils {
 
+    public static final String TYPE_ARG_MAP_KEY = "K";
+    public static final String TYPE_ARG_MAP_VALUE = "V";
+
     public static final AnnotationValue<?>[] EMPTY_ANNOTATION_VALUES_ARRAY = new AnnotationValue[0];
 
     public static final List<String> CONTAINER_TYPES = List.of(
@@ -572,4 +575,89 @@ public final class ElementUtils {
         var jsonShape = jsonFormatAnn.get("shape", JsonFormat.Shape.class).orElse(JsonFormat.Shape.ANY);
         return jsonShape != JsonFormat.Shape.OBJECT && isEnum;
     }
+
+    public static boolean isIterableOfMultipartFiles(TypedElement el) {
+        var type = el.getGenericType();
+        if (type.isArray()) {
+            return isFileUpload(type);
+        }
+        if (type.isAssignable("org.springframework.util.MultiValueMap")) {
+            var typeArgs = el.getGenericType().getTypeArguments();
+            if (typeArgs.size() == 2) {
+                var typeArgType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+                return isFileUpload(typeArgType);
+            }
+            return false;
+        }
+        if (!type.isIterable()) {
+            if (!type.isAssignable(Map.class)) {
+                return false;
+            }
+            // case for Map<String, List<MultipartFile>>
+            var typeArgs = el.getGenericType().getTypeArguments();
+            if (typeArgs.size() == 2) {
+                var typeArgType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+                if (typeArgType.isIterable()) {
+                    type = typeArgType.getGenericType();
+                }
+            }
+        }
+        var typeArg = type.getFirstTypeArgument().orElse(null);
+        if (typeArg == null) {
+            return false;
+        }
+        return isFileUpload(typeArg);
+    }
+
+    public static boolean isMapOfListOfMultipartFiles(TypedElement el) {
+        ClassElement typeArgType = null;
+        var type = el.getGenericType();
+        if (type.isAssignable("org.springframework.util.MultiValueMap")) {
+            var typeArgs = el.getGenericType().getTypeArguments();
+            if (typeArgs.size() != 2) {
+                return false;
+            }
+            typeArgType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+        } else if (type.isAssignable(Map.class)) {
+            // case for Map<String, List<MultipartFile>>
+            var typeArgs = el.getGenericType().getTypeArguments();
+            if (typeArgs.size() != 2) {
+                return false;
+            }
+            typeArgType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+            if (typeArgType == null || !typeArgType.isIterable()) {
+                return false;
+            }
+            typeArgType = typeArgType.getGenericType().getFirstTypeArgument().orElse(null);
+        }
+        if (typeArgType == null) {
+            return false;
+        }
+        return isFileUpload(typeArgType);
+    }
+
+    public static boolean isMapOfMultipartFiles(TypedElement el) {
+        if (!el.getType().isAssignable(Map.class)) {
+            return false;
+        }
+        var typeArgs = el.getGenericType().getTypeArguments();
+        if (typeArgs.size() != 2) {
+            return false;
+        }
+        var valueType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+        return isFileUpload(valueType);
+    }
+
+    public static boolean isMapOfStrings(TypedElement el) {
+        if (!el.getType().isAssignable(Map.class)) {
+            return false;
+        }
+        var typeArgs = el.getGenericType().getTypeArguments();
+        if (typeArgs.size() != 2) {
+            return false;
+        }
+        var valueType = typeArgs.get(TYPE_ARG_MAP_VALUE);
+        return valueType.getType().isAssignable(CharSequence.class);
+    }
+
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -137,6 +137,8 @@ import static io.micronaut.openapi.visitor.ContextUtils.warn;
 import static io.micronaut.openapi.visitor.ConvertUtils.parseJsonString;
 import static io.micronaut.openapi.visitor.ConvertUtils.setDefaultValueObject;
 import static io.micronaut.openapi.visitor.ConvertUtils.toTupleSubMap;
+import static io.micronaut.openapi.visitor.ElementUtils.TYPE_ARG_MAP_KEY;
+import static io.micronaut.openapi.visitor.ElementUtils.TYPE_ARG_MAP_VALUE;
 import static io.micronaut.openapi.visitor.ElementUtils.findAnnotation;
 import static io.micronaut.openapi.visitor.ElementUtils.getAnnotation;
 import static io.micronaut.openapi.visitor.ElementUtils.getAnnotationMetadata;
@@ -2801,8 +2803,8 @@ public final class SchemaDefinitionUtils {
             return schema;
         }
         // Case, when map key is enumeration
-        ClassElement keyType = typeArgs.get("K");
-        ClassElement valueType = typeArgs.get("V");
+        ClassElement keyType = typeArgs.get(TYPE_ARG_MAP_KEY);
+        ClassElement valueType = typeArgs.get(TYPE_ARG_MAP_VALUE);
         if (isEnum(keyType)) {
             var enumSchema = getSchemaDefinition(openApi, context, keyType, keyType.getTypeArguments(), null, mediaTypes, null);
             if (enumSchema != null && enumSchema.get$ref() != null) {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiFileUploadSpec.groovy
@@ -223,6 +223,7 @@ interface PetOperations<T extends Pet> {
     @Post("/")
     T saveByUpload(@Body T pet);
 }
+
 class Pet {
     private int age;
     private String name;
@@ -261,6 +262,7 @@ class Pet {
         this.tags = tags;
     }
 }
+
 @jakarta.inject.Singleton
 class MyBean {}
 ''')
@@ -283,4 +285,124 @@ class MyBean {}
         operation.requestBody.content['application/x-www-form-urlencoded'].schema
     }
 
+    void "test converted spring boot controller to micronaut controller with multipart form data"() {
+        given:
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
+
+@Controller
+class TestController {
+
+    @Post(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA)
+    // Query value, because for Spring Boot need to set annotation `@RequestParam` and it's mapped to `@QueryValue`
+    // `json` parameter must be ignored, because it is map fo all query parameters, and we can't interpret it correct
+    public void endpoint(@QueryValue Map<String, CompletedFileUpload> files, @QueryValue @Parameter(in = QUERY) Map<String, String> json) {
+    }
+    
+    @Post(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA)
+    public void endpoint2(@QueryValue Map<String, CompletedFileUpload> files) {
+    }
+
+    @Post(value = "/fileWithJson", consumes = MediaType.MULTIPART_FORM_DATA)
+    // Query value, because for Spring Boot need to set annotation `@RequestParam` and it's mapped to `@QueryValue`
+    // in this case json will be interpreted as a part of multipart request 
+    public void endpoint2(@QueryValue Map<String, CompletedFileUpload> files, @QueryValue Map<String, String> json) {
+    }
+
+    @Post(value = "/fileArray", consumes = MediaType.MULTIPART_FORM_DATA)
+    public void endpoint3(CompletedFileUpload[] files) {
+    }
+
+    @Post(value = "/fileList", consumes = MediaType.MULTIPART_FORM_DATA)
+    public void endpoint4(List<CompletedFileUpload> files) {
+    }
+
+    @Post(value = "/fileMapOfList", consumes = MediaType.MULTIPART_FORM_DATA)
+    public void endpoint5(Map<String, List<CompletedFileUpload>> files) {
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then:
+        Utils.testReference != null
+
+        when:
+        OpenAPI openAPI = Utils.testReference
+        Operation fileOp = openAPI.paths?."/file"?.post
+        Operation fileWithJsonOp = openAPI.paths?."/fileWithJson"?.post
+        Operation fileArrayOp = openAPI.paths?."/fileArray"?.post
+        Operation fileListOp = openAPI.paths?."/fileList"?.post
+
+        then:
+        fileOp.requestBody
+        fileOp.requestBody.content
+        fileOp.requestBody.content."multipart/form-data"
+        fileOp.requestBody.content."multipart/form-data".schema
+        fileOp.requestBody.content."multipart/form-data".schema.type == "object"
+        fileOp.requestBody.content."multipart/form-data".schema.properties.size() == 1
+        fileOp.requestBody.content."multipart/form-data".schema.properties.files.type == "string"
+        fileOp.requestBody.content."multipart/form-data".schema.properties.files.format == "binary"
+
+        fileOp.requestBody.content."multipart/form-data".encoding.size() == 1
+        fileOp.requestBody.content."multipart/form-data".encoding.files.contentType == "application/octet-stream"
+
+        fileWithJsonOp.requestBody
+        fileWithJsonOp.requestBody.content
+        fileWithJsonOp.requestBody.content."multipart/form-data"
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema.type == "object"
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema.properties.size() == 2
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema.properties.files.type == "string"
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema.properties.files.format == "binary"
+        fileWithJsonOp.requestBody.content."multipart/form-data".schema.properties.json.type == "string"
+
+        fileWithJsonOp.requestBody.content."multipart/form-data".encoding.size() == 2
+        fileWithJsonOp.requestBody.content."multipart/form-data".encoding.files.contentType == "application/octet-stream"
+        fileWithJsonOp.requestBody.content."multipart/form-data".encoding.json.contentType == "text/plain"
+
+        fileArrayOp.requestBody
+        fileArrayOp.requestBody.content
+        fileArrayOp.requestBody.content."multipart/form-data"
+        fileArrayOp.requestBody.content."multipart/form-data".schema
+        fileArrayOp.requestBody.content."multipart/form-data".schema.type == "object"
+        fileArrayOp.requestBody.content."multipart/form-data".schema.properties.size() == 1
+        fileArrayOp.requestBody.content."multipart/form-data".schema.properties.files.type == "array"
+        fileArrayOp.requestBody.content."multipart/form-data".schema.properties.files.items
+        fileArrayOp.requestBody.content."multipart/form-data".schema.properties.files.items.type == "string"
+        fileArrayOp.requestBody.content."multipart/form-data".schema.properties.files.items.format == "binary"
+
+        fileArrayOp.requestBody.content."multipart/form-data".encoding.size() == 1
+        fileArrayOp.requestBody.content."multipart/form-data".encoding.files.contentType == "application/octet-stream"
+        fileArrayOp.requestBody.content."multipart/form-data".encoding.files.explode
+
+        fileListOp.requestBody
+        fileListOp.requestBody.content
+        fileListOp.requestBody.content."multipart/form-data"
+        fileListOp.requestBody.content."multipart/form-data".schema
+        fileListOp.requestBody.content."multipart/form-data".schema.type == "object"
+        fileListOp.requestBody.content."multipart/form-data".schema.properties.size() == 1
+        fileListOp.requestBody.content."multipart/form-data".schema.properties.files.type == "array"
+        fileListOp.requestBody.content."multipart/form-data".schema.properties.files.items
+        fileListOp.requestBody.content."multipart/form-data".schema.properties.files.items.type == "string"
+        fileListOp.requestBody.content."multipart/form-data".schema.properties.files.items.format == "binary"
+
+        fileListOp.requestBody.content."multipart/form-data".encoding.size() == 1
+        fileListOp.requestBody.content."multipart/form-data".encoding.files.contentType == "application/octet-stream"
+        fileListOp.requestBody.content."multipart/form-data".encoding.files.explode
+    }
 }

--- a/test-suite-java-spring/src/main/java/io/micronaut/openapi/spring/api/HelloController.java
+++ b/test-suite-java-spring/src/main/java/io/micronaut/openapi/spring/api/HelloController.java
@@ -1,9 +1,14 @@
 package io.micronaut.openapi.spring.api;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Locale;
@@ -15,6 +20,16 @@ public class HelloController {
     @GetMapping
     public ResponseEntity<ResponseObject<List<Dto>>> endpoint() {
         return ResponseEntity.ok(new ResponseObject<>());
+    }
+
+    @PostMapping(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void endpoint2(@RequestParam MultiValueMap<String, MultipartFile> files) {
+        System.out.println("endpoint2");
+    }
+
+    @PostMapping(value = "/file2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void endpoint3(MultipartFile files) {
+        System.out.println("endpoint3");
     }
 
     public static class ResponseObject<T> {


### PR DESCRIPTION
Added support endpoints like these:
```java
    @Post(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA)
    // Query value, because for Spring Boot need to set annotation `@RequestParam` and it's mapped to `@QueryValue`
    // `json` parameter must be ignored, because it is map fo all query parameters, and we can't interpret it correct
    public void endpoint(@QueryValue Map<String, CompletedFileUpload> files, @QueryValue @Parameter(in = QUERY) Map<String, String> json) {
    }
    
    @Post(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA)
    public void endpoint2(@QueryValue Map<String, CompletedFileUpload> files) {
    }

    @Post(value = "/fileWithJson", consumes = MediaType.MULTIPART_FORM_DATA)
    // Query value, because for Spring Boot need to set annotation `@RequestParam` and it's mapped to `@QueryValue`
    // in this case json will be interpreted as a part of multipart request 
    public void endpoint2(@QueryValue Map<String, CompletedFileUpload> files, @QueryValue Map<String, String> json) {
    }

    @Post(value = "/fileArray", consumes = MediaType.MULTIPART_FORM_DATA)
    public void endpoint3(CompletedFileUpload[] files) {
    }

    @Post(value = "/fileList", consumes = MediaType.MULTIPART_FORM_DATA)
    public void endpoint4(List<CompletedFileUpload> files) {
    }

    @Post(value = "/fileMapOfList", consumes = MediaType.MULTIPART_FORM_DATA)
    public void endpoint5(Map<String, List<CompletedFileUpload>> files) {
    }

```