### PR TITLE
Add kotlin compilation testing for kotlin-client-generator

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ commons-io = "2.19.0"
 commons-text = "1.13.1"
 guava = "33.4.8-jre"
 commonmark = "0.25.0"
+kotlin-compile-testing = "1.6.0"
+kotlin-compiler = "1.9.25"
 
 micronaut = "4.9.4"
 micronaut-platform = "4.8.3"
@@ -108,3 +110,5 @@ openapi-generator = { module = "org.openapitools:openapi-generator", version.ref
 swagger-parser = { module = "io.swagger:swagger-parser", version.ref = "swagger-parser" }
 swagger-parser-v3 = { module = "io.swagger.parser.v3:swagger-parser-v3", version.ref = "swagger-parser-v3" }
 sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
+kotlin-compile-testing = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlin-compile-testing" }
+kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler" }

--- a/openapi-generator/build.gradle
+++ b/openapi-generator/build.gradle
@@ -19,6 +19,12 @@ dependencies {
 
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(mnTest.junit.jupiter.params)
+    testImplementation(libs.kotlin.compile.testing)
+    testImplementation(libs.kotlin.compiler)
+    testFixturesApi(mn.micronaut.http.client.core)
+    testFixturesApi(mnValidation.validation)
+    testFixturesApi(mnSerde.micronaut.serde.api)
+    testFixturesApi(mnSecurity.micronaut.security.oauth2)
 
     testFixturesImplementation(mn.micronaut.inject)
     testFixturesImplementation(mnTest.assertj.core)

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
@@ -115,9 +115,9 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         cliOptions.add(authorizationFilterPatternStyleOpt);
 
         typeMapping.put("file", "ByteArray");
-        typeMapping.put("responseFile", "ByteBuffer<?>");
+        typeMapping.put("responseFile", "ByteBuffer<*>");
 
-        importMapping.put("ByteBuffer<?>", "io.micronaut.core.io.buffer.ByteBuffer");
+        importMapping.put("ByteBuffer<*>", "io.micronaut.core.io.buffer.ByteBuffer");
         importMapping.put("MultipartBody", "io.micronaut.http.client.multipart.MultipartBody");
     }
 

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/generatedAnnotation.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@Generated({{^hideGenerationTimestamp}}value = {{/hideGenerationTimestamp}}"{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@Generated("{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/AbstractMicronautCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/AbstractMicronautCodegenTest.java
@@ -1,13 +1,20 @@
 package io.micronaut.openapi.generator;
 
+import com.tschuchort.compiletesting.KotlinCompilation;
+import com.tschuchort.compiletesting.SourceFile;
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,6 +108,38 @@ public abstract class AbstractMicronautCodegenTest {
         String outputPath = output.getAbsolutePath().replace('\\', '/');
 
         return outputPath + "/";
+    }
+
+    /**
+     * @see AbstractMicronautCodegenTest#assertFilesCompile(String, String, SourceFile...)
+     */
+    public static void assertFilesCompile(String directory, SourceFile... extraSourceFiles) {
+        assertFilesCompile(directory, null, extraSourceFiles);
+    }
+
+    /**
+     * Compile files using the kotlin compiler and assert the compilation succeeded
+     *
+     * @param directory        - path of a directory of generated files to be compiled
+     * @param jvmTarget        - jvmTarget version to compile to
+     * @param extraSourceFiles - extra source files to add to the compilation - useful for adding dummy types
+     */
+    public static void assertFilesCompile(String directory, String jvmTarget, SourceFile... extraSourceFiles) {
+        String[] compilableFileExtensions = {".java", ".kt"};
+        List<SourceFile> sourceFiles = new ArrayList<>();
+        FileUtils.iterateFiles(new File(directory), compilableFileExtensions, true)
+            .forEachRemaining(
+                file -> sourceFiles.add(SourceFile.Companion.fromPath(file, false))
+            );
+        sourceFiles.addAll(List.of(extraSourceFiles));
+        var compilation = new KotlinCompilation();
+        compilation.setSources(sourceFiles);
+        compilation.setInheritClassPath(true);
+        if (jvmTarget != null) {
+            compilation.setJvmTarget(jvmTarget);
+        }
+        var result = compilation.compile();
+        assertEquals(KotlinCompilation.ExitCode.OK, result.getExitCode());
     }
 
     public static void assertFileContainsRegex(String path, String... regex) {

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -472,7 +472,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "model/Book.java",
             """
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 public class Book {
                 """,
             """
@@ -1315,7 +1315,7 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             """
                 @Serdeable
                 @Generated("io.micronaut.openapi.generator.JavaMicronautClientCodegen")
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 public class Book {
                 
                     @Override

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -464,7 +464,7 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "model/Book.java",
             """
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 public class Book {
                 """,
             """

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -1,5 +1,6 @@
 package io.micronaut.openapi.generator;
 
+import com.tschuchort.compiletesting.SourceFile;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -181,6 +183,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/micronaut/content-type.yml", CodegenConstants.APIS);
 
+        assertFilesCompile(outputPath);
+
         // body and response content types should be properly annotated using @Consumes and @Produces micronaut annotations
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
         assertFileContains(apiPath + "DefaultApi.kt", "@Consumes(\"application/vnd.oracle.resource+json; type=collection\", \"application/vnd.oracle.resource+json; type=error\")");
@@ -190,30 +194,38 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     @Test
     void testAdditionalClientTypeAnnotations() {
         var codegen = new KotlinMicronautClientCodegen();
-        codegen.additionalProperties().put(KotlinMicronautClientCodegen.ADDITIONAL_CLIENT_TYPE_ANNOTATIONS, "@MyAdditionalAnnotation1(1,${param1});@MyAdditionalAnnotation2(2,${param2});");
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        codegen.additionalProperties().put(KotlinMicronautClientCodegen.ADDITIONAL_CLIENT_TYPE_ANNOTATIONS, "@SuppressWarnings(\"someWarning\");@java.lang.Deprecated(since=\"\\${badVersion}\",forRemoval=true);");
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should contain custom added annotations
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt",
-            "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
+            "@SuppressWarnings(\"someWarning\")", "@java.lang.Deprecated(since=\"\\${badVersion}\",forRemoval=true)");
     }
 
+    @Deprecated
     @Test
     void testAdditionalClientTypeAnnotationsFromSetter() {
         var codegen = new KotlinMicronautClientCodegen();
-        codegen.setAdditionalClientTypeAnnotations(List.of("@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})"));
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+
+        codegen.setAdditionalClientTypeAnnotations(List.of("@SuppressWarnings(\"someWarning\")", "@java.lang.Deprecated(since=\"\\${badVersion}\",forRemoval=true)"));
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should contain custom added annotations
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt",
-            "@MyAdditionalAnnotation1(1,${param1})", "@MyAdditionalAnnotation2(2,${param2})");
+            "@SuppressWarnings(\"someWarning\")", "@java.lang.Deprecated(since=\"\\${badVersion}\",forRemoval=true)");
     }
 
     @Test
     void testDefaultAuthorizationFilterPattern() {
         var codegen = new KotlinMicronautClientCodegen();
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.OPT_CONFIGURE_AUTH, "true");
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.SUPPORTING_FILES, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.SUPPORTING_FILES, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut AuthorizationFilter should default to match all patterns
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/auth/AuthorizationFilter.kt", "@Filter(patterns = [Filter.MATCH_ALL_PATTERN])");
@@ -224,7 +236,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.OPT_CONFIGURE_AUTH, "true");
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.AUTHORIZATION_FILTER_PATTERN, "pet/**");
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.SUPPORTING_FILES, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.SUPPORTING_FILES, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut AuthorizationFilter should match the provided pattern
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/auth/AuthorizationFilter.kt", "@Filter(patterns = [\"pet/**\"])");
@@ -233,7 +247,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     @Test
     void testNoConfigureClientId() {
         var codegen = new KotlinMicronautClientCodegen();
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should not specify a Client id
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt", "@Client(\"\\${openapi-micronaut-client.base-path}\")");
@@ -243,7 +259,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void testConfigureClientId() {
         var codegen = new KotlinMicronautClientCodegen();
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.CLIENT_ID, "unit-test");
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should use the provided Client id
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt", "@Client(\"unit-test\")");
@@ -254,7 +272,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.CLIENT_ID, "unit-test");
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.OPT_CLIENT_PATH, true);
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should use the provided Client id
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt", "@Client(id = \"unit-test\", path = \"\\${unit-test.base-path}\")");
@@ -263,7 +283,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     @Test
     void testDefaultPathSeparator() {
         var codegen = new KotlinMicronautClientCodegen();
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should use the default path separator
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt", "@Client(\"\\${openapi-micronaut-client.base-path}\")");
@@ -273,7 +295,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void testConfigurePathSeparator() {
         var codegen = new KotlinMicronautClientCodegen();
         codegen.additionalProperties().put(KotlinMicronautClientCodegen.BASE_PATH_SEPARATOR, "-");
-        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.APIS, CodegenConstants.MODELS);
+
+        assertFilesCompile(outputPath);
 
         // Micronaut declarative http client should use the provided path separator
         assertFileContains(outputPath + "/src/main/kotlin/org/openapitools/api/PetApi.kt", "@Client(\"\\${openapi-micronaut-client-base-path}\")");
@@ -285,6 +309,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/readonlyconstructorbug.yml", CodegenConstants.MODELS);
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(apiPath + "BookInfo.kt",
             """
@@ -361,6 +387,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/modelwithlist.yml", CodegenConstants.APIS, CodegenConstants.API_TESTS, CodegenConstants.MODELS);
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(apiPath + "BooksContainer.kt",
             """
                     @field:JsonProperty(JSON_PROPERTY_BOOKS)
@@ -375,6 +403,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/modelwithprimitivelist.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(apiPath + "BooksApi.kt",
             "requestBody: List<@Pattern(regexp = \"[a-zA-Z ]+\") @Size(max = 10) @NotNull String>",
@@ -393,6 +423,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             CodegenConstants.MODELS
         );
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(apiPath + "BookInfo.kt",
             """
@@ -456,6 +488,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/propWithSecondUpperCaseChar.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(
             modelPath + "Book.kt",
             "const val JSON_PROPERTY_TITLE = \"tItle\"",
@@ -471,6 +505,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(modelPath + "StringEnum.kt", "@JsonProperty(\"starting\")", "STARTING(\"starting\"),",
             "val VALUE_MAPPING = entries.associateBy { it.value }",
@@ -500,6 +536,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         );
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        // assertFilesCompile(outputPath); TODO: fix /src/test/kotlin/org/openapitools/api/ParametersApiTest.kt:25:25 No value passed for parameter 'data'
+
         assertFileContains(path + "api/ParametersApi.kt", "fun callInterface(",
             "@QueryValue(\"name\") @NotNull @Valid name: Class,",
             "@QueryValue(\"data\") @NotNull `data`: String",
@@ -517,6 +555,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/controller-enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/api/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(modelPath + "BusinessCardsApi.kt", "@QueryValue(\"statusCodes\") @Nullable @Format(FORMAT_MULTI) statusCodes: List<@NotNull String>?");
     }
 
@@ -526,6 +566,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/openmeteo.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/WeatherForecastApisApi.kt", "@Get(\"/v1/forecast/{id}\")",
             "@PathVariable(\"id\") @NotNull id: String,",
@@ -545,6 +587,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/BooksApi.kt",
             """
@@ -572,6 +616,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneof-with-discriminator.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "model/Subject.kt", "val typeCode: String?");
         assertFileContains(path + "model/Person.kt", "override var typeCode: String? = \"PERS\",");
@@ -583,6 +628,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneof-without-discriminator.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+        assertFilesCompile(outputPath);
 
         assertFileNotContains(path + "model/ShoppingNotesDTO.kt", "@JsonIgnoreProperties(",
             "@JsonTypeInfo"
@@ -596,6 +642,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneof-with-discriminator2.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
         assertFileContains(path + "model/CancellationReasonTypesV2.kt", """
                 @field:Nullable
                 @field:JsonProperty(JSON_PROPERTY_VERSION)
@@ -622,6 +669,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/DefaultApi.kt",
             "@QueryValue(\"ids\") @Nullable @Format(FORMAT_MULTI) ids: List<@NotNull Int>? = null,",
             "@Header(\"X-Favor-Token\") @Nullable xFavorToken: String? = null,",
@@ -638,6 +687,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/file-download.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(apiPath + "DefaultApi.kt", """
                 fun fetchData(
                     @PathVariable("id") @NotNull @Min(0L) id: Long,
@@ -652,6 +703,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/client-produces-content-type.yml", CodegenConstants.APIS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/FilesApi.kt", "@Produces(\"application/octet-stream\")");
     }
 
@@ -660,8 +713,10 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         var codegen = new KotlinMicronautClientCodegen();
         codegen.setImplicitHeaders(true);
-        String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileNotContains(path + "api/DefaultApi.kt", "@Header(\"X-Favor-Token\") @Nullable xFavorToken: String? = null,",
             "@Header(name = \"Content-Type\", defaultValue = \"application/json\") @Nullable contentType: String? = \"application/json\""
@@ -673,8 +728,10 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         var codegen = new KotlinMicronautClientCodegen();
         codegen.setImplicitHeadersRegex(".*");
-        String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileNotContains(path + "api/DefaultApi.kt", "@Header(\"X-Favor-Token\") @Nullable xFavorToken: String? = null,",
             "@Header(name = \"Content-Type\", defaultValue = \"application/json\") @Nullable contentType: String? = \"application/json\""
@@ -688,6 +745,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setUseOneOfInterfaces(false);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/discriminator2.yml", CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "model/JsonOp.kt",
             """
@@ -738,6 +797,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/discriminator2.yml", CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "model/JsonOp.kt",
             """
                 interface JsonOp {
@@ -772,6 +833,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/multipartdata.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/ResetPasswordApi.kt", """
                 @Produces("multipart/form-data")
                 fun profilePasswordPost(
@@ -788,6 +851,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/multiple/swagger.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/CustomerApi.kt",
             """
@@ -823,6 +888,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/multiple-content-types.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/DefaultApi.kt", """
                     @Post("/multiplecontentpath")
                     @Produces("application/json", "application/xml")
@@ -855,6 +922,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        // assertFilesCompile(outputPath);  BUG: https://github.com/micronaut-projects/micronaut-openapi/issues/2233
+
         assertFileContains(path + "model/StringEnum.kt",
             "val VALUE_MAPPING = entries.associateBy { it.value.lowercase() }",
             """
@@ -870,37 +939,72 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
     void testAdditionalAnnotations() {
 
         var codegen = new KotlinMicronautClientCodegen();
-        codegen.setAdditionalClientTypeAnnotations(List.of("@java.io.MyAnnotation1"));
-        codegen.setAdditionalModelTypeAnnotations(List.of("@java.io.MyAnnotation2"));
-        codegen.setAdditionalOneOfTypeAnnotations(List.of("@java.io.MyAnnotation3"));
-        codegen.setAdditionalEnumTypeAnnotations(List.of("@java.io.MyAnnotation4"));
+        String clientTypeAnnotation = "MyClientTypeAnnotation";
+        String modelTypeAnnotation = "MyModelTypeAnnotation";
+        String oneOfTypeAnnotation = "MyOneOfTypeAnnotation";
+        String enumTypeAnnotation = "MyEnumTypeAnnotation";
+
+        var annotations = new String[]{clientTypeAnnotation, modelTypeAnnotation, oneOfTypeAnnotation, enumTypeAnnotation};
+        codegen.setAdditionalClientTypeAnnotations(List.of("@org.openapitools." + clientTypeAnnotation));
+        codegen.setAdditionalModelTypeAnnotations(List.of("@org.openapitools." + modelTypeAnnotation));
+        codegen.setAdditionalOneOfTypeAnnotations(List.of("@org.openapitools." + oneOfTypeAnnotation));
+        codegen.setAdditionalEnumTypeAnnotations(List.of("@org.openapitools." + enumTypeAnnotation));
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneof-with-discriminator.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
-        assertFileContains(path + "api/SubjectsApi.kt", "@java.io.MyAnnotation1");
-        assertFileContains(path + "model/Person.kt", "@java.io.MyAnnotation2");
-        assertFileContains(path + "model/Subject.kt", "@java.io.MyAnnotation3");
-        assertFileContains(path + "model/PersonSex.kt", "@java.io.MyAnnotation4");
+        var annotationSources = Arrays.stream(annotations).map(annotation ->
+            SourceFile.Companion.kotlin(path + annotation + ".kt", """
+                    package org.openapitools
+                    annotation class %s
+                    """.formatted(annotation),
+                true,
+                false)
+        ).toArray(SourceFile[]::new);
+
+        assertFilesCompile(outputPath, annotationSources);
+
+        assertFileContains(path + "api/SubjectsApi.kt", "@org.openapitools." + clientTypeAnnotation);
+        assertFileContains(path + "model/Person.kt", "@org.openapitools." + modelTypeAnnotation);
+        assertFileContains(path + "model/Subject.kt", "@org.openapitools." + oneOfTypeAnnotation);
+        assertFileContains(path + "model/PersonSex.kt", "@org.openapitools." + enumTypeAnnotation);
     }
 
     @Test
     void testAdditionalAnnotations2() {
 
         var codegen = new KotlinMicronautClientCodegen();
+        String clientTypeAnnotation = "MyClientTypeAnnotation";
+        String modelTypeAnnotation = "MyModelTypeAnnotation";
+        String oneOfTypeAnnotation = "MyOneOfTypeAnnotation";
+        String enumTypeAnnotation1 = "MyEnumTypeAnnotation1";
+        String enumTypeAnnotation2 = "MyEnumTypeAnnotation2";
+        String enumTypeAnnotation3 = "MyEnumTypeAnnotation3";
+        var annotations = new String[]{clientTypeAnnotation, modelTypeAnnotation, oneOfTypeAnnotation, enumTypeAnnotation1, enumTypeAnnotation2, enumTypeAnnotation3};
         codegen.additionalProperties().putAll(Map.of(
-            "additionalClientTypeAnnotations", List.of("@java.io.MyAnnotation1"),
-            "additionalModelTypeAnnotations", List.of("@java.io.MyAnnotation2"),
-            "additionalOneOfTypeAnnotations", List.of("@java.io.MyAnnotation3"),
-            "additionalEnumTypeAnnotations", "@java.io.MyAnnotation41;@java.io.MyAnnotation42;\n@java.io.MyAnnotation43;"
+            "additionalClientTypeAnnotations", List.of("@org.openapitools." + clientTypeAnnotation),
+            "additionalModelTypeAnnotations", List.of("@org.openapitools." + modelTypeAnnotation),
+            "additionalOneOfTypeAnnotations", List.of("@org.openapitools." + oneOfTypeAnnotation),
+            "additionalEnumTypeAnnotations", "@org.openapitools.%s;@org.openapitools.%s;\n@org.openapitools.%s;".formatted(enumTypeAnnotation1, enumTypeAnnotation2, enumTypeAnnotation3)
         ));
         codegen.processOpts();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneof-with-discriminator.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
-        assertFileContains(path + "api/SubjectsApi.kt", "@java.io.MyAnnotation1");
-        assertFileContains(path + "model/Person.kt", "@java.io.MyAnnotation2");
-        assertFileContains(path + "model/Subject.kt", "@java.io.MyAnnotation3");
-        assertFileContains(path + "model/PersonSex.kt", "@java.io.MyAnnotation41\n", "@java.io.MyAnnotation42\n", "@java.io.MyAnnotation43\n");
+        var annotationSources = Arrays.stream(annotations).map(annotation ->
+            SourceFile.Companion.kotlin(path + annotation + ".kt", """
+                    package org.openapitools
+                    annotation class %s
+                    """.formatted(annotation),
+                true,
+                false)
+        ).toArray(SourceFile[]::new);
+
+        assertFilesCompile(outputPath, annotationSources);
+
+        assertFileContains(path + "api/SubjectsApi.kt", "@org.openapitools." + clientTypeAnnotation);
+        assertFileContains(path + "model/Person.kt", "@org.openapitools." + modelTypeAnnotation);
+        assertFileContains(path + "model/Subject.kt", "@org.openapitools." + oneOfTypeAnnotation);
+        assertFileContains(path + "model/PersonSex.kt", ("@org.openapitools." + enumTypeAnnotation1), ("@org.openapitools." + enumTypeAnnotation2), ("@org.openapitools." + enumTypeAnnotation3));
     }
 
     @Test
@@ -909,6 +1013,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(modelPath + "BytePrimitiveEnum.kt",
             "NUMBER_1(1),",
@@ -1003,6 +1109,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/model-with-primitives.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String basePath = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(basePath + "api/ParametersApi.kt",
             "@QueryValue(\"name\") @NotNull name: String",
             "@QueryValue(\"byteType\") @NotNull byteType: Byte",
@@ -1079,6 +1187,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setGenerateSwaggerAnnotations(true);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/deprecated.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/ParametersApi.kt",
             """
@@ -1162,6 +1272,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/validation-messages.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/BooksApi.kt",
             """
@@ -1313,6 +1425,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/extra-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "model/Book.kt",
             """
                 @Serdeable
@@ -1332,6 +1446,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setGenerateSwaggerAnnotations(true);
         String outputPath = generateFiles(codegen, "src/test/resources/petstore.json", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/PetApi.kt",
             """
@@ -1368,6 +1484,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setGenerateSwaggerAnnotations(true);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/test-override-discriminator.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "model/AnimalRequest.kt",
             """
@@ -1408,6 +1526,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/check-equals.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileNotContains(path + "model/SalesInvoiceCreateDto.kt", "@JsonPropertyOrder");
         assertFileContains(path + "model/SalesInvoiceCreateDto.kt", """
                 override fun equals(other: Any?): Boolean {
@@ -1434,6 +1554,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/optional-controller-values.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/DefaultApi.kt",
             """
                    @Post("/sendPrimitives/{name}")
@@ -1454,6 +1576,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/body-enum.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/MyCustomApi.kt", """
                 @Post("/api/v1/colors/{name}")
                 fun selectColor(
@@ -1469,6 +1593,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/DocumentResourcesApi.kt", """
             @QueryValue("CREATIONDATE") @Nullable CREATIONDATE: LocalDate? = null,
@@ -1490,6 +1616,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setJsonIncludeAlwaysForRequiredFields(true);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/json-include-always.yml", CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "model/TextRequestDto.kt",
             """
@@ -1529,6 +1657,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setModelNameSuffix("Dto");
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/openapi-built-in-prefix.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/DefaultApi.kt",
             """
@@ -1756,6 +1886,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/sealed/" + apiFile, CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+//        assertFilesCompile(outputPath); TODO: fix broken
+
         definitions.forEach((file, check) ->
             assertFileContains(path + file, check));
     }
@@ -1768,6 +1900,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setReactive(true);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-default-value.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/DefaultApi.kt",
             """
@@ -1790,6 +1924,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum-implements.yml", CodegenConstants.APIS, CodegenConstants.MODELS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "model/Type.kt",
             """
                 enum class Type(
@@ -1805,6 +1941,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setKsp(true);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/default-value-optional.yml", CodegenConstants.MODELS, CodegenConstants.APIS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/DefaultApi.kt",
             "@QueryValue(\"reqParamWithDefault\", defaultValue = \"test-req\") @NotNull reqParamWithDefault: String = \"test-req\",",
@@ -1833,6 +1971,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/default-value-optional.yml", CodegenConstants.MODELS, CodegenConstants.APIS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "api/DefaultApi.kt",
             "@QueryValue(\"reqParamWithDefault\", defaultValue = \"test-req\") @NotNull reqParamWithDefault: String = \"test-req\",",
@@ -1863,6 +2003,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/params-with-style.yml", CodegenConstants.MODELS, CodegenConstants.APIS);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "api/DefaultApi.kt",
             "import io.micronaut.core.convert.converters.MultiValuesConverterFactory.*",
             "@QueryValue(\"fields\") @NotNull @Format(FORMAT_MULTI) fields: Map<String, @NotNull String>,",
@@ -1882,6 +2024,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileExists(path + "auth/config/ConfigurableAuthorization.kt");
         assertFileExists(path + "auth/config/ApiKeyAuthConfig.kt");
         assertFileDoesntExist(path + "auth/config/HttpBasicAuthConfig.kt");
@@ -1896,6 +2040,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileExists(path + "auth/config/ConfigurableAuthorization.kt");
         assertFileDoesntExist(path + "auth/config/ApiKeyAuthConfig.kt");
         assertFileExists(path + "auth/config/HttpBasicAuthConfig.kt");
@@ -1909,6 +2055,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setAuthFilter(false);
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileExists(path + "auth/config/ConfigurableAuthorization.kt");
         assertFileExists(path + "auth/config/ApiKeyAuthConfig.kt");
@@ -1942,6 +2090,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "@Filter(serviceId = [\"myApiClient\"], patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
         assertFileContains(path + "auth/AuthorizationBinder.kt",
@@ -1960,6 +2110,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setAuthConfigName("test");
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "@Filter(serviceId = [\"myApiClient\"], patterns = [Filter.MATCH_ALL_PATTERN])");
@@ -1981,6 +2133,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "@Filter(serviceId = [\"test1\", \"test2\", \"test3\"], patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
     }
@@ -1994,6 +2148,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setAuthorizationFilterPattern("/v1/user/**;/v1/company/**;/v1/payment/**");
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "@Filter(serviceId = [\"myApiClient\"], excludeServiceId = [\"test1\", \"test2\", \"test3\"], patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
@@ -2009,6 +2165,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setAuthorizationFilterPattern("/v1/user/**;/v1/company/**;/v1/payment/**");
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "@Filter(excludeServiceId = [\"test1\", \"test2\", \"test3\"], patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
@@ -2026,6 +2184,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         String path = outputPath + "src/main/kotlin/org/openapitools/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(path + "auth/AuthorizationFilter.kt",
             "import io.micronaut.http.filter.FilterPatternStyle",
             "@Filter(excludeServiceId = [\"test1\", \"test2\", \"test3\"], patternStyle = FilterPatternStyle.REGEX, patterns = [\"/v1/user/**\", \"/v1/company/**\", \"/v1/payment/**\"])");
@@ -2039,6 +2199,9 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String outputPath = generateFiles(codegen, PETSTORE_PATH, CodegenConstants.MODELS, CodegenConstants.APIS, CodegenConstants.SUPPORTING_FILES);
         // Constructor should have properties
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
+
+        assertFilesCompile(outputPath, "16"); // JvmRecord is supported only since java 16
+
         assertFileContains(modelPath + "Pet.kt",
             """
                 @JvmRecord
@@ -2097,6 +2260,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         // Constructor should have properties
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+        assertFilesCompile(outputPath);
+
         assertFileNotContains(modelPath + "Pet.kt", "@JvmRecord");
         assertFileContains(modelPath + "Pet.kt",
             """
@@ -2143,6 +2308,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         // Constructor should have properties
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(modelPath + "CurrentWeather.kt",
             """
                 data class CurrentWeather(
@@ -2179,6 +2346,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         // Constructor should have properties
         String modelPath = outputPath + "src/main/kotlin/org/openapitools/model/";
 
+        assertFilesCompile(outputPath);
+
         assertFileContains(modelPath + "BookInfo.kt",
             """
                 @JsonSubTypes(
@@ -2207,6 +2376,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
+
+        assertFilesCompile(outputPath);
 
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileExists(path + "EnumConverterClientConfig.kt");
@@ -2254,6 +2425,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setClientId("myApiClient");
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
+        assertFilesCompile(outputPath);
+
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileExists(path + "EnumConverterMyApiClientConfig.kt");
 
@@ -2299,6 +2472,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         var codegen = new KotlinMicronautClientCodegen();
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/date-annotations.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
+        assertFilesCompile(outputPath);
+
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
@@ -2310,6 +2485,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.setGenerateEnumConverters(false);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/enum2.yml", CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES);
 
+        assertFilesCompile(outputPath);
+
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
@@ -2320,6 +2497,8 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
         String outputPath = generateFiles(codegen, "src/test/resources/3_0/file.yml", CodegenConstants.APIS);
         String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
+
+        assertFilesCompile(outputPath);
 
         assertFileContains(apiPath + "RequestBodyApi.kt", """
             @Generated("io.micronaut.openapi.generator.KotlinMicronautClientCodegen", date =

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -2313,4 +2313,16 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         String path = outputPath + "src/main/kotlin/org/openapitools/config/";
         assertFileDoesntExist(path + "EnumConverterClientConfig.kt");
     }
+
+    @Test
+    void testHideGenerationTimestamp() {
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/file.yml", CodegenConstants.APIS);
+        String apiPath = outputPath + "src/main/kotlin/org/openapitools/api/";
+
+        assertFileContains(apiPath + "RequestBodyApi.kt", """
+            @Generated("io.micronaut.openapi.generator.KotlinMicronautClientCodegen", date =
+            """);
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -641,7 +641,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
         assertFileContains(apiPath + "DefaultApi.kt", """
                 fun fetchData(
                     @PathVariable("id") @NotNull @Min(0L) id: Long,
-                ): Mono<HttpResponse<ByteBuffer<?>>>
+                ): Mono<HttpResponse<ByteBuffer<*>>>
             """);
     }
 

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -555,7 +555,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "model/Book.kt",
             """
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 data class Book(
                     @field:NotNull
                     @field:Size(max = 10)
@@ -1317,7 +1317,7 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             """
                 @Serdeable
                 @Generated("io.micronaut.openapi.generator.KotlinMicronautClientCodegen")
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 class Book {
                 }
                 """);

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -593,7 +593,7 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
 
         assertFileContains(path + "model/Book.kt",
             """
-                @Serializable
+                @io.micronaut.serde.annotation.Serdeable.Serializable
                 data class Book(
                     @field:NotNull
                     @field:Size(max = 10)

--- a/openapi-generator/src/test/resources/3_0/extra-annotations.yml
+++ b/openapi-generator/src/test/resources/3_0/extra-annotations.yml
@@ -37,7 +37,7 @@ components:
     Book:
       type: object
       x-class-extra-annotation:
-        - "@Serializable"
+        - "@io.micronaut.serde.annotation.Serdeable.Serializable"
       properties:
         title:
           x-field-extra-annotation: |-


### PR DESCRIPTION
So far I have found 3 Bugs using this method so I think it works quite well.

This PR Depends on:
#2231 
#2234 

I can comment out the non-working assertions for these tests if we don't want to wate for those PRs 

I have also commented out an assertion which should also be solved by #2235 

I have added these assertions for the client for now, Ill add them to the server if things go smoothly.
Java files also work with the compiler so I could add these tests to all the generators.