### PR TITLE
Fix `resultSchemaName` not checking all existing class entries

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -258,7 +258,7 @@ public final class SchemaDefinitionUtils {
     /**
      * Stores class name counters for schema suffix, when found classes with same name in different packages.
      */
-    private static Map<String, Integer> shemaNameSuffixCounterMap = new HashMap<>();
+    private static Map<String, Integer> schemaNameSuffixCounterMap = new HashMap<>();
     /**
      * {@link PropertyNamingStrategy} instances cache.
      */
@@ -273,7 +273,7 @@ public final class SchemaDefinitionUtils {
     public static void clean() {
         inProgressSchemas = new ArrayList<>(10);
         schemaNameToClassNameMap = new HashMap<>();
-        shemaNameSuffixCounterMap = new HashMap<>();
+        schemaNameSuffixCounterMap = new HashMap<>();
         propertyNamingStrategyInstances = new HashMap<>();
     }
 
@@ -553,18 +553,57 @@ public final class SchemaDefinitionUtils {
             }
         }
 
-        String storedClassName = schemaNameToClassNameMap.get(resultSchemaName);
+        return computeResultSchemaName(context, resultSchemaName, fullClassNameWithGenerics);
+    }
+
+    /**
+     * Computes the result schema name by resolving conflicts, if any, when multiple classes
+     * share the same base schema name. If conflicting schema names exist, a suffix is appended
+     * to ensure uniqueness. Schema names are stored and checked against a mapping of class names
+     * to schema names.
+     *
+     * @param context the context object providing metadata and configuration necessary to resolve schema names
+     * @param resultSchemaName the initial schema name to be checked and potentially modified for uniqueness
+     * @param fullClassNameWithGenerics the fully qualified class name, including generics, that corresponds to the schema name
+     * @return the resolved schema name, potentially modified with a suffix to ensure uniqueness
+     * @throws ConfigurationException if a duplicate schema name conflict is encountered, and the configured
+     *         resolution strategy does not allow duplicates
+     */
+    private static String computeResultSchemaName(VisitorContext context, String resultSchemaName, String fullClassNameWithGenerics) {
+        var genericSeparator = getGenericSeparator(context);
+
+        var storedClassName = schemaNameToClassNameMap.get(resultSchemaName);
         // Check if the class exists in other packages. If so, you need to add a suffix,
         // because there are two classes in different packages, but with the same class name.
         if (storedClassName != null && !storedClassName.equals(fullClassNameWithGenerics)) {
             if (getSchemaDuplicateResolution(context) == ConfigUtils.DuplicateResolution.ERROR) {
                 throw new ConfigurationException("Found 2 schemas with same name \"" + resultSchemaName + "\" for classes " + storedClassName + " and " + fullClassNameWithGenerics);
             }
-            int index = shemaNameSuffixCounterMap.getOrDefault(resultSchemaName, 0);
-            index++;
-            shemaNameSuffixCounterMap.put(resultSchemaName, index);
-            resultSchemaName += genericSeparator + index;
+
+            // Before adding a new entry to schemaNameToClassNameMap, check all the existing
+            // entries for this resultSchemaName.
+            var lastIndex = schemaNameSuffixCounterMap.putIfAbsent(resultSchemaName, 1);
+            // if there is no existing value, there is nothing else to check
+            if (lastIndex == null) {
+                resultSchemaName += genericSeparator + "1";
+            } else {
+                for (int i = 1; i <= lastIndex; i++) {
+                    var existingSchemaName = resultSchemaName + genericSeparator + i;
+                    var existingClassName = schemaNameToClassNameMap.get(existingSchemaName);
+                    // Check if this package matches the expected package, and if so,
+                    // return this matching entry.
+                    if (fullClassNameWithGenerics.equals(existingClassName)) {
+                        return existingSchemaName;
+                    }
+                }
+
+                // If we made it here, it means no existing entry was found.
+                // Increment the counter.
+                int index = schemaNameSuffixCounterMap.merge(resultSchemaName, 1, Integer::sum);
+                resultSchemaName += genericSeparator + index;
+            }
         }
+
         schemaNameToClassNameMap.put(resultSchemaName, fullClassNameWithGenerics);
 
         return resultSchemaName;

--- a/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelController.java
+++ b/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelController.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 
-@Path("/user")
+@Path("/model")
 class ModelController {
     @GET
     @Path("/model-one")

--- a/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelController.java
+++ b/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelController.java
@@ -1,0 +1,46 @@
+package io.micronaut.openapi.jaxrs;
+
+import io.micronaut.openapi.jaxrs.model.one.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+@Path("/user")
+class ModelController {
+    @GET
+    @Path("/model-one")
+    @Produces("application/json")
+    public Response getResponseOne() {
+        return new Response("one");
+    }
+
+    @GET
+    @Path("/model-one-b")
+    @Produces("application/json")
+    public Response getResponseOneB() {
+        return new Response("one-b");
+    }
+
+    @GET
+    @Path("/model-two")
+    @Produces("application/json")
+    public io.micronaut.openapi.jaxrs.model.two.Response getResponseTwo() {
+        return new io.micronaut.openapi.jaxrs.model.two.Response("two");
+    }
+
+    @GET
+    @Path("/model-two-b")
+    @Produces("application/json")
+    public io.micronaut.openapi.jaxrs.model.two.Response getResponseTwoB() {
+        return new io.micronaut.openapi.jaxrs.model.two.Response("two-b");
+    }
+
+    @GET
+    @Path("/model-two-c")
+    @Produces("application/json")
+    public io.micronaut.openapi.jaxrs.model.two.Response getResponseTwoC() {
+        return new io.micronaut.openapi.jaxrs.model.two.Response("two-c");
+    }
+
+}

--- a/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelControllerTest.java
+++ b/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/ModelControllerTest.java
@@ -1,0 +1,44 @@
+package io.micronaut.openapi.jaxrs;
+
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+class ModelControllerTest {
+
+    /**
+     * Two objects which generate the same schema-name, but are in different packages, should
+     * each be output exactly one time in the generated yaml's components/schema. The first object
+     * will have the expected schema-name, the second will have a `_1` appended to it.
+     */
+    @Test
+    void duplicateSchemasOnlyAppearOnce(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String responseYaml = assertDoesNotThrow(() -> client.retrieve("/swagger/demo-0.0.yml", String.class));
+        assertNotNull(responseYaml);
+        Yaml yaml = new Yaml();
+        Map<String, Object> obj = yaml.load(responseYaml);
+        assertNotNull(obj);
+        assertInstanceOf(Map.class, obj.get("components"));
+        Map<String, Object> components = (Map<String, Object>) obj.get("components");
+        assertEquals(1, components.size());
+        assertInstanceOf(Map.class, components.get("schemas"));
+        Map<String, Object> schemas = (Map<String, Object>) components.get("schemas");
+        assertEquals(2, schemas.size());
+
+        assertTrue(schemas.containsKey("Response"));
+        assertTrue(schemas.containsKey("Response_1"));
+    }
+}

--- a/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/model/one/Response.java
+++ b/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/model/one/Response.java
@@ -1,0 +1,4 @@
+package io.micronaut.openapi.jaxrs.model.one;
+
+public record Response(String body) {
+}

--- a/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/model/two/Response.java
+++ b/test-suite-java-jaxrs/src/test/java/io/micronaut/openapi/jaxrs/model/two/Response.java
@@ -1,0 +1,4 @@
+package io.micronaut.openapi.jaxrs.model.two;
+
+public record Response(String body) {
+}


### PR DESCRIPTION
- fix #2130 
- fix typo - `shemaNameSuffixCounterMap` -> `schemaNameSuffixCounterMap`
- extract `resultSchemaName` to new `computeResultSchemaName` function
    - if this is the first time this schema has been encountered (e.g. `foo.Data`)
        - add an entry to `schemaNameToClassNameMap` (e.g. `Data : foo.Data`)
    - if this is schema already exists _and_ the packages match
        - use existing `resultSchemaName` (e.g. `Data`)
     - if this schema already exists _and_ the packages do not match
         - determine how many additional schemas may exists (the value stored in `schemaNameSuffixCounterMap`)
             - if no additional entries, create an entry in `schemaNameSuffixCounterMap` (e.g. `Data : 1`) and `schemaNameToClassNameMap` (e.g. `Data_1 : foo.Data`).
         - check each of these values for a package match
             - if found, return the existing `resultSchemaName` (e.g. `Data_1`)
         - if no match is found, increment the entry in the `schemaNameSuffixCounterMap` by 1 (e.g. `Data : 2`), add an entry to `schemaNameToClassNameMap` with this new value (e.g. `Data_2 : foo.Data`)

Fixed #2130