### PR TITLE
security: check if context path is safe

### DIFF
--- a/openapi/src/main/resources/templates/openapi-explorer/index.html
+++ b/openapi/src/main/resources/templates/openapi-explorer/index.html
@@ -96,7 +96,10 @@
         return decodeURIComponent(v.replace(/(?:^|.*;\s*)contextPath\s*=\s*([^;]*).*$|^.*$/, "$1"));
     }
     const cookie = extract(document.cookie)
-    const contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie
+    contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+    if (!isSafeContextPath(contextPath)) {
+        contextPath = '';
+    }
     const openApiExplorer = document.getElementById('openapi-explorer');
     const head = document.getElementsByTagName('head')[0]
 
@@ -161,6 +164,37 @@
         }
         head.appendChild(el);
         return el;
+    }
+    function isSafeContextPath(cp) {
+        if (typeof cp !== 'string') return false;
+        cp = cp.trim();
+        if (cp === '') return true; // allow empty = root
+
+        try {
+            // Build against current origin to normalize
+            const u = new URL(cp, window.location.origin);
+
+            // Must be same origin and http(s)
+            if (u.origin !== window.location.origin) return false;
+            if (!(u.protocol === 'http:' || u.protocol === 'https:')) return false;
+
+            // Path only: no query or fragment
+            if (u.search !== '' || u.hash !== '') return false;
+
+            const p = u.pathname;
+
+            // Must start with a single slash and contain only safe path chars
+            if (!p.startsWith('/')) return false;
+            if (!/^\/[A-Za-z0-9._~\-\/]*$/.test(p)) return false;
+
+            // Disallow protocol relative indicators traversal and HTML breaking chars
+            if (p.includes('//') || p.includes('..')) return false;
+            if (/[<>"'`\\]/.test(p)) return false;
+
+            return true;
+        } catch {
+            return false;
+        }
     }
 </script>
 

--- a/openapi/src/main/resources/templates/rapidoc/index.html
+++ b/openapi/src/main/resources/templates/rapidoc/index.html
@@ -22,7 +22,10 @@
                 return decodeURIComponent(v.replace(/(?:^|.*;\s*)contextPath\s*=\s*([^;]*).*$|^.*$/, "$1"));
             }
             const cookie = extract(document.cookie)
-            const contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie
+            contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+            if (!isSafeContextPath(contextPath)) {
+                contextPath = '';
+            }
             const head = document.getElementsByTagName('head')[0];
             {{rapipdf.script}}
             const rapidocJs = script(contextPath + "{{rapidoc.js.url.prefix}}rapidoc-min.js", head, true)
@@ -48,6 +51,37 @@
                 }
                 head.appendChild(el);
                 return el;
+            }
+            function isSafeContextPath(cp) {
+                if (typeof cp !== 'string') return false;
+                cp = cp.trim();
+                if (cp === '') return true; // allow empty = root
+
+                try {
+                    // Build against current origin to normalize
+                    const u = new URL(cp, window.location.origin);
+
+                    // Must be same origin and http(s)
+                    if (u.origin !== window.location.origin) return false;
+                    if (!(u.protocol === 'http:' || u.protocol === 'https:')) return false;
+
+                    // Path only: no query or fragment
+                    if (u.search !== '' || u.hash !== '') return false;
+
+                    const p = u.pathname;
+
+                    // Must start with a single slash and contain only safe path chars
+                    if (!p.startsWith('/')) return false;
+                    if (!/^\/[A-Za-z0-9._~\-\/]*$/.test(p)) return false;
+
+                    // Disallow protocol relative indicators traversal and HTML breaking chars
+                    if (p.includes('//') || p.includes('..')) return false;
+                    if (/[<>"'`\\]/.test(p)) return false;
+
+                    return true;
+                } catch {
+                    return false;
+                }
             }
         </script>
     </body>

--- a/openapi/src/main/resources/templates/redoc/index.html
+++ b/openapi/src/main/resources/templates/redoc/index.html
@@ -14,7 +14,10 @@
                 return decodeURIComponent(v.replace(/(?:^|.*;\s*)contextPath\s*=\s*([^;]*).*$|^.*$/, "$1"));
             }
             const cookie = extract(document.cookie);
-            const contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+            contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+            if (!isSafeContextPath(contextPath)) {
+                contextPath = '';
+            }
             const head = document.getElementsByTagName('head')[0];
             {{rapipdf.script}}
             const redocJs = script(contextPath + "{{redoc.js.url.prefix}}redoc.standalone.js", head, true);
@@ -31,6 +34,37 @@
                 }
                 head.appendChild(el);
                 return el;
