### PR TITLE
Added support JvmOverloads, JvmRecord and java compatibility annotations for kotlin generator

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
@@ -145,6 +145,9 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     public static final String OPT_DATE_TIME_FORMAT = "dateTimeFormat";
     public static final String OPT_REACTIVE = "reactive";
     public static final String OPT_COROUTINES = "coroutines";
+    public static final String OPT_JVM_OVERLOADS = "jvmOverloads";
+    public static final String OPT_JVM_RECORD = "jvmRecord";
+    public static final String OPT_JAVA_COMPATIBILITY = "javaCompatibility";
     public static final String OPT_GENERATE_HTTP_RESPONSE_ALWAYS = "generateHttpResponseAlways";
     public static final String OPT_GENERATE_CONTROLLER_AS_ABSTRACT = "generateControllerAsAbstract";
     public static final String OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED = "generateHttpResponseWhereRequired";
@@ -190,6 +193,9 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     protected boolean ksp;
     protected boolean jsonIncludeAlwaysForRequiredFields;
     protected boolean implicitHeaders;
+    protected boolean jvmOverloads;
+    protected boolean jvmRecord;
+    protected boolean javaCompatibility = true;
     protected String implicitHeadersRegex;
     protected String appName;
     protected String dateFormat;
@@ -337,6 +343,10 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             "If true, each operation will be generated only once in the first assigned tag.", generateOperationOnlyForFirstTag));
         cliOptions.add(CliOption.newBoolean(OPT_USE_ENUM_CASE_INSENSITIVE, "Use `equalsIgnoreCase` when String for enum comparison", useEnumCaseInsensitive));
         cliOptions.add(CliOption.newBoolean(OPT_JSON_INCLUDE_ALWAYS_FOR_REQUIRED_FIELDS, "If set to true, @JsonInclude annotation will be with value ALWAYS for required properties in POJO's", jsonIncludeAlwaysForRequiredFields));
+
+        cliOptions.add(CliOption.newBoolean(OPT_JVM_OVERLOADS, "Add or not @JvmOverloads annotation for classes with properties with default values.", jvmOverloads));
+        cliOptions.add(CliOption.newBoolean(OPT_JVM_RECORD, "Add or not @JvmRecord annotation to data classes.", jvmRecord));
+        cliOptions.add(CliOption.newBoolean(OPT_JAVA_COMPATIBILITY, "Add or not @JvmField, @JvmStatic and @JvmRepeatable annotations to improve java compatibility", javaCompatibility));
 
         var testToolOption = new CliOption(OPT_TEST, "Specify which test tool to generate files for").defaultValue(testTool);
         var testToolOptionMap = new HashMap<String, String>();
@@ -587,6 +597,21 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             useEnumCaseInsensitive = convertPropertyToBoolean(OPT_USE_ENUM_CASE_INSENSITIVE);
         }
         writePropertyBack(OPT_USE_ENUM_CASE_INSENSITIVE, useEnumCaseInsensitive);
+
+        if (additionalProperties.containsKey(OPT_JVM_OVERLOADS)) {
+            jvmOverloads = convertPropertyToBoolean(OPT_JVM_OVERLOADS);
+        }
+        writePropertyBack(OPT_JVM_OVERLOADS, jvmOverloads);
+
+        if (additionalProperties.containsKey(OPT_JVM_RECORD)) {
+            jvmRecord = convertPropertyToBoolean(OPT_JVM_RECORD);
+        }
+        writePropertyBack(OPT_JVM_RECORD, jvmRecord);
+
+        if (additionalProperties.containsKey(OPT_JAVA_COMPATIBILITY)) {
+            javaCompatibility = convertPropertyToBoolean(OPT_JAVA_COMPATIBILITY);
+        }
+        writePropertyBack(OPT_JAVA_COMPATIBILITY, javaCompatibility);
 
         if (additionalProperties.containsKey(OPT_GENERATED_ANNOTATION)) {
             generatedAnnotation = convertPropertyToBoolean(OPT_GENERATED_ANNOTATION);
@@ -1192,7 +1217,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                     param.maxLength = null;
                 }
                 var paramDefaultValueInit = (String) param.vendorExtensions.get("defaultValueInit");
