### PR TITLE
Add property for Jackson include mode

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -1195,31 +1195,16 @@ public final class ConfigUtils {
         };
     }
 
-    public static JsonInclude.Include getInclude(VisitorContext context) {
+    public static boolean isIncludeAll(VisitorContext context) {
         var value = getConfigProperty(MICRONAUT_OPENAPI_PROPERTY_INCLUDE, context);
         if (value == null) {
-            return null;
+            return false;
         }
-        return toJacksonInclude(value.toUpperCase(Locale.ENGLISH), context);
-    }
-
-    private static JsonInclude.Include toJacksonInclude(String include, VisitorContext context) {
-        if (include == null) {
-            return null;
+        // ALWAYS is the only value that has any impact on API spec generation.
+        if (value.toUpperCase(Locale.ENGLISH).equals("ALWAYS")) {
+            return true;
         }
-        return switch (include.toUpperCase(Locale.ENGLISH)) {
-            case "ALWAYS" -> JsonInclude.Include.ALWAYS;
-            case "NON_NULL" -> JsonInclude.Include.NON_NULL;
-            case "NON_ABSENT" -> JsonInclude.Include.NON_ABSENT;
-            case "NON_EMPTY" -> JsonInclude.Include.NON_EMPTY;
-            case "NON_DEFAULT" -> JsonInclude.Include.NON_DEFAULT;
-            case "CUSTOM" -> JsonInclude.Include.CUSTOM;
-            case "USE_DEFAULTS" -> JsonInclude.Include.USE_DEFAULTS;
-            default -> {
-                warn("Unknown include value: " + include, context);
-                yield null;
-            }
-        };
+        return false;
     }
 
     public static String getConfigProperty(String key, VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.openapi.visitor;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -116,6 +117,7 @@ import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENA
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_GROUPS;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_JSON_VIEW_DEFAULT_INCLUSION;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_PROJECT_DIR;
+import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_PROPERTY_INCLUDE;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_RESPONSE_READ_SUCCESSFUL_FROM_CODE;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_SCHEMA;
@@ -1188,6 +1190,33 @@ public final class ConfigUtils {
             case "LOWER_DOT_CASE" -> PropertyNamingStrategies.LOWER_DOT_CASE;
             default -> {
                 warn("Unknown naming strategy value: " + namingStrategy, context);
+                yield null;
+            }
+        };
+    }
+
+    public static JsonInclude.Include getInclude(VisitorContext context) {
+        var value = getConfigProperty(MICRONAUT_OPENAPI_PROPERTY_INCLUDE, context);
+        if (value == null) {
+            return null;
+        }
+        return toJacksonInclude(value.toUpperCase(Locale.ENGLISH), context);
+    }
+
+    private static JsonInclude.Include toJacksonInclude(String include, VisitorContext context) {
+        if (include == null) {
+            return null;
+        }
+        return switch (include.toUpperCase(Locale.ENGLISH)) {
+            case "ALWAYS" -> JsonInclude.Include.ALWAYS;
+            case "NON_NULL" -> JsonInclude.Include.NON_NULL;
+            case "NON_ABSENT" -> JsonInclude.Include.NON_ABSENT;
+            case "NON_EMPTY" -> JsonInclude.Include.NON_EMPTY;
+            case "NON_DEFAULT" -> JsonInclude.Include.NON_DEFAULT;
+            case "CUSTOM" -> JsonInclude.Include.CUSTOM;
+            case "USE_DEFAULTS" -> JsonInclude.Include.USE_DEFAULTS;
+            default -> {
+                warn("Unknown include value: " + include, context);
                 yield null;
             }
         };

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiConfigProperty.java
@@ -135,6 +135,10 @@ public interface OpenApiConfigProperty {
      */
     String MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY = "micronaut.openapi.property.naming.strategy";
     /**
+     * System property for property inclusion. One jackson Include.
+     */
+    String MICRONAUT_OPENAPI_PROPERTY_INCLUDE = "micronaut.openapi.property.include";
+    /**
      * System property for views specification.
      */
     String MICRONAUT_OPENAPI_VIEWS_SPEC = "micronaut.openapi.views.spec";
@@ -468,6 +472,7 @@ public interface OpenApiConfigProperty {
         MICRONAUT_OPENAPI_ENABLED,
         MICRONAUT_OPENAPI_CONTEXT_SERVER_PATH,
         MICRONAUT_OPENAPI_PROPERTY_NAMING_STRATEGY,
+        MICRONAUT_OPENAPI_PROPERTY_INCLUDE,
         MICRONAUT_OPENAPI_VIEWS_SPEC,
         MICRONAUT_OPENAPI_FILENAME,
         MICRONAUT_OPENAPI_JSON_FORMAT,

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -18,6 +18,7 @@ package io.micronaut.openapi.visitor;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -1719,6 +1720,11 @@ public final class SchemaDefinitionUtils {
             boolean required = elementSchemaRequired != null ? elementSchemaRequired : isNotNullable || isMandatoryInConstructor;
 
             if (isRequiredDefaultValueSet && isAutoRequiredMode && isNotNullable) {
+                required = true;
+            }
+
+            // If inclusion is ALWAYS, then all properties are required
+            if (!required && ConfigUtils.getInclude(context) == JsonInclude.Include.ALWAYS) {
                 required = true;
             }
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -1699,6 +1699,7 @@ public final class SchemaDefinitionUtils {
             Boolean elementSchemaRequired = null;
             boolean isAutoRequiredMode = true;
             boolean isRequiredDefaultValueSet = false;
+            boolean isExplicitlyNotRequired = false;
             if (schemaAnn != null) {
                 elementSchemaRequired = schemaAnn.get(PROP_REQUIRED, Argument.BOOLEAN).orElse(null);
                 isRequiredDefaultValueSet = !schemaAnn.contains(PROP_REQUIRED);
@@ -1710,6 +1711,7 @@ public final class SchemaDefinitionUtils {
                 } else if (requiredMode == io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED) {
                     elementSchemaRequired = false;
                     isAutoRequiredMode = false;
+                    isExplicitlyNotRequired = true;
                 }
             }
 
@@ -1723,8 +1725,9 @@ public final class SchemaDefinitionUtils {
                 required = true;
             }
 
-            // If inclusion is ALWAYS, then all properties are required
-            if (!required && ConfigUtils.getInclude(context) == JsonInclude.Include.ALWAYS) {
+            // If inclusion is ALWAYS, then all properties are required, except if overridden
+            // via a NOT_REQUIRED annotation.
+            if (!required && !isExplicitlyNotRequired && ConfigUtils.isIncludeAll(context)) {
                 required = true;
             }
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
@@ -1882,6 +1882,10 @@ class Person {
     public void setAccessorProp(int value) {
     }
 
+    // Ensure that NOT_REQUIRED takes precedence over JsonInclude.Include.ALWAYS
+    @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    public String notRequiredProp;
+
 }
 
 @jakarta.inject.Singleton
@@ -1898,16 +1902,17 @@ public class MyBean {}
         personSchema.type == "object"
 
         personSchema.properties
-        personSchema.properties.size() == 3
+        personSchema.properties.size() == 4
 
         personSchema.properties["fieldProp"]
         personSchema.properties["readOnlyProp"]
         personSchema.properties["accessorProp"]
+        personSchema.properties["notRequiredProp"]
 
         personSchema.properties["fieldProp"].type == "string"
         personSchema.properties["readOnlyProp"].type == "integer"
         personSchema.properties["accessorProp"].type == "integer"
-
+        personSchema.properties["notRequiredProp"].type == "string"
 
         personSchema.required.size() == 3
         personSchema.required.contains("fieldProp")

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiBasicSchemaSpec.groovy
@@ -1817,4 +1817,101 @@ public class MyBean {}
         itemSchema.properties.name.minProperties == 1
         ((Schema) itemSchema.properties.name.additionalProperties).type == "string"
     }
+
+    @RestoreSystemProperties
+    void "test custom JSON inclusion - issue #2261"() {
+        given:
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_PROPERTY_INCLUDE, "ALWAYS")
+
+        when:
+        buildBeanDefinition("test.MyBean", '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;import jakarta.validation.constraints.PositiveOrZero;
+
+@Controller
+class PersonController {
+
+    @Operation(
+            summary = "Fetch the person information",
+            description = "Fetch the person name, debt and goals information",
+            parameters = { @Parameter(name = "name", required = true, description = "The person name", in = ParameterIn.PATH) },
+            responses = {
+                    @ApiResponse(description = "The person information",
+                        content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema( implementation = Person.class )
+                    ))
+            }
+    )
+    @Get("/person/{name}")
+    HttpResponse<Person> get(@NotBlank String name) {
+        return HttpResponse.ok();
+    }
+}
+
+/**
+ * The person information.
+ */
+@Introspected
+class Person {
+
+    public String fieldProp;
+
+    public Integer getReadOnlyProp() {
+        return null;
+    }
+
+    public int getAccessorProp() {
+        return 0;
+    }
+
+    public void setAccessorProp(int value) {
+    }
+
+}
+
+@jakarta.inject.Singleton
+public class MyBean {}
+
+''')
+
+        then:
+        OpenAPI openAPI = Utils.testReference
+        openAPI?.paths?.get("/person/{name}")?.get
+        Schema personSchema = openAPI.components.schemas.Person
+
+        personSchema
+        personSchema.type == "object"
+
+        personSchema.properties
+        personSchema.properties.size() == 3
+
+        personSchema.properties["fieldProp"]
+        personSchema.properties["readOnlyProp"]
+        personSchema.properties["accessorProp"]
+
+        personSchema.properties["fieldProp"].type == "string"
+        personSchema.properties["readOnlyProp"].type == "integer"
+        personSchema.properties["accessorProp"].type == "integer"
+
+
+        personSchema.required.size() == 3
+        personSchema.required.contains("fieldProp")
+        personSchema.required.contains("readOnlyProp")
+        personSchema.required.contains("accessorProp")
+    }
 }


### PR DESCRIPTION
Closes #2261 . As suggested in the comments there, I implemented this as a system property.

This adds the `micronaut.openapi.property.include` setting which chooses an item from Jackson's `JsonInclude.Include` enum. If it is set to `ALWAYS`, then it will mark all properties as required in the schema. Currently, none of the other enum choices have any impact, as they still result in the field not necessarily being included.

I'm not sure if I entirely like the implication that this would also mark things as required on *request* schema types, since the intention is to mark everything as required on *response* schemas, which is what you would expect when using `Include.ALWAYS`. However, `ALWAYS` does not imply that all fields would be required on a request. Very open to feedback as to what the most proper way would be. 