### PR TITLE
fix: fix kotlin-generator hideGenerationTimestamp produces invalid code

### DIFF
--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/generatedAnnotation.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@Generated({{^hideGenerationTimestamp}}value = {{/hideGenerationTimestamp}}"{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@Generated("{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -2313,4 +2313,16 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
+
+    @Test
+    void testHideGenerationTimestamp() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/file.yml", CodegenConstants.APIS);
+        String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
+
+        assertFileContains(apiPath + "RequestBodyApi.kt", """
+            @Generated("io.micronaut.openapi.generator.KotlinMicronautClientCodegen", date =
+            """);
+    }
 }


### PR DESCRIPTION
Previous code doesn't compile with:

```
e: file:///tmp/test15651700443780886616/src/main/kotlin/org/openapitools/api/RequestBodyApi.kt:24:20 Assigning single elements to varargs in named form is forbidden
e: file:///tmp/test15651700443780886616/src/main/kotlin/org/openapitools/api/RequestBodyApi.kt:24:20 Type mismatch: inferred type is String but Array<out String> was expected
```