-                param.vendorExtensions.put("valueWithDefaultValue", ksp && (paramDefaultValueInit != null  && !paramDefaultValueInit.equals(NULL_STRING)));
+                param.vendorExtensions.put("valueWithDefaultValue", ksp && (paramDefaultValueInit != null && !paramDefaultValueInit.equals(NULL_STRING)));
                 var queryValueFormat = calcQueryValueFormat(param);
                 if (queryValueFormat != null) {
                     needToAddImportFormat = true;
@@ -2150,7 +2175,9 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 model.vendorExtensions.put("withRequiredVars", false);
                 model.vars = Collections.emptyList();
             }
-            model.vendorExtensions.put("dataClass", !model.hasChildren && model.hasVars && (!withInheritance || model.parentVars.isEmpty()) ? "data " : "");
+            var isDataClass = !model.hasChildren && model.hasVars && (!withInheritance || model.parentVars.isEmpty());
+            model.vendorExtensions.put("dataClass", isDataClass ? "data " : "");
+            model.vendorExtensions.put("isDataClass", isDataClass);
 
             addStrValueToEnum(model);
         }
@@ -2200,6 +2227,22 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                     }
                 }
             }
+        }
+
+        for (var models : objs.values()) {
+            CodegenModel model = models.getModels().get(0).getModel();
+            var props = (List<CodegenProperty>) model.vendorExtensions.get("requiredVarsWithoutDiscriminator");
+            if (props == null || props.isEmpty()) {
+                continue;
+            }
+            for (var prop : props) {
+                var defaultValueInit = prop.vendorExtensions.get("defaultValueInit");
+                if (defaultValueInit != null && !defaultValueInit.toString().isEmpty()) {
+                    model.vendorExtensions.put("hasDefaultValues", true);
+                }
+                prop.vendorExtensions.put("isDataClass", model.vendorExtensions.get("isDataClass"));
+            }
+
         }
 
         return objs;
@@ -2413,7 +2456,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         normalizeExtraAnnotations(EXT_ANNOTATIONS_SETTER, true, property.vendorExtensions);
 
         var defaultValueInit = (String) property.vendorExtensions.get("defaultValueInit");
