### PR TITLE
Add ability to add principal / authentication parameter to controller methods

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
@@ -29,8 +29,11 @@ import org.openapitools.codegen.utils.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static io.micronaut.openapi.generator.Utils.addUserParameter;
 import static org.openapitools.codegen.CodegenConstants.API_PACKAGE;
 
 /**
@@ -46,6 +49,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
     public static final String OPT_GENERATE_HARD_NULLABLE = "generateHardNullable";
     public static final String OPT_GENERATE_STREAMING_FILE_UPLOAD = "generateStreamingFileUpload";
     public static final String OPT_AOT = "aot";
+    public static final String OPT_USER_PARAMETER_MODE = "userParameterMode";
 
     public static final String EXTENSION_ROLES = "x-roles";
     public static final String ANONYMOUS_ROLE_KEY = "isAnonymous()";
@@ -71,6 +75,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
     protected boolean generateHardNullable = true;
     protected boolean generateStreamingFileUpload;
     protected boolean aot;
+    protected UserParameterMode userParameterMode = UserParameterMode.NONE;
 
     JavaMicronautServerCodegen() {
 
@@ -98,6 +103,14 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_STREAMING_FILE_UPLOAD, "Whether to generate StreamingFileUpload type for file request body", generateStreamingFileUpload));
         cliOptions.add(CliOption.newBoolean(OPT_AOT, "Generate compatible code with micronaut-aot", aot));
 
+        var userModeOption = new CliOption(OPT_USER_PARAMETER_MODE, "Add or not principal / authentication parameter to controller methods").defaultValue(userParameterMode.name());
+        var userModeOptionsMap = new HashMap<String, String>();
+        userModeOptionsMap.put(UserParameterMode.NONE.name(), "Don't add principal / authentication parameter to controller methods");
+        userModeOptionsMap.put(UserParameterMode.PRINCIPAL.name(), "Add java.security.Principal principal parameter to each controller method");
+        userModeOptionsMap.put(UserParameterMode.AUTHENTICATION.name(), "Add io.micronaut.security.authentication.Authentication authentication parameter to each controller method");
+        userModeOption.setEnum(userModeOptionsMap);
+        cliOptions.add(userModeOption);
+
         setApiNamePrefix(API_PREFIX);
         setApiNameSuffix(API_SUFFIX);
 
@@ -110,6 +123,9 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         typeMapping.put("responseFile", "FileCustomizableResponseType");
         importMapping.put("FileCustomizableResponseType", "io.micronaut.http.server.types.files.FileCustomizableResponseType");
 
+        importMapping.put(UserParameterMode.PRINCIPAL.getClassName(), UserParameterMode.PRINCIPAL.getClassFullName());
+        importMapping.put(UserParameterMode.AUTHENTICATION.getClassName(), UserParameterMode.AUTHENTICATION.getClassFullName());
+
         // Add all the supporting files
         String resourceFolder = projectFolder + "/resources";
         supportingFiles.add(new SupportingFile("common/configuration/application.yml.mustache", resourceFolder, "application.yml").doNotOverwrite());
@@ -119,48 +135,6 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
     @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
-    }
-
-    @Override
-    public String getName() {
-        return NAME;
-    }
-
-    @Override
-    public String getHelp() {
-        return "Generates a Java Micronaut Server.";
-    }
-
-    public void setControllerPackage(String controllerPackage) {
-        this.controllerPackage = controllerPackage;
-    }
-
-    public void setGenerateImplementationFiles(boolean generateImplementationFiles) {
-        this.generateImplementationFiles = generateImplementationFiles;
-    }
-
-    public void setGenerateOperationsToReturnNotImplemented(boolean generateOperationsToReturnNotImplemented) {
-        this.generateOperationsToReturnNotImplemented = generateOperationsToReturnNotImplemented;
-    }
-
-    public void setGenerateControllerFromExamples(boolean generateControllerFromExamples) {
-        this.generateControllerFromExamples = generateControllerFromExamples;
-    }
-
-    public void setUseAuth(boolean useAuth) {
-        this.useAuth = useAuth;
-    }
-
-    public void setAot(boolean aot) {
-        this.aot = aot;
-    }
-
-    public void setGenerateStreamingFileUpload(boolean generateStreamingFileUpload) {
-        this.generateStreamingFileUpload = generateStreamingFileUpload;
-    }
-
-    public void setGenerateHardNullable(boolean generateHardNullable) {
-        this.generateHardNullable = generateHardNullable;
     }
 
     @Override
@@ -213,6 +187,12 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
             generateStreamingFileUpload = convertPropertyToBoolean(OPT_GENERATE_STREAMING_FILE_UPLOAD);
         }
         writePropertyBack(OPT_GENERATE_STREAMING_FILE_UPLOAD, generateStreamingFileUpload);
+
+        if (additionalProperties.containsKey(OPT_USER_PARAMETER_MODE)) {
+            var userModeOpt = (String) additionalProperties.get(OPT_USER_PARAMETER_MODE);
+            setUserParameterMode(userModeOpt);
+        }
+        writePropertyBack(OPT_USER_PARAMETER_MODE, userParameterMode.name());
 
         // Api file
         apiTemplateFiles.clear();
@@ -291,19 +271,24 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
 
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
-        objs = super.postProcessOperationsWithModels(objs, allModels);
 
         // Add the controller classname to operations
         OperationMap operations = objs.getOperations();
         String controllerClassname = StringUtils.camelize(CONTROLLER_PREFIX + "_" + operations.getPathPrefix() + "_" + CONTROLLER_SUFFIX);
         objs.put("controllerClassname", controllerClassname);
-
         var allOperations = (List<CodegenOperation>) operations.get("operation");
-        if (useAuth) {
-            for (CodegenOperation operation : allOperations) {
-                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
 
-                    var roles = new ArrayList<String>();
+        if (useAuth) {
+
+            var alreadyAddedPrincipalImport = false;
+            String importClassFullName = userParameterMode.getClassFullName();
+            String importClassName = userParameterMode.getClassName();
+
+            for (CodegenOperation operation : allOperations) {
+
+                List<String> roles = new ArrayList<>();
+
+                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
                     var authMethods = operation.authMethods;
                     if (authMethods != null && !authMethods.isEmpty()) {
                         var scopes = authMethods.get(0).scopes;
@@ -317,20 +302,33 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
                     } else {
                         roles.add(ANONYMOUS_ROLE);
                     }
-
-                    operation.vendorExtensions.put(EXTENSION_ROLES, roles);
                 } else {
-                    var roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
-                    roles = roles.stream().map(role -> switch (role) {
-                        case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
-                        case AUTHORIZED_ROLE_KEY -> AUTHORIZED_ROLE;
-                        case DENY_ALL_ROLE_KEY -> DENY_ALL_ROLE;
-                        default -> "\"" + escapeText(role) + "\"";
-                    }).toList();
-                    operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+                    roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
+                    roles = roles.stream()
+                        .map(role -> switch (role) {
+                            case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
+                            case AUTHORIZED_ROLE_KEY -> AUTHORIZED_ROLE;
+                            case DENY_ALL_ROLE_KEY -> DENY_ALL_ROLE;
+                            default -> "\"" + escapeText(role) + "\"";
+                        }).toList();
+                }
+
+                operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+
+                if (userParameterMode != UserParameterMode.NONE) {
+                    var isAnonymous = roles.contains(ANONYMOUS_ROLE);
+                    var isDenyAll = roles.contains(DENY_ALL_ROLE);
+                    addUserParameter(operation, userParameterMode, isAnonymous, isDenyAll);
+
+                    if (importClassFullName != null && !alreadyAddedPrincipalImport) {
+                        objs.getImports().add(Map.of("import", importClassFullName, "classname", importClassName));
+                        alreadyAddedPrincipalImport = true;
+                    }
                 }
             }
         }
+
+        objs = super.postProcessOperationsWithModels(objs, allModels);
 
         var enumParams = (List<String>) additionalProperties.get("enumParams");
         if (generateEnumConverters && !enumParams.isEmpty()) {
@@ -349,6 +347,64 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         return new DefaultServerOptionsBuilder();
     }
 
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getHelp() {
+        return "Generates a Java Micronaut Server.";
+    }
+
+    public void setControllerPackage(String controllerPackage) {
+        this.controllerPackage = controllerPackage;
+    }
+
+    public void setGenerateImplementationFiles(boolean generateImplementationFiles) {
+        this.generateImplementationFiles = generateImplementationFiles;
+    }
+
+    public void setGenerateOperationsToReturnNotImplemented(boolean generateOperationsToReturnNotImplemented) {
+        this.generateOperationsToReturnNotImplemented = generateOperationsToReturnNotImplemented;
+    }
+
+    public void setGenerateControllerFromExamples(boolean generateControllerFromExamples) {
+        this.generateControllerFromExamples = generateControllerFromExamples;
+    }
+
+    public void setUseAuth(boolean useAuth) {
+        this.useAuth = useAuth;
+    }
+
+    public void setAot(boolean aot) {
+        this.aot = aot;
+    }
+
+    public void setGenerateStreamingFileUpload(boolean generateStreamingFileUpload) {
+        this.generateStreamingFileUpload = generateStreamingFileUpload;
+    }
+
+    public void setGenerateHardNullable(boolean generateHardNullable) {
+        this.generateHardNullable = generateHardNullable;
+    }
+
+    public void setUserParameterMode(String userParameterMode) {
+        if (userParameterMode == null) {
+            this.userParameterMode = UserParameterMode.NONE;
+            return;
+        }
+        try {
+            this.userParameterMode = UserParameterMode.valueOf(userParameterMode.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            var sb = new StringBuilder(userParameterMode + " is an invalid enum property naming option. Please choose from:");
+            for (var availableOpt : UserParameterMode.values()) {
+                sb.append("\n  ").append(availableOpt.name());
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+
     static class DefaultServerOptionsBuilder implements JavaMicronautServerOptionsBuilder {
 
         private String controllerPackage;
@@ -356,6 +412,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         private boolean generateControllerFromExamples;
         private boolean generateOperationsToReturnNotImplemented = true;
         private boolean useAuth = true;
+        private String userParameterMode = UserParameterMode.NONE.name();
         private boolean lombok;
         private boolean plural = true;
         private boolean fluxForArrays;
@@ -398,6 +455,12 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         @Override
         public JavaMicronautServerOptionsBuilder withAuthentication(boolean useAuth) {
             this.useAuth = useAuth;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautServerOptionsBuilder withUserParameterMode(String userParameterMode) {
+            this.userParameterMode = userParameterMode;
             return this;
         }
 
@@ -450,6 +513,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
                 generateOperationsToReturnNotImplemented,
                 generateControllerFromExamples,
                 useAuth,
+                userParameterMode,
                 lombok,
                 plural,
                 fluxForArrays,
@@ -468,6 +532,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
         boolean generateOperationsToReturnNotImplemented,
         boolean generateControllerFromExamples,
         boolean useAuth,
+        String userParameterMode,
         boolean lombok,
         boolean plural,
         boolean fluxForArrays,

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerOptionsBuilder.java
@@ -76,6 +76,19 @@ public interface JavaMicronautServerOptionsBuilder extends GeneratorOptionsBuild
     JavaMicronautServerOptionsBuilder withAuthentication(boolean useAuth);
 
     /**
+     * Add or not principal / authentication parameter to controller methods.
+     * Available modes:
+     * NONE
+     * PRINCIPAL
+     * AUTHENTICATION
+     *
+     * @param userParameterMode user parameter mode
+     *
+     * @return this builder
+     */
+    JavaMicronautServerOptionsBuilder withUserParameterMode(String userParameterMode);
+
+    /**
      * If set to true, generated code will be with lombok annotations.
      *
      * @param lombok generate code with lombok annotations or not

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
@@ -29,8 +29,11 @@ import org.openapitools.codegen.utils.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static io.micronaut.openapi.generator.Utils.addUserParameter;
 import static org.openapitools.codegen.CodegenConstants.API_PACKAGE;
 
 /**
@@ -45,6 +48,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
     public static final String OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED = "generateOperationsToReturnNotImplemented";
     public static final String OPT_GENERATE_STREAMING_FILE_UPLOAD = "generateStreamingFileUpload";
     public static final String OPT_AOT = "aot";
+    public static final String OPT_USER_PARAMETER_MODE = "userParameterMode";
 
     public static final String EXTENSION_ROLES = "x-roles";
     public static final String ANONYMOUS_ROLE_KEY = "isAnonymous()";
@@ -69,6 +73,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
     protected boolean useAuth = true;
     protected boolean generateStreamingFileUpload;
     protected boolean aot;
+    protected UserParameterMode userParameterMode = UserParameterMode.NONE;
 
     KotlinMicronautServerCodegen() {
 
@@ -95,6 +100,14 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_STREAMING_FILE_UPLOAD, "Whether to generate StreamingFileUpload type for file request body", generateStreamingFileUpload));
         cliOptions.add(CliOption.newBoolean(OPT_AOT, "Generate compatible code with micronaut-aot", aot));
 
+        var userModeOption = new CliOption(OPT_USER_PARAMETER_MODE, "Add or not principal / authentication parameter to controller methods").defaultValue(userParameterMode.name());
+        var userModeOptionsMap = new HashMap<String, String>();
+        userModeOptionsMap.put(UserParameterMode.NONE.name(), "Don't add principal / authentication parameter to controller methods");
+        userModeOptionsMap.put(UserParameterMode.PRINCIPAL.name(), "Add java.security.Principal principal parameter to each controller method");
+        userModeOptionsMap.put(UserParameterMode.AUTHENTICATION.name(), "Add io.micronaut.security.authentication.Authentication authentication parameter to each controller method");
+        userModeOption.setEnum(userModeOptionsMap);
+        cliOptions.add(userModeOption);
+
         setApiNamePrefix(API_PREFIX);
         setApiNameSuffix(API_SUFFIX);
 
@@ -106,6 +119,9 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
 
         typeMapping.put("responseFile", "FileCustomizableResponseType");
         importMapping.put("FileCustomizableResponseType", "io.micronaut.http.server.types.files.FileCustomizableResponseType");
+
+        importMapping.put(UserParameterMode.PRINCIPAL.getClassName(), UserParameterMode.PRINCIPAL.getClassFullName());
+        importMapping.put(UserParameterMode.AUTHENTICATION.getClassName(), UserParameterMode.AUTHENTICATION.getClassFullName());
 
         // Add all the supporting files
         supportingFiles.add(new SupportingFile("common/configuration/application.yml.mustache", resourcesFolder, "application.yml").doNotOverwrite());
@@ -125,34 +141,6 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
     @Override
     public String getHelp() {
         return "Generates a Kotlin Micronaut Server.";
-    }
-
-    public void setControllerPackage(String controllerPackage) {
-        this.controllerPackage = controllerPackage;
-    }
-
-    public void setGenerateImplementationFiles(boolean generateImplementationFiles) {
-        this.generateImplementationFiles = generateImplementationFiles;
-    }
-
-    public void setGenerateOperationsToReturnNotImplemented(boolean generateOperationsToReturnNotImplemented) {
-        this.generateOperationsToReturnNotImplemented = generateOperationsToReturnNotImplemented;
-    }
-
-    public void setGenerateControllerFromExamples(boolean generateControllerFromExamples) {
-        this.generateControllerFromExamples = generateControllerFromExamples;
-    }
-
-    public void setUseAuth(boolean useAuth) {
-        this.useAuth = useAuth;
-    }
-
-    public void setGenerateStreamingFileUpload(boolean generateStreamingFileUpload) {
-        this.generateStreamingFileUpload = generateStreamingFileUpload;
-    }
-
-    public void setAot(boolean aot) {
-        this.aot = aot;
     }
 
     @Override
@@ -200,6 +188,12 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
             generateStreamingFileUpload = convertPropertyToBoolean(OPT_GENERATE_STREAMING_FILE_UPLOAD);
         }
         writePropertyBack(OPT_GENERATE_STREAMING_FILE_UPLOAD, generateStreamingFileUpload);
+
+        if (additionalProperties.containsKey(OPT_USER_PARAMETER_MODE)) {
+            var userModeOpt = (String) additionalProperties.get(OPT_USER_PARAMETER_MODE);
+            setUserParameterMode(userModeOpt);
+        }
+        writePropertyBack(OPT_USER_PARAMETER_MODE, userParameterMode.name());
 
         // Api file
         apiTemplateFiles.clear();
@@ -271,7 +265,6 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
 
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
-        objs = super.postProcessOperationsWithModels(objs, allModels);
 
         // Add the controller classname to operations
         OperationMap operations = objs.getOperations();
@@ -279,11 +272,18 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         objs.put("controllerClassname", controllerClassname);
 
         var allOperations = (List<CodegenOperation>) operations.get("operation");
-        if (useAuth) {
-            for (CodegenOperation operation : allOperations) {
-                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
 
-                    var roles = new ArrayList<String>();
+        if (useAuth) {
+
+            var alreadyAddedPrincipalImport = false;
+            String importClassFullName = userParameterMode.getClassFullName();
+            String importClassName = userParameterMode.getClassName();
+
+            for (CodegenOperation operation : allOperations) {
+
+                List<String> roles = new ArrayList<>();
+
+                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
                     var authMethods = operation.authMethods;
                     if (authMethods != null && !authMethods.isEmpty()) {
                         var scopes = authMethods.get(0).scopes;
@@ -297,20 +297,33 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
                     } else {
                         roles.add(ANONYMOUS_ROLE);
                     }
-
-                    operation.vendorExtensions.put(EXTENSION_ROLES, roles);
                 } else {
-                    var roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
-                    roles = roles.stream().map(role -> switch (role) {
-                        case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
-                        case AUTHORIZED_ROLE_KEY -> AUTHORIZED_ROLE;
-                        case DENY_ALL_ROLE_KEY -> DENY_ALL_ROLE;
-                        default -> "\"" + escapeText(role) + "\"";
-                    }).toList();
-                    operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+                    roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
+                    roles = roles.stream()
+                        .map(role -> switch (role) {
+                            case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
+                            case AUTHORIZED_ROLE_KEY -> AUTHORIZED_ROLE;
+                            case DENY_ALL_ROLE_KEY -> DENY_ALL_ROLE;
+                            default -> "\"" + escapeText(role) + "\"";
+                        }).toList();
+                }
+
+                operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+
+                if (userParameterMode != UserParameterMode.NONE) {
+                    var isAnonymous = roles.contains(ANONYMOUS_ROLE);
+                    var isDenyAll = roles.contains(DENY_ALL_ROLE);
+                    addUserParameter(operation, userParameterMode, isAnonymous, isDenyAll);
+
+                    if (importClassFullName != null && !alreadyAddedPrincipalImport) {
+                        objs.getImports().add(Map.of("import", importClassFullName, "classname", importClassName));
+                        alreadyAddedPrincipalImport = true;
+                    }
                 }
             }
         }
+
+        objs = super.postProcessOperationsWithModels(objs, allModels);
 
         var enumParams = (List<String>) additionalProperties.get("enumParams");
         if (generateEnumConverters && !enumParams.isEmpty()) {
@@ -329,6 +342,50 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         return new DefaultServerOptionsBuilder();
     }
 
+    public void setControllerPackage(String controllerPackage) {
+        this.controllerPackage = controllerPackage;
+    }
+
+    public void setGenerateImplementationFiles(boolean generateImplementationFiles) {
+        this.generateImplementationFiles = generateImplementationFiles;
+    }
+
+    public void setGenerateOperationsToReturnNotImplemented(boolean generateOperationsToReturnNotImplemented) {
+        this.generateOperationsToReturnNotImplemented = generateOperationsToReturnNotImplemented;
+    }
+
+    public void setGenerateControllerFromExamples(boolean generateControllerFromExamples) {
+        this.generateControllerFromExamples = generateControllerFromExamples;
+    }
+
+    public void setUseAuth(boolean useAuth) {
+        this.useAuth = useAuth;
+    }
+
+    public void setGenerateStreamingFileUpload(boolean generateStreamingFileUpload) {
+        this.generateStreamingFileUpload = generateStreamingFileUpload;
+    }
+
+    public void setAot(boolean aot) {
+        this.aot = aot;
+    }
+
+    public void setUserParameterMode(String userParameterMode) {
+        if (userParameterMode == null) {
+            this.userParameterMode = null;
+            return;
+        }
+        try {
+            this.userParameterMode = UserParameterMode.valueOf(userParameterMode.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            var sb = new StringBuilder(userParameterMode + " is an invalid enum property naming option. Please choose from:");
+            for (var availableOpt : UserParameterMode.values()) {
+                sb.append("\n  ").append(availableOpt.name());
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+
     static class DefaultServerOptionsBuilder implements KotlinMicronautServerOptionsBuilder {
 
         private String controllerPackage;
@@ -337,6 +394,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         private boolean generateOperationsToReturnNotImplemented = true;
         private boolean plural = true;
         private boolean useAuth = true;
+        private String userParameterMode = UserParameterMode.NONE.name();
         private boolean fluxForArrays;
         private boolean generatedAnnotation = true;
         private boolean aot;
@@ -374,6 +432,12 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         @Override
         public KotlinMicronautServerOptionsBuilder withAuthentication(boolean useAuth) {
             this.useAuth = useAuth;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautServerOptionsBuilder withUserParameterMode(String userParameterMode) {
+            this.userParameterMode = userParameterMode;
             return this;
         }
 
@@ -444,6 +508,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
                 generateOperationsToReturnNotImplemented,
                 generateControllerFromExamples,
                 useAuth,
+                userParameterMode,
                 plural,
                 fluxForArrays,
                 generatedAnnotation,
@@ -464,6 +529,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
         boolean generateOperationsToReturnNotImplemented,
         boolean generateControllerFromExamples,
         boolean useAuth,
+        String userParameterMode,
         boolean plural,
         boolean fluxForArrays,
         boolean generatedAnnotation,

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerOptionsBuilder.java
@@ -67,6 +67,19 @@ public interface KotlinMicronautServerOptionsBuilder extends GeneratorOptionsBui
     KotlinMicronautServerOptionsBuilder withAuthentication(boolean useAuth);
 
     /**
+     * Add or not principal / authentication parameter to controller methods.
+     * Available modes:
+     * NONE
+     * PRINCIPAL
+     * AUTHENTICATION
+     *
+     * @param userParameterMode user parameter mode
+     *
+     * @return this builder
+     */
+    KotlinMicronautServerOptionsBuilder withUserParameterMode(String userParameterMode);
+
+    /**
      * If set to true, generated code will be with Flux{@literal <}?> instead Mono{@literal <}List{@literal <}?>>.
      *
      * @param fluxForArrays generate code with Flux{@literal <}?> instead Mono{@literal <}List{@literal <}?>> or not

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -356,6 +356,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             javaServerCodegen.setGenerateOperationsToReturnNotImplemented(javaServerOptions.generateOperationsToReturnNotImplemented());
             javaServerCodegen.setGenerateControllerFromExamples(javaServerOptions.generateControllerFromExamples());
             javaServerCodegen.setUseAuth(javaServerOptions.useAuth());
+            javaServerCodegen.setUserParameterMode(javaServerOptions.userParameterMode());
             javaServerCodegen.setLombok(javaServerOptions.lombok());
             javaServerCodegen.setPlural(javaServerOptions.plural());
             javaServerCodegen.setFluxForArrays(javaServerOptions.fluxForArrays());
@@ -416,6 +417,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             kotlinServerCodegen.setKsp(kotlinServerOptions.ksp());
             kotlinServerCodegen.setCoroutines(kotlinServerOptions.coroutines());
             kotlinServerCodegen.setUseAuth(kotlinServerOptions.useAuth());
+            kotlinServerCodegen.setUserParameterMode(kotlinServerOptions.userParameterMode());
             kotlinServerCodegen.setPlural(kotlinServerOptions.plural());
             kotlinServerCodegen.setFluxForArrays(kotlinServerOptions.fluxForArrays());
             kotlinServerCodegen.setGenerateStreamingFileUpload(kotlinServerOptions.generateStreamingFileUpload());

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.openapi.generator;
 
+import io.micronaut.openapi.generator.MicronautCodeGeneratorEntryPoint.TestFramework;
+
 import java.util.List;
 import java.util.Map;
 
@@ -316,7 +318,7 @@ public interface MicronautCodeGeneratorOptionsBuilder {
      * @param testFramework the test framework
      * @return this builder
      */