+            }
+            function isSafeContextPath(cp) {
+                if (typeof cp !== 'string') return false;
+                cp = cp.trim();
+                if (cp === '') return true; // allow empty = root
+
+                try {
+                    // Build against current origin to normalize
+                    const u = new URL(cp, window.location.origin);
+
+                    // Must be same origin and http(s)
+                    if (u.origin !== window.location.origin) return false;
+                    if (!(u.protocol === 'http:' || u.protocol === 'https:')) return false;
+
+                    // Path only: no query or fragment
+                    if (u.search !== '' || u.hash !== '') return false;
+
+                    const p = u.pathname;
+
+                    // Must start with a single slash and contain only safe path chars
+                    if (!p.startsWith('/')) return false;
+                    if (!/^\/[A-Za-z0-9._~\-\/]*$/.test(p)) return false;
+
+                    // Disallow protocol relative indicators traversal and HTML breaking chars
+                    if (p.includes('//') || p.includes('..')) return false;
+                    if (/[<>"'`\\]/.test(p)) return false;
+
+                    return true;
+                } catch {
+                    return false;
+                }
             }
         </script>
     </body>

--- a/openapi/src/main/resources/templates/scalar/index.html
+++ b/openapi/src/main/resources/templates/scalar/index.html
@@ -15,7 +15,10 @@
             return decodeURIComponent(v.replace(/(?:^|.*;\s*)contextPath\s*=\s*([^;]*).*$|^.*$/, "$1"));
         };
         const cookie = extract(document.cookie);
-        const contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+        contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+        if (!isSafeContextPath(contextPath)) {
+            contextPath = '';
+        }
         const head = document.getElementsByTagName("head")[0];
 
         window.onload = function() {
@@ -35,6 +38,37 @@
             el.src = src;
             head.appendChild(el);
             return el;
+        }
+        function isSafeContextPath(cp) {
+            if (typeof cp !== 'string') return false;
+            cp = cp.trim();
+            if (cp === '') return true; // allow empty = root
+
+            try {
+                // Build against current origin to normalize
+                const u = new URL(cp, window.location.origin);
+
+                // Must be same origin and http(s)
+                if (u.origin !== window.location.origin) return false;
+                if (!(u.protocol === 'http:' || u.protocol === 'https:')) return false;
+
+                // Path only: no query or fragment
+                if (u.search !== '' || u.hash !== '') return false;
+
+                const p = u.pathname;
+
+                // Must start with a single slash and contain only safe path chars
+                if (!p.startsWith('/')) return false;
+                if (!/^\/[A-Za-z0-9._~\-\/]*$/.test(p)) return false;
+
+                // Disallow protocol relative indicators traversal and HTML breaking chars
+                if (p.includes('//') || p.includes('..')) return false;
+                if (/[<>"'`\\]/.test(p)) return false;
+
+                return true;
+            } catch {
+                return false;
+            }
         }
     </script>
 </body>

--- a/openapi/src/main/resources/templates/swagger-ui/index.html
+++ b/openapi/src/main/resources/templates/swagger-ui/index.html
@@ -15,7 +15,10 @@
             return decodeURIComponent(v.replace(/(?:^|.*;\s*)contextPath\s*=\s*([^;]*).*$|^.*$/, "$1"));
         };
         const cookie = extract(document.cookie);
-        const contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+        contextPath = cookie === '' ? extract(window.location.search.substring(1)) : cookie;
+        if (!isSafeContextPath(contextPath)) {
+            contextPath = '';
+        }
         const head = document.getElementsByTagName('head')[0]
 
         link(contextPath + "{{swagger-ui.js.url.prefix}}swagger-ui.css", head, "text/css", "stylesheet")
@@ -94,6 +97,37 @@
             el.src = src;
             head.appendChild(el);
             return el;
+        }
+        function isSafeContextPath(cp) {
+            if (typeof cp !== 'string') return false;
+            cp = cp.trim();
+            if (cp === '') return true; // allow empty = root
+
+            try {
+                // Build against current origin to normalize
+                const u = new URL(cp, window.location.origin);
+
+                // Must be same origin and http(s)
+                if (u.origin !== window.location.origin) return false;
+                if (!(u.protocol === 'http:' || u.protocol === 'https:')) return false;
+
+                // Path only: no query or fragment
+                if (u.search !== '' || u.hash !== '') return false;
+
+                const p = u.pathname;
+
+                // Must start with a single slash and contain only safe path chars
+                if (!p.startsWith('/')) return false;
+                if (!/^\/[A-Za-z0-9._~\-\/]*$/.test(p)) return false;
+
+                // Disallow protocol relative indicators traversal and HTML breaking chars
+                if (p.includes('//') || p.includes('..')) return false;
+                if (/[<>"'`\\]/.test(p)) return false;
+
+                return true;
+            } catch {
+                return false;
+            }
         }
     </script>
 </body>


### PR DESCRIPTION
This pull-request adds a `isSafeContextPath` method to sanitise the `contextPath`.

> When the application exposes a Swagger UI page, say at “https://localhost:8081/swagger-ui?contextPath=“, it appears that the contextPath parameter is vulnerable. To run potentially malicious Javascript code, an attacker could set the contextPath parameter to the location of a malicious script. For example, here is a test payload used for evaluating whether a website is vulnerable to reflected XSS attacks (it simply triggers a Javascript alert()):

> https://localhost:8081/swagger-ui?contextPath=https://x55.is/brutelogic/brute.svg

> When this URL is evaluated by my browser, the value of the contextPath parameter is not fully sanitised. So the alert(1) script present at https://x55.is/brutelogic/brute.svg  is evaluated and the example payload is executed.

> An attacker could exploit this vulnerability by finding domains on the internet that are serving Swagger UI pages using  micronaut-openapi. They could then craft a link that looks safe, but is actually vulnerable, by packing a malicious script into the contextPath parameter and sending it to an unsuspecting user. Something like “https://mysafewebsite.com/swagger-ui?contextPath=bad_and_unsafe_script.js”

