### PR TITLE
Added annotation `@OpenAPIRequest` as alternative to `@io.micronaut.http.annotation.RequestBean` annotation

### DIFF
--- a/openapi-annotations/src/main/java/io/micronaut/openapi/annotation/OpenAPIRequest.java
+++ b/openapi-annotations/src/main/java/io/micronaut/openapi/annotation/OpenAPIRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotation can be used as alternative to io.micronaut.http.annotation.RequestBean
+ * to mark parameter as wrapped request details. It useful, when you haven't micronaut-http in dependencies.
+ * For example, when you use micronaut-openapi with spring-boot application.
+ *
+ * @since 6.18.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Inherited
+public @interface OpenAPIRequest {
+}

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -53,6 +53,7 @@ import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.openapi.OpenApiUtils;
 import io.micronaut.openapi.annotation.OpenAPIDecorator;
+import io.micronaut.openapi.annotation.OpenAPIRequest;
 import io.micronaut.openapi.javadoc.JavadocDescription;
 import io.micronaut.openapi.swagger.core.util.PrimitiveType;
 import io.swagger.v3.oas.annotations.Webhook;
@@ -882,7 +883,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             return;
         }
 
-        if (parameter.isAnnotationPresent(RequestBean.class)) {
+        if (parameter.isAnnotationPresent(RequestBean.class)
+            || parameter.isAnnotationPresent(OpenAPIRequest.class)) {
             processRequestBean(context, openApi, swaggerOperation, javadocDescription, permitsRequestBody, pathVariables, queryParams,
                 consumesMediaTypes, swaggerParameters, parameter, extraBodyParameters, httpMethod, matchTemplates, pathItems);
             return;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
@@ -48,6 +48,7 @@ import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.openapi.annotation.OpenAPIRequest;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -263,6 +264,7 @@ public final class ElementUtils {
             && !parameter.isAnnotationPresent(CookieValue.class)
             && !parameter.isAnnotationPresent(Header.class)
             && !parameter.isAnnotationPresent(RequestBean.class)
+            && !parameter.isAnnotationPresent(OpenAPIRequest.class)
             && !isResponseType(parameter.getType());
     }
 

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiRequestBeanSpec.groovy
@@ -8,22 +8,20 @@ class OpenApiRequestBeanSpec extends AbstractOpenApiTypeElementSpec {
 
     void "test basic @RequestBean annotation"() {
         given:
-            buildBeanDefinition('test.MyBean', '''
+        buildBeanDefinition('test.MyBean', '''
 
 package test;
 
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.annotation.*;
-import io.micronaut.core.annotation.*;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.parameters.*;
-import io.swagger.v3.oas.annotations.responses.*;
-import io.swagger.v3.oas.annotations.security.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.links.*;
-import java.util.List;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.annotation.RequestBean;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Controller("/")
 class MyController {
@@ -86,25 +84,124 @@ class MyBean {}
 
 ''')
 
-            OpenAPI openAPI = Utils.testReference
-            Operation operation = openAPI.paths?.get("/{pV}")?.get
+        OpenAPI openAPI = Utils.testReference
+        Operation operation = openAPI.paths?.get("/{pV}")?.get
 
         expect:
-            operation
-            operation.parameters
-            operation.parameters.size() == 3
-            operation.parameters[0].name == 'pV'
-            operation.parameters[0].description == 'Any path variable'
-            operation.parameters[0].in == 'path'
-            operation.parameters[0].required
-            operation.parameters[1].name == 'qV'
-            operation.parameters[1].description == 'Any query value'
-            operation.parameters[1].in == 'query'
-            operation.parameters[1].required
-            operation.parameters[2].name == 'My-Content-type'
-            operation.parameters[2].description == 'Any content type'
-            operation.parameters[2].in == 'header'
-            !operation.parameters[2].required
+        operation
+        operation.parameters
+        operation.parameters.size() == 3
+        operation.parameters[0].name == 'pV'
+        operation.parameters[0].description == 'Any path variable'
+        operation.parameters[0].in == 'path'
+        operation.parameters[0].required
+        operation.parameters[1].name == 'qV'
+        operation.parameters[1].description == 'Any query value'
+        operation.parameters[1].in == 'query'
+        operation.parameters[1].required
+        operation.parameters[2].name == 'My-Content-type'
+        operation.parameters[2].description == 'Any content type'
+        operation.parameters[2].in == 'header'
+        !operation.parameters[2].required
+    }
+
+    void "test basic @OpenAPIRequest annotation"() {
+        given:
+        buildBeanDefinition('test.MyBean', '''
+
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.openapi.annotation.OpenAPIRequest;
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Controller("/")
+class MyController {
+
+    @Get("/{pV}")
+    public Response updatePet(@OpenAPIRequest MyRequestBean bean) {
+        return null;
+    }
+}
+
+@Introspected
+class MyRequestBean {
+
+    public static final String HEADER_CONTENT_TYPE = "My-Content-type";
+
+    HttpRequest<?> httpRequest;
+
+    @PathVariable("pV")
+    @Parameter(description="Any path variable")
+    private String pathVariable;
+
+    @QueryValue("qV")
+    @Parameter(description="Any query value")
+    private String queryValue;
+
+    @Nullable
+    @Parameter(description="Any content type")
+    @Header(HEADER_CONTENT_TYPE)
+    private String contentType;
+
+    MyRequestBean(HttpRequest<?> httpRequest, String pathVariable, String queryValue, String contentType) {
+        this.httpRequest = httpRequest;
+        this.pathVariable = pathVariable;
+        this.queryValue = queryValue;
+        this.contentType = contentType;
+    }
+
+    public HttpRequest<?> getHttpRequest() {
+        return httpRequest;
+    }
+
+    public String getPathVariable() {
+        return pathVariable;
+    }
+
+    public String getQueryValue() {
+        return queryValue;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+}
+
+class Response {}
+
+@jakarta.inject.Singleton
+class MyBean {}
+
+''')
+
+        OpenAPI openAPI = Utils.testReference
+        Operation operation = openAPI.paths?.get("/{pV}")?.get
+
+        expect:
+        operation
+        operation.parameters
+        operation.parameters.size() == 3
+        operation.parameters[0].name == 'pV'
+        operation.parameters[0].description == 'Any path variable'
+        operation.parameters[0].in == 'path'
+        operation.parameters[0].required
+        operation.parameters[1].name == 'qV'
+        operation.parameters[1].description == 'Any query value'
+        operation.parameters[1].in == 'query'
+        operation.parameters[1].required
+        operation.parameters[2].name == 'My-Content-type'
+        operation.parameters[2].description == 'Any content type'
+        operation.parameters[2].in == 'header'
+        !operation.parameters[2].required
     }
 
     void "test @RequestBean annotation duplicate props"() {
@@ -113,18 +210,11 @@ class MyBean {}
 
 package test;
 
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.annotation.*;
-import io.micronaut.core.annotation.*;
-import io.micronaut.core.annotation.Nullable;
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.parameters.*;
-import io.swagger.v3.oas.annotations.responses.*;
-import io.swagger.v3.oas.annotations.security.*;
-import io.swagger.v3.oas.annotations.media.*;
-import io.swagger.v3.oas.annotations.enums.*;
-import io.swagger.v3.oas.annotations.links.*;
-import java.util.List;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.RequestBean;
 
 @Controller
 class SimpleController {

--- a/src/main/docs/guide/micronautOpenApiAnnotations/openApiRequest.adoc
+++ b/src/main/docs/guide/micronautOpenApiAnnotations/openApiRequest.adoc
@@ -1,18 +1,8 @@
-package io.micronaut.openapi.spring.api;
+Annotation api:openapi.annotation.OpenAPIRequest[] can be used as alternative to *io.micronaut.http.annotation.RequestBean* to mark parameter as wrapped request details. It useful, when you haven't micronaut-http in dependencies. For example, when you use micronaut-openapi with spring-boot application.
 
-// tag::imports[]
-import io.micronaut.openapi.annotation.OpenAPIRequest;
-import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
-import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
-
-// end::imports[]
-// tag::clazz[]
+.Example of using `@OpenAPIRequest` annotation with a Spring Boot application
+[source,java]
+----
 @RestController
 @RequestMapping("/my-api")
 public class MyController {
@@ -80,4 +70,4 @@ public class MyController {
         }
     }
 }
-//end::clazz[]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -43,6 +43,7 @@ micronautOpenApiAnnotations:
   openApiExclude: '@OpenAPIExclude'
   openApiManagement: '@OpenAPIManagement'
   openApiSecurity: '@OpenAPISecurity'
+  openApiRequest: '@OpenAPIRequest'
   accessorsStyle: '@AccessorsStyle'
 mergingSchemas: Merging Schemas
 tagsGeneration: Tags generation


### PR DESCRIPTION
This annotation needed, to remove `micronaut-http` from Spring Boot applications