### PR TITLE
Fixed EnumConverterConfig: added lost import when used lombok

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -44,7 +44,6 @@ import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.IJsonSchemaValidationProperties;
-import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.VendorExtension;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
@@ -711,10 +710,6 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         additionalProperties.put("formatOneEmptyLine", new Formatting.LineFormatter(1));
         additionalProperties.put("formatSingleLine", new Formatting.SingleLineFormatter());
         additionalProperties.put("indent", new Formatting.IndentFormatter(4));
-
-        if (generateEnumConverters) {
-            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", "EnumConverterConfig.java"));
-        }
     }
 
     public void addParameterMappings(List<ParameterMapping> parameterMappings) {
@@ -1454,7 +1449,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
 
         var converterCounters = new HashMap<String, Integer>();
         var enumParams = new ArrayList<CodegenParameter>();
-        var enumImports = new ArrayList<String>(enumParams.size());
+        var enumImports = new ArrayList<String>();
 
         for (CodegenOperation op : operationList) {
             // Set whether body is supported in request

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
@@ -49,7 +49,6 @@ import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.IJsonSchemaValidationProperties;
-import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.VendorExtension;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.AbstractKotlinCodegen;
@@ -780,10 +779,6 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         additionalProperties.put("formatOneEmptyLine", new Formatting.LineFormatter(1));
         additionalProperties.put("formatSingleLine", new Formatting.SingleLineFormatter());
         additionalProperties.put("indent", new Formatting.IndentFormatter(4));
-
-        if (generateEnumConverters) {
-            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", "EnumConverterConfig.kt"));
-        }
     }
 
     public void addParameterMappings(List<ParameterMapping> parameterMappings) {
@@ -1116,7 +1111,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
 
         var converterCounters = new HashMap<String, Integer>();
         var enumParams = new ArrayList<CodegenParameter>();
-        var enumImports = new ArrayList<String>(enumParams.size());
+        var enumImports = new ArrayList<String>();
 
         for (CodegenOperation op : operationList) {
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.openapi.generator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
@@ -178,6 +179,18 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
                 param.vendorExtensions.put("hasNotBodyParam", hasNotBodyParam);
                 param.vendorExtensions.put("hasMultipleParams", hasMultipleParams);
             }
+        }
+
+        var enumParams = (List<String>) additionalProperties.get("enumParams");
+        if (generateEnumConverters && !enumParams.isEmpty()) {
+            var enumConfigName = "Client";
+            if (clientId != null) {
+                enumConfigName = StringUtils.capitalize(clientId.replace("-", ""));
+            }
+            var enumConfigClassName = "EnumConverter" + enumConfigName + "Config";
+            additionalProperties.put("enumConfigClassName", enumConfigClassName);
+            final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
+            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", enumConfigClassName + ".java"));
         }
 
         return objs;

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
@@ -332,6 +332,15 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
             }
         }
 
+        var enumParams = (List<String>) additionalProperties.get("enumParams");
+        if (generateEnumConverters && !enumParams.isEmpty()) {
+            var enumConfigName = "Server";
+            var enumConfigClassName = "EnumConverter" + enumConfigName + "Config";
+            additionalProperties.put("enumConfigClassName", enumConfigClassName);
+            final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
+            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", enumConfigClassName + ".java"));
+        }
+
         return objs;
     }
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.openapi.generator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
@@ -178,6 +179,18 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
                 param.vendorExtensions.put("hasNotBodyParam", hasNotBodyParam);
                 param.vendorExtensions.put("hasMultipleParams", hasMultipleParams);
             }
+        }
+
+        var enumParams = (List<String>) additionalProperties.get("enumParams");
+        if (generateEnumConverters && !enumParams.isEmpty()) {
+            var enumConfigName = "Client";
+            if (clientId != null) {
+                enumConfigName = StringUtils.capitalize(clientId.replace("-", ""));
+            }
+            var enumConfigClassName = "EnumConverter" + enumConfigName + "Config";
+            additionalProperties.put("enumConfigClassName", enumConfigClassName);
+            final String invokerFolder = (sourceFolder + '/' + packageName).replace(".", "/");
+            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", enumConfigClassName + ".kt"));
         }
 
         return objs;

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
@@ -312,6 +312,15 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
             }
         }
 