-    MicronautCodeGeneratorOptionsBuilder withTestFramework(MicronautCodeGeneratorEntryPoint.TestFramework testFramework);
+    MicronautCodeGeneratorOptionsBuilder withTestFramework(TestFramework testFramework);
 
     /**
      * Configure the serialization library.

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/UserParameterMode.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/UserParameterMode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.generator;
+
+/**
+ * Supported user parameter modes.
+ */
+public enum UserParameterMode {
+
+    NONE(null, null, null, null),
+    PRINCIPAL("principal", "The principal", "Principal", "java.security.Principal"),
+    AUTHENTICATION("authentication", "The authentication", "Authentication", "io.micronaut.security.authentication.Authentication"),
+    ;
+
+    private final String paramName;
+    private final String paramDescription;
+    private final String className;
+    private final String classFullName;
+
+    UserParameterMode(String paramName, String paramDescription, String className, String classFullName) {
+        this.paramName = paramName;
+        this.paramDescription = paramDescription;
+        this.className = className;
+        this.classFullName = classFullName;
+    }
+
+    public String getParamName() {
+        return paramName;
+    }
+
+    public String getParamDescription() {
+        return paramDescription;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getClassFullName() {
+        return classFullName;
+    }
+}

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
@@ -643,4 +643,28 @@ public final class Utils {
             enumImports.add(modelPackage + "." + param.dataType);
         }
     }
