### PR TITLE
Add more clarification about api code gen in docs

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,5 +1,3 @@
 Micronaut includes support for producing https://www.openapis.org[OpenAPI] (Swagger) YAML at compilation time. Micronaut will at compile time produce a OpenAPI 3.x compliant YAML file just based on the regular Micronaut annotations and the javadoc comments within your code.
 
 You can customize the generated Swagger using the standard <<swaggerAnnotations, Swagger Annotations>>.
-
-If you wish to generate Micronaut projects from OpenAPI definition files, utilize the https://openapi-generator.tech/[OpenAPI Generator]'s Micronaut support. Refer to the https://guides.micronaut.io/latest/micronaut-openapi-generator-server["Micronaut server generation with OpenAPI" guide] or the https://guides.micronaut.io/latest/micronaut-openapi-generator-client["Micronaut Client generation with OpenAPI" guide] for details.

--- a/src/main/docs/guide/openApiGenerator.adoc
+++ b/src/main/docs/guide/openApiGenerator.adoc
@@ -1,0 +1,8 @@
+If you wish to generate Micronaut code (e.g. Client/Server) from OpenAPI definition files, utilize the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#_openapi_code_generation[Micronaut OpenAPI Gradle Plugin]. Refer to the https://guides.micronaut.io/latest/micronaut-openapi-generator-server["Micronaut server generation with OpenAPI" guide] or the https://guides.micronaut.io/latest/micronaut-openapi-generator-client["Micronaut Client generation with OpenAPI" guide] for details.
+
+
+[WARNING]
+====
+Micronaut stopped contributing to https://openapi-generator.tech/[OpenAPIGenerator] with Micronaut 3.X. You will
+notice the `helpTxt` in the https://openapi-generator.tech/docs/generators/java-micronaut-client/[generators] have been updated to reflect this. You must use the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#_openapi_code_generation[Micronaut OpenAPI Gradle Plugin].
+====

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,4 +1,6 @@
-introduction: Introduction
+introduction:
+  title: Introduction
+  openApiGenerator: OpenAPI Generator
 releaseHistory: Release History
 cli: Using the Micronaut CLI
 gettingStarted: Dependencies


### PR DESCRIPTION
The original content was under "Introduction" so I left it there and made it a subsection. I think having it in the ToC makes it much clearer to find.

<img width="1394" alt="Screenshot 2025-04-16 at 11 40 20 AM" src="https://github.com/user-attachments/assets/f4720727-24f4-4f23-a430-51d31d227294" />