-        property.vendorExtensions.put("valueWithDefaultValue", ksp && defaultValueInit != null && !defaultValueInit.equals(NULL_STRING));
+        var valueWithDefaultValue = ksp && defaultValueInit != null && !defaultValueInit.equals(NULL_STRING);
+        property.vendorExtensions.put("valueWithDefaultValue", valueWithDefaultValue);
+        if (valueWithDefaultValue) {
+            model.vendorExtensions.put("hasDefaultValues", true);
+        }
     }
 
     private void processParentModel(CodegenModel model, List<CodegenProperty> requiredVarsWithoutDiscriminator,
@@ -3016,6 +3063,18 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
 
     public void setUseEnumCaseInsensitive(boolean useEnumCaseInsensitive) {
         this.useEnumCaseInsensitive = useEnumCaseInsensitive;
+    }
+
+    public void setJvmOverloads(boolean jvmOverloads) {
+        this.jvmOverloads = jvmOverloads;
+    }
+
+    public void setJvmRecord(boolean jvmRecord) {
+        this.jvmRecord = jvmRecord;
+    }
+
+    public void setJavaCompatibility(boolean javaCompatibility) {
+        this.javaCompatibility = javaCompatibility;
     }
 
     public void setAdditionalOneOfTypeAnnotations(List<String> additionalOneOfTypeAnnotations) {

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
@@ -442,6 +442,9 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         private boolean generatedAnnotation = true;
         private boolean ksp;
         private boolean coroutines;
+        private boolean jvmOverloads;
+        private boolean jvmRecord;
+        private boolean javaCompatibility = true;
 
         @Override
         public KotlinMicronautClientOptionsBuilder withAuthorization(boolean useAuth) {
@@ -563,6 +566,24 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
             return this;
         }
 
+        @Override
+        public KotlinMicronautClientOptionsBuilder withJvmOverloads(boolean jvmOverloads) {
+            this.jvmOverloads = jvmOverloads;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withJvmRecord(boolean jvmRecord) {
+            this.jvmRecord = jvmRecord;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withJavaCompatibility(boolean javaCompatibility) {
+            this.javaCompatibility = javaCompatibility;
+            return this;
+        }
+
         ClientOptions build() {
             return new ClientOptions(
                 additionalClientTypeAnnotations,
@@ -584,7 +605,10 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
                 fluxForArrays,
                 generatedAnnotation,
                 ksp,
-                coroutines
+                coroutines,
+                jvmOverloads,
+                jvmRecord,
+                javaCompatibility
             );
         }
     }
@@ -609,7 +633,10 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         boolean fluxForArrays,
         boolean generatedAnnotation,
         boolean ksp,
-        boolean coroutines
+        boolean coroutines,
+        boolean jvmOverloads,
+        boolean jvmRecord,
+        boolean javaCompatibility
     ) {
     }
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientOptionsBuilder.java
@@ -210,4 +210,31 @@ public interface KotlinMicronautClientOptionsBuilder extends GeneratorOptionsBui
      * @return this builder
      */
     KotlinMicronautClientOptionsBuilder withCoroutines(boolean coroutines);
+
+    /**
+     * Add or not @JvmOverloads annotation for classes with properties with default values. Default: false
+     *
+     * @param jvmOverloads if true, then @JvmOverload annotation will be added to classes with properties with default values
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withJvmOverloads(boolean jvmOverloads);
+
+    /**
+     * Add or not @JvmRecord annotation to data classes. Default: false
+     *
+     * @param jvmRecord if true, then @JvmRecord annotation will be added to data classes
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withJvmRecord(boolean jvmRecord);
+
+    /**
+     * Add or not @JvmField, @JvmStatic and @JvmRepeatable annotations to improve java compatibility. Default: true
+     *
+     * @param javaCompatibility if true, then @JvmField, @JvmStatic and @JvmRepeatable annotations wil be added where it needed to improve java compatibility
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withJavaCompatibility(boolean javaCompatibility);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
@@ -330,6 +330,9 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         private boolean ksp;
         private boolean coroutines;
         private boolean generateStreamingFileUpload;
+        private boolean jvmOverloads;
+        private boolean jvmRecord;
+        private boolean javaCompatibility = true;
 
         @Override
         public KotlinMicronautServerOptionsBuilder withControllerPackage(String controllerPackage) {
@@ -403,6 +406,24 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
             return this;
         }
 
+        @Override
+        public KotlinMicronautServerOptionsBuilder withJvmOverloads(boolean jvmOverloads) {
+            this.jvmOverloads = jvmOverloads;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautServerOptionsBuilder withJvmRecord(boolean jvmRecord) {
+            this.jvmRecord = jvmRecord;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautServerOptionsBuilder withJavaCompatibility(boolean javaCompatibility) {
+            this.javaCompatibility = javaCompatibility;
+            return this;
+        }
+
         ServerOptions build() {
             return new ServerOptions(
                 controllerPackage,
@@ -416,7 +437,10 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
                 aot,
                 ksp,
                 coroutines,
-                generateStreamingFileUpload
+                generateStreamingFileUpload,
+                jvmOverloads,
+                jvmRecord,
+                javaCompatibility
             );
         }
     }
@@ -433,7 +457,10 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         boolean aot,
         boolean ksp,
         boolean coroutines,
-        boolean generateStreamingFileUpload
+        boolean generateStreamingFileUpload,
+        boolean jvmOverloads,
+        boolean jvmRecord,
+        boolean javaCompatibility
     ) {
     }
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerOptionsBuilder.java
@@ -128,4 +128,31 @@ public interface KotlinMicronautServerOptionsBuilder extends GeneratorOptionsBui
      * @return this builder
      */
     KotlinMicronautServerOptionsBuilder withGenerateStreamingFileUpload(boolean generateStreamingFileUpload);
+
+    /**
+     * Add or not @JvmOverloads annotation for classes with properties with default values. Default: false
+     *
+     * @param jvmOverloads if true, then @JvmOverload annotation will be added to classes with properties with default values
+     *
+     * @return this builder
+     */
+    KotlinMicronautServerOptionsBuilder withJvmOverloads(boolean jvmOverloads);
+
+    /**
+     * Add or not @JvmRecord annotation to data classes. Default: false
+     *
+     * @param jvmRecord if true, then @JvmRecord annotation will be added to data classes
+     *
+     * @return this builder
+     */
+    KotlinMicronautServerOptionsBuilder withJvmRecord(boolean jvmRecord);
+
+    /**
+     * Add or not @JvmField, @JvmStatic and @JvmRepeatable annotations to improve java compatibility. Default: true
+     *
+     * @param javaCompatibility if true, then @JvmField, @JvmStatic and @JvmRepeatable annotations wil be added where it needed to improve java compatibility
+     *
+     * @return this builder
+     */
+    KotlinMicronautServerOptionsBuilder withJavaCompatibility(boolean javaCompatibility);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -418,6 +418,9 @@ public final class MicronautCodeGeneratorEntryPoint {
             kotlinServerCodegen.setFluxForArrays(kotlinServerOptions.fluxForArrays());
             kotlinServerCodegen.setGenerateStreamingFileUpload(kotlinServerOptions.generateStreamingFileUpload());
             kotlinServerCodegen.setAot(kotlinServerOptions.aot());
+            kotlinServerCodegen.setJvmOverloads(kotlinServerOptions.jvmOverloads());
+            kotlinServerCodegen.setJvmRecord(kotlinServerOptions.jvmRecord());
+            kotlinServerCodegen.setJavaCompatibility(kotlinServerOptions.javaCompatibility());
         }
     }
 
@@ -455,6 +458,9 @@ public final class MicronautCodeGeneratorEntryPoint {
             kotlinClientCodegen.setFluxForArrays(kotlinClientOptions.fluxForArrays());
             kotlinClientCodegen.setKsp(kotlinClientOptions.ksp());
             kotlinClientCodegen.setCoroutines(kotlinClientOptions.coroutines());
+            kotlinClientCodegen.setJvmOverloads(kotlinClientOptions.jvmOverloads());
+            kotlinClientCodegen.setJvmRecord(kotlinClientOptions.jvmRecord());
+            kotlinClientCodegen.setJavaCompatibility(kotlinClientOptions.javaCompatibility());
         }
     }
 

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/Authorization.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/Authorization.mustache
@@ -17,7 +17,12 @@ import {{javaxPackage}}.annotation.Generated
 @MustBeDocumented
 @Retention(RUNTIME)
 @Target(FUNCTION, ANNOTATION_CLASS)