+
+    public static boolean addUserParameter(CodegenOperation op, UserParameterMode userParameterMode, boolean isAnonymous, boolean isDenyAll) {
+
+        if (userParameterMode == UserParameterMode.NONE || isDenyAll) {
+            return false;
+        }
+
+        CodegenParameter userParam = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+        userParam.paramName = userParameterMode.getParamName();
+        userParam.description = userParameterMode.getParamDescription();
+        userParam.dataType = userParameterMode.getClassName();
+        userParam.unescapedDescription = userParam.description;
+        userParam.required = true;
+        if (!isAnonymous) {
+            userParam.vendorExtensions.put("withoutNullable", true);
+        } else {
+            userParam.isNullable = true;
+            userParam.vendorExtensions.put("defaultValueInit", NULL_STRING);
+        }
+
+        op.allParams.add(userParam);
+
+        return true;
+    }
 }

--- a/openapi-generator/src/main/resources/templates/java-micronaut/common/params/validation.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/common/params/validation.mustache
@@ -1,11 +1,12 @@
 {{^vendorExtensions.isPrimitiveArray}}
+{{^vendorExtensions.withoutNullable}}
 {{#isNullable}}
-    {{#generateHardNullable}}
+        {{#generateHardNullable}}
     @Nullable(inherited = true)
-    {{/generateHardNullable}}
-    {{^generateHardNullable}}
+        {{/generateHardNullable}}
+        {{^generateHardNullable}}
     @Nullable
-    {{/generateHardNullable}}
+        {{/generateHardNullable}}
 {{/isNullable}}
 {{^isNullable}}
     {{#required}}
@@ -32,6 +33,7 @@
         {{/generateHardNullable}}
     {{/required}}
 {{/isNullable}}
+{{/vendorExtensions.withoutNullable}}
 {{/vendorExtensions.isPrimitiveArray}}
 {{!All the validation}}
 {{#useBeanValidation}}
@@ -39,7 +41,9 @@
     {{^isNullable}}
         {{#required}}
             {{^isReadOnly}}
+                {{^vendorExtensions.withoutNullable}}
     @NotNull{{#vendorExtensions.x-not-null-message}}(message = "{{{.}}}"){{/vendorExtensions.x-not-null-message}}
+                {{/vendorExtensions.withoutNullable}}
             {{/isReadOnly}}
         {{/required}}
     {{/isNullable}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/params/validation.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/common/params/validation.mustache
@@ -1,5 +1,6 @@
 
 {{^vendorExtensions.isPrimitiveArray}}
+{{^vendorExtensions.withoutNullable}}
     {{^vendorExtensions.valueWithDefaultValue}}
 {{#isNullable}}
     @Nullable
@@ -15,6 +16,7 @@
     {{/required}}
 {{/isNullable}}
     {{/vendorExtensions.valueWithDefaultValue}}
+{{/vendorExtensions.withoutNullable}}
 {{/vendorExtensions.isPrimitiveArray}}
 {{!All the validation}}
 {{#useBeanValidation}}
@@ -22,7 +24,9 @@
     {{^isNullable}}
         {{#required}}
             {{^isReadOnly}}
+                {{^vendorExtensions.withoutNullable}}
     @NotNull{{#vendorExtensions.x-not-null-message}}(message = "{{{.}}}"){{/vendorExtensions.x-not-null-message}}
+                {{/vendorExtensions.withoutNullable}}
             {{/isReadOnly}}
         {{/required}}
     {{/isNullable}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -1032,4 +1032,118 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
                 """
         );
     }
+
+    @Test
+    void testUserParameterModeNone() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/java/org/openapitools/api/";
+
+        assertFileNotContains(path + "DefaultApi.java",
+            "import java.security.Principal;",
+            "import io.micronaut.security.authentication.Authentication;"
+        );
+
+        assertFileContains(path + "DefaultApi.java", """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    Mono<Void> denyAllOp();
+                """,
+            """
+                    @Get("/pet")
+                    @Secured({"read", "admin"})
+                    Mono<Void> get();
+                """,
+            """
+                    @Post("/pet")
+                    @Secured({"write", "admin"})
+                    Mono<Void> save();
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    Mono<Void> savePublic();
+                """
+        );
+    }
+
+    @Test
+    void testUserParameterModePrincipal() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        codegen.setUserParameterMode(UserParameterMode.PRINCIPAL.name());
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/java/org/openapitools/api/";
+        assertFileContains(path + "DefaultApi.java",
+            "import java.security.Principal;",
+            """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    Mono<Void> denyAllOp();
+                """,
+            """
+                    @Get("/pet")
+                    @Secured({"read", "admin"})
+                    Mono<Void> get(
+                        Principal principal
+                    );
+                """,
+            """
+                    @Post("/pet")
+                    @Secured({"write", "admin"})
+                    Mono<Void> save(
+                        Principal principal
+                    );
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    Mono<Void> savePublic(
+                        @Nullable(inherited = true) Principal principal
+                    );
+                """
+        );
+    }
+
+    @Test
+    void testUserParameterModeAuthentication() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        codegen.setUserParameterMode(UserParameterMode.AUTHENTICATION.name());
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/java/org/openapitools/api/";
+        assertFileContains(path + "DefaultApi.java",
+            "import io.micronaut.security.authentication.Authentication;",
+            """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    Mono<Void> denyAllOp();
+                """,
+            """
+                    @Get("/pet")
+                    @Secured({"read", "admin"})
+                    Mono<Void> get(
+                        Authentication authentication
+                    );
+                """,
+            """
+                    @Post("/pet")
+                    @Secured({"write", "admin"})
+                    Mono<Void> save(
+                        Authentication authentication
+                    );
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    Mono<Void> savePublic(
+                        @Nullable(inherited = true) Authentication authentication
+                    );
+                """
+        );
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -1269,4 +1269,118 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
                 """
         );
     }
+
+    @Test
+    void testUserParameterModeNone() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/api/";
+
+        assertFileNotContains(path + "DefaultApi.kt",
+            "import java.security.Principal",
+            "import io.micronaut.security.authentication.Authentication"
+        );
+
+        assertFileContains(path + "DefaultApi.kt", """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    fun denyAllOp(): Mono<Void>
+                """,
+            """
+                    @Get("/pet")
+                    @Secured("read", "admin")
+                    fun get(): Mono<Void>
+                """,
+            """
+                    @Post("/pet")
+                    @Secured("write", "admin")
+                    fun save(): Mono<Void>
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    fun savePublic(): Mono<Void>
+                """
+        );
+    }
+
+    @Test
+    void testUserParameterModePrincipal() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        codegen.setUserParameterMode(UserParameterMode.PRINCIPAL.name());
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/api/";
+        assertFileContains(path + "DefaultApi.kt",
+            "import java.security.Principal",
+            """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    fun denyAllOp(): Mono<Void>
+                """,
+            """
+                    @Get("/pet")
+                    @Secured("read", "admin")
+                    fun get(
+                        principal: Principal,
+                    ): Mono<Void>
+                """,
+            """
+                    @Post("/pet")
+                    @Secured("write", "admin")
+                    fun save(
+                        principal: Principal,
+                    ): Mono<Void>
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    fun savePublic(
+                        @Nullable principal: Principal? = null,
+                    ): Mono<Void>
+                """
+        );
+    }
+
+    @Test
+    void testUserParameterModeAuthentication() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        codegen.setUserParameterMode(UserParameterMode.AUTHENTICATION.name());
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/security.yml");
+
+        String path = outputPath + "src/main/kotlin/org/openapitools/api/";
+        assertFileContains(path + "DefaultApi.kt",
+            "import io.micronaut.security.authentication.Authentication",
+            """
+                    @Post("/deny-all-endpoint")
+                    @Secured(SecurityRule.DENY_ALL)
+                    fun denyAllOp(): Mono<Void>
+                """,
+            """
+                    @Get("/pet")
+                    @Secured("read", "admin")
+                    fun get(
+                        authentication: Authentication,
+                    ): Mono<Void>
+                """,
+            """
+                    @Post("/pet")
+                    @Secured("write", "admin")
+                    fun save(
+                        authentication: Authentication,
+                    ): Mono<Void>
+                """,
+            """
+                    @Post("/pet-public")
+                    @Secured(SecurityRule.IS_ANONYMOUS)
+                    fun savePublic(
+                        @Nullable authentication: Authentication? = null,
+                    ): Mono<Void>
+                """
+        );
+    }
 }

--- a/openapi-generator/src/test/resources/3_0/security.yml
+++ b/openapi-generator/src/test/resources/3_0/security.yml
@@ -19,6 +19,22 @@ paths:
       responses:
         200:
           description: Successfully retrieved information
+  /pet-public:
+    post:
+      operationId: save-public
+      security: []
+      responses:
+        200:
+          description: Successfully saved
+  /deny-all-endpoint:
+    post:
+      operationId: denyAllOp
+      x-roles:
+        - denyAll()
+      security: []
+      responses:
+        200:
+          description: Successfully saved
 components:
   securitySchemes:
     OAuth2:


### PR DESCRIPTION
Added new property `userParameterMode` with enum values: `NONE`, `PRINCIPAL`, `AUTHENTICATION`.

If you set `PRINCIPAL` for each secured controller method will be added parameter `Principal principal`
If you set `AUTHENTICATION` for each secured controller method will be added parameter `Authentication authentication`

Fixed #2277