### PR TITLE
Add ability to interpret primary constructor arguments without annotations as not required properties

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -107,6 +107,7 @@ import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENA
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_TEMPLATE_FILENAME;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_TEMPLATE_PREFIX;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_CONFIG_FILE;
+import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_CONSTRUCTOR_ARGUMENTS_AS_REQUIRED;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ENABLED;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ENVIRONMENTS;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_EXPAND_PREFIX;
@@ -351,6 +352,10 @@ public final class ConfigUtils {
             return DuplicateResolution.ERROR;
         }
         return DuplicateResolution.AUTO;
+    }
+
+    public static boolean isConstructorArgumentsAsRequired(VisitorContext context) {
+        return getBooleanProperty(MICRONAUT_OPENAPI_CONSTRUCTOR_ARGUMENTS_AS_REQUIRED, true, context);
     }
 
     public static boolean isResponseReadSuccessfulFromCode(VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
@@ -359,6 +359,12 @@ public interface OpenApiConfigProperty {
     String MICRONAUT_OPENAPI_GROUPS = "micronaut.openapi.groups";
 
     /**
+     * System property that enables interpret primary constructor arguments as required properties.
+     * <p>
+     * Default: true
+     */
+    String MICRONAUT_OPENAPI_CONSTRUCTOR_ARGUMENTS_AS_REQUIRED = "micronaut.openapi.constructor-arguments-as-required";
+    /**
      * System property that enables tag generation by controller class name.
      */
     String MICRONAUT_OPENAPI_TAG_GENERATION_BY_CLASS_ENABLED = "micronaut.openapi.tag.generation.by.class.enabled";

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -130,6 +130,7 @@ import static io.micronaut.openapi.visitor.ConfigUtils.getGenericSeparator;
 import static io.micronaut.openapi.visitor.ConfigUtils.getInnerClassSeparator;
 import static io.micronaut.openapi.visitor.ConfigUtils.getSchemaDecoration;
 import static io.micronaut.openapi.visitor.ConfigUtils.getSchemaDuplicateResolution;
+import static io.micronaut.openapi.visitor.ConfigUtils.isConstructorArgumentsAsRequired;
 import static io.micronaut.openapi.visitor.ConfigUtils.isJsonViewDefaultInclusion;
 import static io.micronaut.openapi.visitor.ContextUtils.info;
 import static io.micronaut.openapi.visitor.ContextUtils.warn;
@@ -1677,7 +1678,7 @@ public final class SchemaDefinitionUtils {
             // check field annotations (@NonNull, @Nullable, etc.)
             boolean isNotNullable = isNotNullable(element);
             // check as mandatory in constructor
-            boolean isMandatoryInConstructor = doesParamExistsMandatoryInConstructor(element, classElement);
+            boolean isMandatoryInConstructor = doesParamExistsMandatoryInConstructor(element, classElement, context);
             boolean required = elementSchemaRequired != null ? elementSchemaRequired : isNotNullable || isMandatoryInConstructor;
 
             if (isRequiredDefaultValueSet && isAutoRequiredMode && isNotNullable) {
@@ -3254,7 +3255,7 @@ public final class SchemaDefinitionUtils {
         }
     }
 
-    private static boolean doesParamExistsMandatoryInConstructor(Element element, @Nullable Element classElement) {
+    private static boolean doesParamExistsMandatoryInConstructor(Element element, @Nullable Element classElement, VisitorContext context) {
         if (classElement instanceof ClassElement classEl) {
             if (classEl.isEnum()) {
                 return true;
@@ -3262,7 +3263,7 @@ public final class SchemaDefinitionUtils {
             return classEl.getPrimaryConstructor()
                 .flatMap(methodElement -> Arrays.stream(methodElement.getParameters())
                     .filter(parameterElement -> parameterElement.getName().equals(element.getName()))
-                    .map(parameterElement -> !parameterElement.isNullable())
+                    .map(paramEl ->  isConstructorArgumentsAsRequired(context) ? !ElementUtils.isNullable(paramEl) : ElementUtils.isNotNullable(paramEl))
                     .findFirst())
                 .orElse(false);
         }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerKotlinSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerKotlinSpec.groovy
@@ -205,7 +205,7 @@ data class Animal (
 )
 
 @jakarta.inject.Singleton
-class MyBean {}
+class MyBean
 ''')
         then: "the state is correct"
         Utils.testReference != null
@@ -325,7 +325,7 @@ enum class ColorEnum (
 }
 
 @jakarta.inject.Singleton
-class MyBean {}
+class MyBean
 ''')
         then: "the state is correct"
         Utils.testReference != null
@@ -424,7 +424,7 @@ open class MyEntity2Controller {
 }
 
 @jakarta.inject.Singleton
-class MyBean {}
+class MyBean
 ''')
         then: "the state is correct"
         Utils.testReference != null

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaWithNotNullSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiSchemaWithNotNullSpec.groovy
@@ -4,6 +4,8 @@ import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.media.Schema
+import spock.lang.Issue
+import spock.util.environment.RestoreSystemProperties
 
 class OpenApiSchemaWithNotNullSpec extends AbstractOpenApiTypeElementSpec {
 
@@ -85,5 +87,89 @@ class MyBean {}
         dtoSchema.required.size() == 2
         dtoSchema.required.contains("id")
         dtoSchema.required.contains("idJavadoc")
+    }
+
+    @RestoreSystemProperties
+    @Issue("https://github.com/micronaut-projects/micronaut-openapi/issues/2116")
+    void "test build OpenAPI spec with @NonNull / @Nullable / simple properties"() {
+
+        given:
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_CONSTRUCTOR_ARGUMENTS_AS_REQUIRED, "false")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller("/hello")
+class HelloController {
+
+    @Get
+    public HelloClass hello() {
+        return new HelloClass("Not Null Value", "Nullable");
+    }
+}
+
+class HelloClass {
+
+    @NonNull
+    private String notNullProperty;
+    @Nullable
+    private String nullableProperty;
+    private String plainProperty;
+
+    public HelloClass(@NonNull String notNullProperty, @Nullable String nullableProperty) {
+        this.notNullProperty = notNullProperty;
+        this.nullableProperty = nullableProperty;
+    }
+
+    @NonNull
+    public String getNotNullProperty() {
+        return notNullProperty;
+    }
+
+    public void setNotNullProperty(@NonNull String notNullProperty) {
+        this.notNullProperty = notNullProperty;
+    }
+
+    @Nullable
+    public String getNullableProperty() {
+        return nullableProperty;
+    }
+
+    public void setNullableProperty(@Nullable String nullableProperty) {
+        this.nullableProperty = nullableProperty;
+    }
+
+    public String getPlainProperty() {
+        return plainProperty;
+    }
+
+    public void setPlainProperty(String plainProperty) {
+        this.plainProperty = plainProperty;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+        then: "the state is correct"
+        Utils.testReference != null
+
+        when: "The OpenAPI is retrieved"
+        OpenAPI openAPI = Utils.testReference
+        Operation operation = openAPI.paths."/hello".get
+        Schema dtoSchema = openAPI.components.schemas.HelloClass
+
+        then:
+        operation
+        dtoSchema
+        dtoSchema.required.size() == 1
+        dtoSchema.required.contains("notNullProperty")
+        dtoSchema.properties.nullableProperty.nullable
     }
 }

--- a/src/main/docs/guide/configuration/availableOptions.adoc
+++ b/src/main/docs/guide/configuration/availableOptions.adoc
@@ -39,6 +39,7 @@ PACKAGE +
 PROTECTED +
 PUBLIC | Default: `PUBLIC`
 |`*micronaut.openapi.json.format*` | Is this property true, output file format will be JSON, otherwise YAML. | Default: `false`
+|`*micronaut.openapi.constructor-arguments-as-required*` | System property that enables interpret primary constructor arguments as required properties. | Default: `true`
 |`*micronaut.openapi.generator.extensions.enabled*` | If this property is 'true', then the generated OpenAPI specification will include extensions for OpenAPI Generator and the generated client according to this specification will be much more accurate than without it. For example, enumerations will be described with extensions `x-enum-varnames`, `x-enum-descriptions` and `x-deprecated` | Default: `false`
 |`*micronaut.openapi.filename*` | The name of the result swagger file. | Default: `${info.title}-${info.version}.yml`, if info block not set, filename will be `swagger.yml`.
 |`*micronaut.openapi.environments*` | Active micronaut environments which will be used for @Requires annotations. |


### PR DESCRIPTION
By config property `micronaut.openapi.constructor-arguments-as-required`

Fixed #2116