+{{#javaCompatibility}}
+@JvmRepeatable(Authorizations::class)
+{{/javaCompatibility}}
+{{^javaCompatibility}}
 @Repeatable
+{{/javaCompatibility}}
 annotation class Authorization(
 
     /**

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/AuthorizationFilter.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/auth/AuthorizationFilter.mustache
@@ -131,7 +131,9 @@ open class AuthorizationFilter(
 
     companion object {
 
+    {{#javaCompatibility}}
         @JvmField
+    {{/javaCompatibility}}
         val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
 {{/useOauth}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/enum.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/enum.mustache
@@ -50,7 +50,9 @@
 
     companion object {
 
+    {{#javaCompatibility}}
         @JvmField
+    {{/javaCompatibility}}
         val VALUE_MAPPING = entries.associateBy { it.value{{#useEnumCaseInsensitive}}.lowercase(){{/useEnumCaseInsensitive}} }
 
         /**
@@ -60,8 +62,10 @@
          *
          * @return The enum
          */
-        @JsonCreator
+    {{#javaCompatibility}}
         @JvmStatic
+    {{/javaCompatibility}}
+        @JsonCreator
         fun fromValue(value: {{{dataType}}}): {{>common/model/enumName}}{{#isNullable}}?{{/isNullable}} {{openbrace}}{{#formatNoEmptyLines}}
             {{#isString}}{{#useEnumCaseInsensitive}}
             val key = value.lowercase()

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/pojo.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/model/pojo.mustache
@@ -44,8 +44,12 @@
 {{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 {{/formatNoEmptyLines}}
-{{!Declare the class with extends and implements}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{#hasChildren}}open {{/hasChildren}}{{vendorExtensions.dataClass}}class {{classname}}{{#hasVars}}({{/hasVars}}
+{{#vendorExtensions.isDataClass}}
+    {{#jvmRecord}}
+@JvmRecord
+    {{/jvmRecord}}
+{{/vendorExtensions.isDataClass}}
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#hasChildren}}open {{/hasChildren}}{{vendorExtensions.dataClass}}class {{classname}}{{#hasVars}}{{#vendorExtensions.hasDefaultValues}}{{#jvmOverloads}} @JvmOverloads constructor{{/jvmOverloads}}{{/vendorExtensions.hasDefaultValues}}({{/hasVars}}
 {{#vendorExtensions.requiredVarsWithoutDiscriminator}}
 
     {{#formatNoEmptyLines}}
@@ -66,7 +70,7 @@
         {{/deprecated}}
     {{/description}}
     {{>common/model/field_annotations}}
-    {{^vendorExtensions.isParentVar}}{{#vendorExtensions.overridden}}override {{/vendorExtensions.overridden}}{{^vendorExtensions.overridden}}{{#hasChildren}}open {{/hasChildren}}{{/vendorExtensions.overridden}}var {{/vendorExtensions.isParentVar}}{{{name}}}: {{{vendorExtensions.typeWithEnumWithGenericAnnotations}}}{{#vendorExtensions.defaultValueInit}} = {{{.}}}{{/vendorExtensions.defaultValueInit}}{{^vendorExtensions.defaultValueInit}}{{#isNullable}} = null{{/isNullable}}{{/vendorExtensions.defaultValueInit}},
+    {{^vendorExtensions.isParentVar}}{{#vendorExtensions.overridden}}override {{/vendorExtensions.overridden}}{{^vendorExtensions.overridden}}{{#hasChildren}}open {{/hasChildren}}{{/vendorExtensions.overridden}}{{#jvmRecord}}{{#vendorExtensions.isDataClass}}val{{/vendorExtensions.isDataClass}}{{^vendorExtensions.isDataClass}}var{{/vendorExtensions.isDataClass}}{{/jvmRecord}}{{^jvmRecord}}var{{/jvmRecord}} {{/vendorExtensions.isParentVar}}{{{name}}}: {{{vendorExtensions.typeWithEnumWithGenericAnnotations}}}{{#vendorExtensions.defaultValueInit}} = {{{.}}}{{/vendorExtensions.defaultValueInit}}{{^vendorExtensions.defaultValueInit}}{{#isNullable}} = null{{/isNullable}}{{/vendorExtensions.defaultValueInit}},
     {{/formatNoEmptyLines}}
 {{/vendorExtensions.requiredVarsWithoutDiscriminator}}
 {{#hasVars}}){{/hasVars}}{{#parent}} : {{{parent}}}({{#vendorExtensions.requiredParentVarsWithoutDiscriminator}}{{{name}}}{{^-last}}, {{/-last}}{{/vendorExtensions.requiredParentVarsWithoutDiscriminator}}){{/parent}}{{#vendorExtensions.x-implements}}{{#parent}}, {{/parent}}{{^parent}} : {{/parent}}{{^-first}}, {{/-first}}{{{.}}}{{/vendorExtensions.x-implements}} {{openbrace}}
@@ -125,8 +129,10 @@
     companion object {
     {{#serializableModel}}
 
-        @Serial
+        {{#javaCompatibility}}
         @JvmStatic
+        {{/javaCompatibility}}
+        @Serial
         private val serialVersionUID = {{{vendorExtensions.serialId}}}L
     {{/serializableModel}}
 
@@ -139,8 +145,10 @@
         {{#serializableModel}}
     companion object {
 
-        @Serial
+        {{#javaCompatibility}}
         @JvmStatic
+        {{/javaCompatibility}}
+        @Serial
         private val serialVersionUID = {{{vendorExtensions.serialId}}}L
     }
         {{/serializableModel}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -1561,34 +1561,34 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             arguments("oneOf_polymorphismAndInheritance.yml", Map.of(
                 "Bar.kt", """
                     class Bar(
-
+                    
                         @Nullable
                         @JsonProperty(JSON_PROPERTY_ID)
                         id: String? = null,
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_BAR_PROP_A)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var barPropA: String? = null,
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_FOO_PROP_B)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var fooPropB: String? = null,
-
+                    
                         @field:Nullable
                         @field:Valid
                         @field:JsonProperty(JSON_PROPERTY_FOO)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var foo: FooRefOrValue? = null,
-
+                    
                         /**
                          * When sub-classing, this defines the sub-class Extensible name
                          */
                         @Nullable
                         @JsonProperty(JSON_PROPERTY_AT_TYPE)
                         atType: String? = null,
-
+                    
                         /**
                          * Hyperlink reference
                          */
@@ -1596,7 +1596,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                         @JsonProperty(JSON_PROPERTY_HREF)
                         @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         href: String? = null,
-
+                    
                         /**
                          * A URI to a JSON-Schema file that defines additional attributes and relationships
                          */
@@ -1604,7 +1604,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                         @JsonProperty(JSON_PROPERTY_AT_SCHEMA_LOCATION)
                         @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         atSchemaLocation: String? = null,
-
+                    
                         /**
                          * When sub-classing, this defines the super-class
                          */
@@ -1616,11 +1616,11 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                     """,
                 "Banana.kt", """
                     data class Banana(
-
+                    
                         @field:NotNull
                         @field:JsonProperty(JSON_PROPERTY_LENGTH)
                         var length: Int,
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_FRUIT_TYPE)
                         override var fruitType: FruitType? = null,
@@ -1628,14 +1628,14 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                     """,
                 "Entity.kt", """
                     open class Entity(
-
+                    
                         /**
                          * When sub-classing, this defines the sub-class Extensible name
                          */
                         @field:NotNull
                         @field:JsonProperty(JSON_PROPERTY_AT_TYPE)
                         open var atType: String? = null,
-
+                    
                         /**
                          * Hyperlink reference
                          */
@@ -1643,7 +1643,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                         @field:JsonProperty(JSON_PROPERTY_HREF)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         open var href: String? = null,
-
+                    
                         /**
                          * unique identifier
                          */
@@ -1651,7 +1651,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                         @field:JsonProperty(JSON_PROPERTY_ID)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         open var id: String? = null,
-
+                    
                         /**
                          * A URI to a JSON-Schema file that defines additional attributes and relationships
                          */
@@ -1659,7 +1659,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                         @field:JsonProperty(JSON_PROPERTY_AT_SCHEMA_LOCATION)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         open var atSchemaLocation: String? = null,
-
+                    
                         /**
                          * When sub-classing, this defines the super-class
                          */
@@ -1672,7 +1672,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             arguments("oneOf_additionalProperties.yml", Map.of(
                 "SchemaA.kt", """
                     data class SchemaA(
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_PROP_A)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
@@ -1689,7 +1689,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             arguments("oneOf_primitive.yml", Map.of(
                 "Child.kt", """
                     data class Child(
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_NAME)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
@@ -1703,12 +1703,12 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 "Fruit.kt", "interface Fruit {",
                 "Banana.kt", """
                     data class Banana(
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_LENGTH_CM)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var lengthCm: BigDecimal? = null,
-
+                    
                         @Nullable
                         @JsonProperty(JSON_PROPERTY_FRUIT_TYPE)
                         override var fruitType: String? = null,
@@ -1716,19 +1716,19 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                     """,
                 "Apple.kt", """
                     data class Apple(
-
+                    
                         @field:Nullable
                         @field:Pattern(regexp = "^[a-zA-Z\\\\s]*$")
                         @field:JsonProperty(JSON_PROPERTY_CULTIVAR)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var cultivar: String? = null,
-
+                    
                         @field:Nullable
                         @field:Pattern(regexp = "/^[A-Z\\\\s]*$/i")
                         @field:JsonProperty(JSON_PROPERTY_ORIGIN)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
                         var origin: String? = null,
-
+                    
                         @Nullable
                         @JsonProperty(JSON_PROPERTY_FRUIT_TYPE)
                         override var fruitType: String? = null,
@@ -1740,7 +1740,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 "Fruit.kt", "interface Fruit",
                 "Grape.kt", """
                     data class Grape(
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_COLOR)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
@@ -1749,7 +1749,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                     """,
                 "Apple.kt", """
                     data class Apple(
-
+                    
                         @field:Nullable
                         @field:JsonProperty(JSON_PROPERTY_KIND)
                         @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
@@ -2044,5 +2044,176 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "import io.micronaut.http.filter.FilterPatternStyle",
             "@Filter(excludeServiceId = [\"test1\", \"test2\", \"test3\"], patternStyle = FilterPatternStyle.REGEX, patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
+    }
+
+    @Test
+    void testJvmOverloadsAndJvmRecordAndJavaCompatibility() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.setJvmOverloads(true);
+        codegen.setJvmRecord(true);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
+        // Constructor should have properties
+        String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+        assertFileContains(modelPath + "Pet.kt",
+            """
+                @JvmRecord
+                data class Pet @JvmOverloads constructor(
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_NAME)
+                    val name: String,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+                    val photoUrls: List<@NotNull String>,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_ID)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    val id: Long? = null,
+                
+                    @field:Nullable
+                    @field:Valid
+                    @field:JsonProperty(JSON_PROPERTY_CATEGORY)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    val category: Category? = null,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_TAGS)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    val tags: List<@Valid Tag>? = null,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_STATUS)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    val status: PetStatus? = null,
+                ) {
+                """);
+        assertFileContains(modelPath + "OrderStatus.kt",
+            """
+                        @JvmField
+                        val VALUE_MAPPING = entries.associateBy { it.value }
+                """,
+            """
+                        @JvmStatic
+                        @JsonCreator
+                        fun fromValue(value: String): OrderStatus {
+                """
+        );
+    }
+
+    @Test
+    void testJvmOverloadsAndNotJavaCompatibility() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.setJvmOverloads(true);
+        codegen.setJvmRecord(false);
+        codegen.setJavaCompatibility(false);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
+        // Constructor should have properties
+        String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFileNotContains(modelPath + "Pet.kt", "@JvmRecord");
+        assertFileContains(modelPath + "Pet.kt",
+            """
+                data class Pet @JvmOverloads constructor(
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_NAME)
+                    var name: String,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+                    var photoUrls: List<@NotNull String>,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_ID)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    var id: Long? = null,
+                
+                    @field:Nullable
+                    @field:Valid
+                    @field:JsonProperty(JSON_PROPERTY_CATEGORY)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    var category: Category? = null,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_TAGS)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    var tags: List<@Valid Tag>? = null,
+                
+                    @field:Nullable
+                    @field:JsonProperty(JSON_PROPERTY_STATUS)
+                    @field:JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+                    var status: PetStatus? = null,
+                ) {
+                """);
+        assertFileNotContains(modelPath + "OrderStatus.kt", "@JvmField", "@JvmStatic");
+    }
+
+    @Test
+    void testJvmOverloadsWithoutDefaultValues() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.setJvmOverloads(true);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/openmeteo.yml", CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
+        // Constructor should have properties
+        String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFileContains(modelPath + "CurrentWeather.kt",
+            """
+                data class CurrentWeather(
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_TIME)
+                    var time: String,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_TEMPERATURE)
+                    var temperature: Float,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_WINDSPEED)
+                    var windspeed: Float,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_WINDDIRECTION)
+                    var winddirection: Float,
+                
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_WEATHERCODE)
+                    var weathercode: Int,
+                ) {
+                """);
+        assertFileContains(modelPath + "DailyResponse.kt", "data class DailyResponse @JvmOverloads constructor(");
+    }
+
+    @Test
+    void testJvmRecordWithInheritance() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.setJvmRecord(true);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/readonlyconstructorbug.yml", CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
+        // Constructor should have properties
+        String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFileContains(modelPath + "BookInfo.kt",
+            """
+                @JsonSubTypes(
+                    JsonSubTypes.Type(value = ExtendedBookInfo::class, name = "EXTENDED"),
+                )
+                open class BookInfo(
+
+                    @field:NotNull
+                    @field:JsonProperty(JSON_PROPERTY_NAME)
+                    open var name: String,
+                """);
+        assertFileContains(modelPath + "ExtendedBookInfo.kt",
+            """
+                @Generated("io.micronaut.openapi.generator.KotlinMicronautClientCodegen")
+                class ExtendedBookInfo(
+                
+                    @field:NotNull
+                    @field:Pattern(regexp = "[0-9]{13}")
+                    @field:JsonProperty(JSON_PROPERTY_ISBN)
+                    var isbn: String,
+                """);
     }
 }


### PR DESCRIPTION
Added new kotlin settings:
```
jvmOverloads = true # Add or not @JvmOverloads annotation for classes with properties with default values. Deault: false
jvmRecord = true # Add or not @JvmRecord annotation to data classes. Deault: false
javaCompatibility = true # Add or not @JvmField, @JvmStatic and @JvmRepeatable annotations to improve java compatibility. Deault: true
```

See details: https://github.com/micronaut-projects/micronaut-openapi/discussions/2153