### PR TITLE
fix: fix kotlin client generator bytebuffer generics

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
@@ -115,9 +115,9 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         cliOptions.add(authorizationFilterPatternStyleOpt);
 
         typeMapping.put("file", "ByteArray");
-        typeMapping.put("responseFile", "ByteBuffer<?>");
+        typeMapping.put("responseFile", "ByteBuffer<*>");
 
-        importMapping.put("ByteBuffer<?>", "io.micronaut.core.io.buffer.ByteBuffer");
+        importMapping.put("ByteBuffer<*>", "io.micronaut.core.io.buffer.ByteBuffer");
         importMapping.put("MultipartBody", "io.micronaut.http.client.multipart.MultipartBody");
     }
 

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -641,7 +641,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         assertFileContains(apiPath + "DefaultApi.kt", """
                 fun fetchData(
                     @PathVariable("id") @NotNull @Min(0L) id: Long,
-                ): Mono<HttpResponse<ByteBuffer<?>>>
+                ): Mono<HttpResponse<ByteBuffer<*>>>
             """);
     }
 


### PR DESCRIPTION
Fixes invalid java syntax in kotlin generator
`ByteBuffer<?>` -> `ByteBuffer<*>`

this is a leftover from the java generator