+        var enumParams = (List<String>) additionalProperties.get("enumParams");
+        if (generateEnumConverters && !enumParams.isEmpty()) {
+            var enumConfigName = "Server";
+            var enumConfigClassName = "EnumConverter" + enumConfigName + "Config";
+            additionalProperties.put("enumConfigClassName", enumConfigClassName);
+            final String invokerFolder = (sourceFolder + '/' + packageName).replace(".", "/");
+            supportingFiles.add(new SupportingFile("common/EnumConverterConfig.mustache", invokerFolder + "/config", enumConfigClassName + ".kt"));
+        }
+
         return objs;
     }
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -939,13 +939,13 @@ public final class MicronautCodeGeneratorEntryPoint {
             @Override
             public MicronautCodeGeneratorOptionsBuilder withUseTags(boolean useTags) {
                 this.useTags = useTags;
-                return null;
+                return this;
             }
 
             @Override
             public MicronautCodeGeneratorOptionsBuilder withGenerateOperationOnlyForFirstTag(boolean generateOperationOnlyForFirstTag) {
                 this.generateOperationOnlyForFirstTag = generateOperationOnlyForFirstTag;
-                return null;
+                return this;
             }
 
             @Override

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/EnumConverterConfig.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/EnumConverterConfig.mustache
@@ -8,6 +8,9 @@ import io.micronaut.serde.ObjectMapper;
 {{#generatedAnnotation}}
 import {{javaxPackage}}.annotation.Generated;
 {{/generatedAnnotation}}
+{{#lombok}}
+import lombok.RequiredArgsConstructor;
+{{/lombok}}
 {{#enumImports}}
 import {{{.}}};
 {{/enumImports}}
@@ -21,12 +24,12 @@ import java.io.IOException;
 {{#generatedAnnotation}}
 {{>common/generatedAnnotation}}
 {{/generatedAnnotation}}
-public class EnumConverterConfig {
+public class {{{enumConfigClassName}}} {
 
     private final ObjectMapper objectMapper;
 {{^lombok}}
 
-    public EnumConverterConfig(ObjectMapper objectMapper) {
+    public {{{enumConfigClassName}}}(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 {{/lombok}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/EnumConverterConfig.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/EnumConverterConfig.mustache
@@ -18,7 +18,7 @@ import java.io.IOException
 {{#generatedAnnotation}}
 {{>common/generatedAnnotation}}
 {{/generatedAnnotation}}
-class EnumConverterConfig(
+class {{{enumConfigClassName}}}(
     private val objectMapper: ObjectMapper,
 ) {
 {{#enumParams}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -1894,9 +1894,9 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/java/org/openapitools/config/";
-        assertFileExists(path + "EnumConverterConfig.java");
+        assertFileExists(path + "EnumConverterClientConfig.java");
 
-        assertFileContains(path + "EnumConverterConfig.java",
+        assertFileContains(path + "EnumConverterClientConfig.java",
             "import org.openapitools.model.BytePrimitiveEnum;",
             "import org.openapitools.model.CharPrimitiveEnum;",
             "import org.openapitools.model.DecimalEnum;",
@@ -1910,6 +1910,58 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             "import org.openapitools.model.LongPrimitiveEnum;",
             "import org.openapitools.model.ShortPrimitiveEnum;",
             "import org.openapitools.model.StringEnum;",
+            "public class EnumConverterClientConfig {",
+            "public EnumConverterClientConfig(ObjectMapper objectMapper) {",
+            """
+                    @Bean
+                    public TypeConverter<String, StringEnum> toEnumStringEnum() {
+                        return commonToEnumConverter(StringEnum.class, objectMapper);
+                    }
+                
+                    @Bean
+                    public TypeConverter<StringEnum, String> toStrStringEnum() {
+                        return commonToStrConverter(StringEnum.class, objectMapper);
+                    }
+                """,
+            """
+                    @Bean
+                    public TypeConverter<String, ShortPrimitiveEnum> toEnumShortPrimitiveEnum() {
+                        return commonToEnumConverter(ShortPrimitiveEnum.class, objectMapper);
+                    }
+                
+                    @Bean
+                    public TypeConverter<ShortPrimitiveEnum, String> toStrShortPrimitiveEnum() {
+                        return commonToStrConverter(ShortPrimitiveEnum.class, objectMapper);
+                    }
+                """
+        );
+    }
+
+    @Test
+    void testEnumConvertersConfigWithCustomClientId() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.setClientId("myApiClient");
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/java/org/openapitools/config/";
+        assertFileExists(path + "EnumConverterMyApiClientConfig.java");
+
+        assertFileContains(path + "EnumConverterMyApiClientConfig.java",
+            "import org.openapitools.model.BytePrimitiveEnum;",
+            "import org.openapitools.model.CharPrimitiveEnum;",
+            "import org.openapitools.model.DecimalEnum;",
+            "import org.openapitools.model.DoubleEnum;",
+            "import org.openapitools.model.DoublePrimitiveEnum;",
+            "import org.openapitools.model.FloatEnum;",
+            "import org.openapitools.model.FloatPrimitiveEnum;",
+            "import org.openapitools.model.IntEnum;",
+            "import org.openapitools.model.IntPrimitiveEnum;",
+            "import org.openapitools.model.LongEnum;",
+            "import org.openapitools.model.LongPrimitiveEnum;",
+            "import org.openapitools.model.ShortPrimitiveEnum;",
+            "import org.openapitools.model.StringEnum;",
+            "public class EnumConverterMyApiClientConfig {",
             """
                     @Bean
                     public TypeConverter<String, StringEnum> toEnumStringEnum() {
@@ -1942,40 +1994,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/java/org/openapitools/config/";
-        assertFileExists(path + "EnumConverterConfig.java");
-
-        assertFileContains(path + "EnumConverterConfig.java",
-            """
-                public class EnumConverterConfig {
-                
-                    private final ObjectMapper objectMapper;
-                
-                    public EnumConverterConfig(ObjectMapper objectMapper) {
-                        this.objectMapper = objectMapper;
-                    }
-                
-                    public static <T> TypeConverter<T, String> commonToStrConverter(Class<T> clazz, ObjectMapper objectMapper) {
-                        return TypeConverter.of(clazz, String.class, (value) -> {
-                            try {
-                                return objectMapper.writeValueAsString(value);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
-                    }
-                
-                    public static <T> TypeConverter<String, T> commonToEnumConverter(Class<T> clazz, ObjectMapper objectMapper) {
-                        return TypeConverter.of(String.class, clazz, (value) -> {
-                            try {
-                                return objectMapper.readValue(value, clazz);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
-                    }
-                }
-                """
-        );
+        assertFileDoesntExist(path + "EnumConverterClientConfig.java");
     }
 
     @Test
@@ -1986,6 +2005,26 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/java/org/openapitools/config/";
-        assertFileDoesntExist(path + "EnumConverterConfig.java");
+        assertFileDoesntExist(path + "EnumConverterClientConfig.java");
+    }
+
+    @Test
+    void testEnumConvertersWithLombok() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.setLombok(true);
+        codegen.setGeneratedAnnotation(false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/java/org/openapitools/config/";
+        assertFileExists(path + "EnumConverterClientConfig.java");
+        assertFileContains(path + "EnumConverterClientConfig.java",
+            "import lombok.RequiredArgsConstructor;",
+            """
+                @RequiredArgsConstructor
+                @Factory
+                public class EnumConverterClientConfig {
+                """
+        );
     }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -870,4 +870,75 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
             "@QueryValue(\"fieldsDeepObject\") @NotNull @Format(FORMAT_DEEP_OBJECT) Map<String, @NotNull String> fieldsDeepObject"
         );
     }
+
+    @Test
+    void testEnumConvertersConfig() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/java/org/openapitools/config/";
+        assertFileExists(path + "EnumConverterServerConfig.java");
+
+        assertFileContains(path + "EnumConverterServerConfig.java",
+            "import org.openapitools.model.BytePrimitiveEnum;",
+            "import org.openapitools.model.CharPrimitiveEnum;",
+            "import org.openapitools.model.DecimalEnum;",
+            "import org.openapitools.model.DoubleEnum;",
+            "import org.openapitools.model.DoublePrimitiveEnum;",
+            "import org.openapitools.model.FloatEnum;",
+            "import org.openapitools.model.FloatPrimitiveEnum;",
+            "import org.openapitools.model.IntEnum;",
+            "import org.openapitools.model.IntPrimitiveEnum;",
+            "import org.openapitools.model.LongEnum;",
+            "import org.openapitools.model.LongPrimitiveEnum;",
+            "import org.openapitools.model.ShortPrimitiveEnum;",
+            "import org.openapitools.model.StringEnum;",
+            "public class EnumConverterServerConfig {",
+            "public EnumConverterServerConfig(ObjectMapper objectMapper) {",
+            """
+                    @Bean
+                    public TypeConverter<String, StringEnum> toEnumStringEnum() {
+                        return commonToEnumConverter(StringEnum.class, objectMapper);
+                    }
+                
+                    @Bean
+                    public TypeConverter<StringEnum, String> toStrStringEnum() {
+                        return commonToStrConverter(StringEnum.class, objectMapper);
+                    }
+                """,
+            """
+                    @Bean
+                    public TypeConverter<String, ShortPrimitiveEnum> toEnumShortPrimitiveEnum() {
+                        return commonToEnumConverter(ShortPrimitiveEnum.class, objectMapper);
+                    }
+                
+                    @Bean
+                    public TypeConverter<ShortPrimitiveEnum, String> toStrShortPrimitiveEnum() {
+                        return commonToStrConverter(ShortPrimitiveEnum.class, objectMapper);
+                    }
+                """
+        );
+    }
+
+    @Test
+    void testEnumConvertersConfigWithoutEnumParams() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/java/org/openapitools/config/";
+        assertFileDoesntExist(path + "EnumConverterServerConfig.java");
+    }
+
+    @Test
+    void testEnumConvertersConfigDisabled() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        codegen.setGenerateEnumConverters(false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/java/org/openapitools/config/";
+        assertFileDoesntExist(path + "EnumConverterServerConfig.java");
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -2202,7 +2202,6 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 """);
     }
 
-
     @Test
     void testEnumConvertersConfig() {
 
@@ -2210,9 +2209,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
-        assertFileExists(path + "EnumConverterConfig.kt");
+        assertFileExists(path + "EnumConverterClientConfig.kt");
 
-        assertFileContains(path + "EnumConverterConfig.kt",
+        assertFileContains(path + "EnumConverterClientConfig.kt",
             "import org.openapitools.model.BytePrimitiveEnum",
             "import org.openapitools.model.CharPrimitiveEnum",
             "import org.openapitools.model.DecimalEnum",
@@ -2226,6 +2225,53 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             "import org.openapitools.model.LongPrimitiveEnum",
             "import org.openapitools.model.ShortPrimitiveEnum",
             "import org.openapitools.model.StringEnum",
+            "class EnumConverterClientConfig(",
+            """
+                    @Bean
+                    fun toEnumStringEnum(): TypeConverter<String, StringEnum> =
+                        commonToEnumConverter(StringEnum::class.java, objectMapper)
+                
+                    @Bean
+                    fun toStrStringEnum(): TypeConverter<StringEnum, String> =
+                        commonToStrConverter(StringEnum::class.java, objectMapper)
+                """,
+            """
+                    @Bean
+                    fun toEnumShortPrimitiveEnum(): TypeConverter<String, ShortPrimitiveEnum> =
+                        commonToEnumConverter(ShortPrimitiveEnum::class.java, objectMapper)
+                
+                    @Bean
+                    fun toStrShortPrimitiveEnum(): TypeConverter<ShortPrimitiveEnum, String> =
+                        commonToStrConverter(ShortPrimitiveEnum::class.java, objectMapper)
+                """
+        );
+    }
+
+    @Test
+    void testEnumConvertersConfigWithCustomClientId() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.setClientId("myApiClient");
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/config/";
+        assertFileExists(path + "EnumConverterMyApiClientConfig.kt");
+
+        assertFileContains(path + "EnumConverterMyApiClientConfig.kt",
+            "import org.openapitools.model.BytePrimitiveEnum",
+            "import org.openapitools.model.CharPrimitiveEnum",
+            "import org.openapitools.model.DecimalEnum",
+            "import org.openapitools.model.DoubleEnum",
+            "import org.openapitools.model.DoublePrimitiveEnum",
+            "import org.openapitools.model.FloatEnum",
+            "import org.openapitools.model.FloatPrimitiveEnum",
+            "import org.openapitools.model.IntEnum",
+            "import org.openapitools.model.IntPrimitiveEnum",
+            "import org.openapitools.model.LongEnum",
+            "import org.openapitools.model.LongPrimitiveEnum",
+            "import org.openapitools.model.ShortPrimitiveEnum",
+            "import org.openapitools.model.StringEnum",
+            "class EnumConverterMyApiClientConfig(",
             """
                     @Bean
                     fun toEnumStringEnum(): TypeConverter<String, StringEnum> =
@@ -2254,37 +2300,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
-        assertFileExists(path + "EnumConverterConfig.kt");
-
-        assertFileContains(path + "EnumConverterConfig.kt",
-            """
-                class EnumConverterConfig(
-                    private val objectMapper: ObjectMapper,
-                ) {
-                
-                    companion object {
-                
-                        fun <T> commonToStrConverter(clazz: Class<T>, objectMapper: ObjectMapper): TypeConverter<T, String> =
-                            TypeConverter.of(clazz, String::class.java) {
-                                try {
-                                    objectMapper.writeValueAsString(it)
-                                } catch (e: IOException) {
-                                    throw RuntimeException(e)
-                                }
-                            }
-                
-                        fun <T> commonToEnumConverter(clazz: Class<T>, objectMapper: ObjectMapper): TypeConverter<String, T> =
-                            TypeConverter.of(String::class.java, clazz) {
-                                try {
-                                    objectMapper.readValue(it, clazz)
-                                } catch (e: IOException) {
-                                    throw RuntimeException(e)
-                                }
-                            }
-                    }
-                }
-                """
-        );
+        assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
 
     @Test
@@ -2295,6 +2311,6 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
-        assertFileDoesntExist(path + "EnumConverterConfig.kt");
+        assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -1100,4 +1100,70 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
             "@QueryValue(\"fieldsDeepObject\") @NotNull @Format(FORMAT_DEEP_OBJECT) fieldsDeepObject: Map<String, @NotNull String>,"
         );
     }
+
+    @Test
+    void testEnumConvertersConfig() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/config/";
+        assertFileExists(path + "EnumConverterServerConfig.kt");
+
+        assertFileContains(path + "EnumConverterServerConfig.kt",
+            "import org.openapitools.model.BytePrimitiveEnum",
+            "import org.openapitools.model.CharPrimitiveEnum",
+            "import org.openapitools.model.DecimalEnum",
+            "import org.openapitools.model.DoubleEnum",
+            "import org.openapitools.model.DoublePrimitiveEnum",
+            "import org.openapitools.model.FloatEnum",
+            "import org.openapitools.model.FloatPrimitiveEnum",
+            "import org.openapitools.model.IntEnum",
+            "import org.openapitools.model.IntPrimitiveEnum",
+            "import org.openapitools.model.LongEnum",
+            "import org.openapitools.model.LongPrimitiveEnum",
+            "import org.openapitools.model.ShortPrimitiveEnum",
+            "import org.openapitools.model.StringEnum",
+            "class EnumConverterServerConfig(",
+            """
+                    @Bean
+                    fun toEnumStringEnum(): TypeConverter<String, StringEnum> =
+                        commonToEnumConverter(StringEnum::class.java, objectMapper)
+                
+                    @Bean
+                    fun toStrStringEnum(): TypeConverter<StringEnum, String> =
+                        commonToStrConverter(StringEnum::class.java, objectMapper)
+                """,
+            """
+                    @Bean
+                    fun toEnumShortPrimitiveEnum(): TypeConverter<String, ShortPrimitiveEnum> =
+                        commonToEnumConverter(ShortPrimitiveEnum::class.java, objectMapper)
+                
+                    @Bean
+                    fun toStrShortPrimitiveEnum(): TypeConverter<ShortPrimitiveEnum, String> =
+                        commonToStrConverter(ShortPrimitiveEnum::class.java, objectMapper)
+                """
+        );
+    }
+
+    @Test
+    void testEnumConvertersConfigWithoutEnumParams() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/config/";
+        assertFileDoesntExist(path + "EnumConverterServerConfig.kt");
+    }
+
+    @Test
+    void testEnumConvertersConfigDisabled() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        codegen.setGenerateEnumConverters(false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/config/";
+        assertFileDoesntExist(path + "EnumConverterServerConfig.kt");
+    }
 }


### PR DESCRIPTION
Don't need to create EnumConverterConfig without converters.
Dynamic class name for EnumConverterConfig for compatibility with multiple clients