### PR TITLE
Added ability to add `@Retryable` annotation to generated Client interface.

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientCodegen.java
@@ -36,8 +36,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static io.micronaut.openapi.generator.Utils.normalizeJavaClass;
 import static io.micronaut.openapi.generator.Utils.processMultipartBody;
+import static io.micronaut.openapi.generator.Utils.readBooleanProperty;
+import static io.micronaut.openapi.generator.Utils.readIntProperty;
 import static io.micronaut.openapi.generator.Utils.readListOfStringsProperty;
+import static io.micronaut.openapi.generator.Utils.readProperty;
 
 /**
  * The generator for creating Micronaut clients.
@@ -62,6 +66,17 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
     public static final String AUTHORIZATION_FILTER_PATTERN_STYLE = "authorizationFilterPatternStyle";
     public static final String BASE_PATH_SEPARATOR = "basePathSeparator";
     public static final String CLIENT_ID = "clientId";
+    public static final String RETRYABLE_ANNOTATION = "retryableAnnotation";
+    public static final String OPT_RETRYABLE = "retryable";
+    public static final String OPT_RETRYABLE_INCLUDES = "retryableIncludes";
+    public static final String OPT_RETRYABLE_EXCLUDES = "retryableExcludes";
+    public static final String OPT_RETRYABLE_ATTEMPTS = "retryableAttempts";
+    public static final String OPT_RETRYABLE_DELAY = "retryableDelay";
+    public static final String OPT_RETRYABLE_MAX_DELAY = "retryableMaxDelay";
+    public static final String OPT_RETRYABLE_MULTIPLIER = "retryableMultiplier";
+    public static final String OPT_RETRYABLE_JITTER = "retryableJitter";
+    public static final String OPT_RETRYABLE_PREDICATE = "retryablePredicate";
+    public static final String OPT_RETRYABLE_CAPTURED_EXCEPTION = "retryableCapturedException";
 
     public static final String NAME = "java-micronaut-client";
 
@@ -80,6 +95,17 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
     protected boolean useApiKeyAuth = true;
     protected boolean authFilter = true;
     protected boolean generateAuthClasses = true;
+
+    protected boolean retryable;
+    protected List<String> retryableIncludes;
+    protected List<String> retryableExcludes;
+    protected int retryableAttempts;
+    protected String retryableDelay;
+    protected String retryableMaxDelay;
+    protected String retryableMultiplier;
+    protected String retryableJitter;
+    protected String retryablePredicate;
+    protected String retryableCapturedException;
 
     JavaMicronautClientCodegen() {
 
@@ -104,6 +130,18 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         cliOptions.add(CliOption.newBoolean(OPT_USE_API_KEY_AUTH, "Generate ApiKeyAuthConfig config or not"));
         cliOptions.add(CliOption.newBoolean(OPT_AUTH_FILTER, "Generate AuthorizationFilter or not"));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_AUTH_CLASSES, "Generate authorization classes or not"));
+
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE, "Add or not @Retryable annotation to client class"));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_INCLUDES, "Set includes parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_EXCLUDES, "Set excludes parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_ATTEMPTS, "Set attempts parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_DELAY, "Set delay parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_MAX_DELAY, "Set maxDelay parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_MULTIPLIER, "Set multiplier parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_JITTER, "Set jitter parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_PREDICATE, "Set predicate parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_CAPTURED_EXCEPTION, "Set capturedException parameter for Retryable annotation."));
+
         GlobalSettings.setProperty(CodegenConstants.API_DOCS, "false");
         GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, "false");
 
@@ -148,6 +186,10 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         objs = super.postProcessOperationsWithModels(objs, allModels);
+
+        if (retryable) {
+            objs.getImports().add(Map.of("import", "io.micronaut.retry.annotation.Retryable", "classname", "Retryable"));
+        }
 
         OperationMap operations = objs.getOperations();
         List<CodegenOperation> operationList = operations.getOperation();
@@ -213,33 +255,30 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
 
+        // Retryable annotation
+        retryable = readBooleanProperty(OPT_RETRYABLE, additionalProperties, retryable);
+        if (retryable) {
+            retryableIncludes = readListOfStringsProperty(OPT_RETRYABLE_INCLUDES, additionalProperties, retryableIncludes);
+            retryableExcludes = readListOfStringsProperty(OPT_RETRYABLE_EXCLUDES, additionalProperties, retryableExcludes);
+            retryableAttempts = readIntProperty(OPT_RETRYABLE_ATTEMPTS, additionalProperties, retryableAttempts);
+            retryableDelay = readProperty(OPT_RETRYABLE_DELAY, additionalProperties, retryableDelay);
+            retryableMaxDelay = readProperty(OPT_RETRYABLE_MAX_DELAY, additionalProperties, retryableMaxDelay);
+            retryableMultiplier = readProperty(OPT_RETRYABLE_MULTIPLIER, additionalProperties, retryableMultiplier);
+            retryableJitter = readProperty(OPT_RETRYABLE_JITTER, additionalProperties, retryableJitter);
+            retryablePredicate = readProperty(OPT_RETRYABLE_PREDICATE, additionalProperties, retryablePredicate);
+            retryableCapturedException = readProperty(OPT_RETRYABLE_CAPTURED_EXCEPTION, additionalProperties, retryableCapturedException);
+
+            writePropertyBack(RETRYABLE_ANNOTATION, calcRetryableAnnotation());
+        }
+
         // Authorization files
         if (configureAuthorization) {
 
-            if (additionalProperties.containsKey(OPT_GENERATE_AUTH_CLASSES)) {
-                generateAuthClasses = convertPropertyToBoolean(OPT_GENERATE_AUTH_CLASSES);
-            }
-            writePropertyBack(OPT_GENERATE_AUTH_CLASSES, generateAuthClasses);
-
-            if (additionalProperties.containsKey(OPT_AUTH_FILTER)) {
-                authFilter = convertPropertyToBoolean(OPT_AUTH_FILTER);
-            }
-            writePropertyBack(OPT_AUTH_FILTER, authFilter);
-
-            if (additionalProperties.containsKey(OPT_USE_OAUTH)) {
-                useOauth = convertPropertyToBoolean(OPT_USE_OAUTH);
-            }
-            writePropertyBack(OPT_USE_OAUTH, useOauth);
-
-            if (additionalProperties.containsKey(OPT_USE_BASIC_AUTH)) {
-                useBasicAuth = convertPropertyToBoolean(OPT_USE_BASIC_AUTH);
-            }
-            writePropertyBack(OPT_USE_BASIC_AUTH, useBasicAuth);
-
-            if (additionalProperties.containsKey(OPT_USE_API_KEY_AUTH)) {
-                useApiKeyAuth = convertPropertyToBoolean(OPT_USE_API_KEY_AUTH);
-            }
-            writePropertyBack(OPT_USE_API_KEY_AUTH, useApiKeyAuth);
+            generateAuthClasses = readBooleanProperty(OPT_GENERATE_AUTH_CLASSES, additionalProperties, generateAuthClasses);
+            authFilter = readBooleanProperty(OPT_AUTH_FILTER, additionalProperties, authFilter);
+            useOauth = readBooleanProperty(OPT_USE_OAUTH, additionalProperties, useOauth);
+            useBasicAuth = readBooleanProperty(OPT_USE_BASIC_AUTH, additionalProperties, useBasicAuth);
+            useApiKeyAuth = readBooleanProperty(OPT_USE_API_KEY_AUTH, additionalProperties, useApiKeyAuth);
 
             if (generateAuthClasses) {
                 final String authFolder = invokerFolder + "/auth";
@@ -351,6 +390,73 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         }
     }
 
+    public String calcRetryableAnnotation() {
+
+        if (!retryable) {
+            return null;
+        }
+
+        var retryable = new StringBuilder("@Retryable");
+        var retryableParams = new StringBuilder();
+        var isFirst = true;
+        if (retryableIncludes != null && !retryableIncludes.isEmpty()) {
+            var normalizedRetryableIncludes = retryableIncludes.stream()
+                .map(Utils::normalizeJavaClass)
+                .toList();
+            retryableParams.append('(');
+            retryableParams.append("\n    includes = {").append(String.join(", ", normalizedRetryableIncludes)).append('}');
+            isFirst = false;
+        }
+        if (retryableExcludes != null && !retryableExcludes.isEmpty()) {
+            var normalizedRetryableExcludes = retryableExcludes.stream()
+                .map(Utils::normalizeJavaClass)
+                .toList();
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    excludes = {").append(String.join(", ", normalizedRetryableExcludes)).append('}');
+            isFirst = false;
+        }
+        if (retryableAttempts > 0) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    attempts = \"").append(retryableAttempts).append('"');
+            isFirst = false;
+        }
+        if (retryableDelay != null && !retryableDelay.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    delay = \"").append(retryableDelay).append('"');
+            isFirst = false;
+        }
+        if (retryableMaxDelay != null && !retryableMaxDelay.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    maxDelay = \"").append(retryableMaxDelay).append('"');
+            isFirst = false;
+        }
+        if (retryableMultiplier != null && !retryableMultiplier.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    multiplier = \"").append(retryableMultiplier).append('"');
+            isFirst = false;
+        }
+        if (retryableJitter != null && !retryableJitter.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    jitter = \"").append(retryableJitter).append('"');
+            isFirst = false;
+        }
+        if (retryablePredicate != null && !retryablePredicate.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    predicate = ").append(normalizeJavaClass(retryablePredicate));
+            isFirst = false;
+        }
+        if (retryableCapturedException != null && !retryableCapturedException.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    capturedException = ").append(normalizeJavaClass(retryableCapturedException));
+        }
+        if (!retryableParams.isEmpty()) {
+            retryableParams.append("\n)");
+            retryable.append(retryableParams);
+        }
+
+        return retryable.toString();
+    }
+
     @Override
     public boolean isServer() {
         return false;
@@ -428,6 +534,46 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         this.configureAuthorization = configureAuthorization;
     }
 
+    public void setRetryable(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    public void setRetryableIncludes(List<String> retryableIncludes) {
+        this.retryableIncludes = retryableIncludes;
+    }
+
+    public void setRetryableExcludes(List<String> retryableExcludes) {
+        this.retryableExcludes = retryableExcludes;
+    }
+
+    public void setRetryableAttempts(int retryableAttempts) {
+        this.retryableAttempts = retryableAttempts;
+    }
+
+    public void setRetryableDelay(String retryableDelay) {
+        this.retryableDelay = retryableDelay;
+    }
+
+    public void setRetryableMaxDelay(String retryableMaxDelay) {
+        this.retryableMaxDelay = retryableMaxDelay;
+    }
+
+    public void setRetryableMultiplier(String retryableMultiplier) {
+        this.retryableMultiplier = retryableMultiplier;
+    }
+
+    public void setRetryableJitter(String retryableJitter) {
+        this.retryableJitter = retryableJitter;
+    }
+
+    public void setRetryablePredicate(String retryablePredicate) {
+        this.retryablePredicate = retryablePredicate;
+    }
+
+    public void setRetryableCapturedException(String retryableCapturedException) {
+        this.retryableCapturedException = retryableCapturedException;
+    }
+
     @Override
     public JavaMicronautClientOptionsBuilder optionsBuilder() {
         return new DefaultClientOptionsBuilder();
@@ -455,6 +601,17 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         private boolean generatedAnnotation = true;
         private boolean lombok;
         private boolean noArgsConstructor;
+
+        private boolean retryable;
+        private List<String> retryableIncludes;
+        private List<String> retryableExcludes;
+        private int retryableAttempts;
+        private String retryableDelay;
+        private String retryableMaxDelay;
+        private String retryableMultiplier;
+        private String retryableJitter;
+        private String retryablePredicate;
+        private String retryableCapturedException;
 
         @Override
         public JavaMicronautClientOptionsBuilder withAuthorization(boolean useAuth) {
@@ -576,6 +733,66 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
             return this;
         }
 
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryable(boolean retryable) {
+            this.retryable = retryable;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableIncludes(List<String> retryableIncludes) {
+            this.retryableIncludes = retryableIncludes;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableExcludes(List<String> retryableExcludes) {
+            this.retryableExcludes = retryableExcludes;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableAttempts(int retryableAttempts) {
+            this.retryableAttempts = retryableAttempts;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableDelay(String retryableDelay) {
+            this.retryableDelay = retryableDelay;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableMaxDelay(String retryableMaxDelay) {
+            this.retryableMaxDelay = retryableMaxDelay;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableMultiplier(String retryableMultiplier) {
+            this.retryableMultiplier = retryableMultiplier;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableJitter(String retryableJitter) {
+            this.retryableJitter = retryableJitter;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryablePredicate(String retryablePredicate) {
+            this.retryablePredicate = retryablePredicate;
+            return this;
+        }
+
+        @Override
+        public JavaMicronautClientOptionsBuilder withRetryableCapturedException(String retryableCapturedException) {
+            this.retryableCapturedException = retryableCapturedException;
+            return this;
+        }
+
         ClientOptions build() {
             return new ClientOptions(
                 additionalClientTypeAnnotations,
@@ -597,7 +814,17 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
                 fluxForArrays,
                 generatedAnnotation,
                 lombok,
-                noArgsConstructor
+                noArgsConstructor,
+                retryable,
+                retryableIncludes,
+                retryableExcludes,
+                retryableAttempts,
+                retryableDelay,
+                retryableMaxDelay,
+                retryableMultiplier,
+                retryableJitter,
+                retryablePredicate,
+                retryableCapturedException
             );
         }
     }
@@ -622,7 +849,17 @@ public class JavaMicronautClientCodegen extends AbstractMicronautJavaCodegen<Jav
         boolean fluxForArrays,
         boolean generatedAnnotation,
         boolean lombok,
-        boolean noArgsConstructor
+        boolean noArgsConstructor,
+        boolean retryable,
+        List<String> retryableIncludes,
+        List<String> retryableExcludes,
+        int retryableAttempts,
+        String retryableDelay,
+        String retryableMaxDelay,
+        String retryableMultiplier,
+        String retryableJitter,
+        String retryablePredicate,
+        String retryableCapturedException
     ) {
     }
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautClientOptionsBuilder.java
@@ -210,4 +210,94 @@ public interface JavaMicronautClientOptionsBuilder extends GeneratorOptionsBuild
      * @return this builder
      */
     JavaMicronautClientOptionsBuilder withLombok(boolean lombok);
+
+    /**
+     * Add or not @Retryable annotation to client interface. Default: false
+     *
+     * @param retryable if true, then @Retryable annotation will be added to client interface
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryable(boolean retryable);
+
+    /**
+     * Set includes parameter for Retryable annotation.
+     *
+     * @param retryableIncludes includes value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableIncludes(List<String> retryableIncludes);
+
+    /**
+     * Set excludes parameter for Retryable annotation.
+     *
+     * @param retryableExcludes excludes value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableExcludes(List<String> retryableExcludes);
+
+    /**
+     * Set attempts parameter for Retryable annotation.
+     *
+     * @param retryableAttempts attempts value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableAttempts(int retryableAttempts);
+
+    /**
+     * Set delay parameter for Retryable annotation.
+     *
+     * @param retryableDelay delay value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableDelay(String retryableDelay);
+
+    /**
+     * Set maxDelay parameter for Retryable annotation.
+     *
+     * @param retryableMaxDelay maxDelay value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableMaxDelay(String retryableMaxDelay);
+
+    /**
+     * Set multiplier parameter for Retryable annotation.
+     *
+     * @param retryableMultiplier multiplier value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableMultiplier(String retryableMultiplier);
+
+    /**
+     * Set jitter parameter for Retryable annotation.
+     *
+     * @param retryableJitter jitter value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableJitter(String retryableJitter);
+
+    /**
+     * Set predicate parameter for Retryable annotation.
+     *
+     * @param retryablePredicate predicate value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryablePredicate(String retryablePredicate);
+
+    /**
+     * Set capturedException parameter for Retryable annotation.
+     *
+     * @param retryableCapturedException capturedException value for Retryable annotation
+     *
+     * @return this builder
+     */
+    JavaMicronautClientOptionsBuilder withRetryableCapturedException(String retryableCapturedException);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegen.java
@@ -36,9 +36,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static io.micronaut.openapi.generator.Utils.normalizeKotlinClass;
 import static io.micronaut.openapi.generator.Utils.normalizeStr;
 import static io.micronaut.openapi.generator.Utils.processMultipartBody;
+import static io.micronaut.openapi.generator.Utils.readBooleanProperty;
+import static io.micronaut.openapi.generator.Utils.readIntProperty;
 import static io.micronaut.openapi.generator.Utils.readListOfStringsProperty;
+import static io.micronaut.openapi.generator.Utils.readProperty;
 
 /**
  * The generator for creating Micronaut clients.
@@ -65,6 +69,17 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
     public static final String BASE_PATH_SEPARATOR = "basePathSeparator";
     public static final String CLIENT_ID = "clientId";
     public static final String CLIENT_ID_NORMALIZED = "clientIdNormalized";
+    public static final String RETRYABLE_ANNOTATION = "retryableAnnotation";
+    public static final String OPT_RETRYABLE = "retryable";
+    public static final String OPT_RETRYABLE_INCLUDES = "retryableIncludes";
+    public static final String OPT_RETRYABLE_EXCLUDES = "retryableExcludes";
+    public static final String OPT_RETRYABLE_ATTEMPTS = "retryableAttempts";
+    public static final String OPT_RETRYABLE_DELAY = "retryableDelay";
+    public static final String OPT_RETRYABLE_MAX_DELAY = "retryableMaxDelay";
+    public static final String OPT_RETRYABLE_MULTIPLIER = "retryableMultiplier";
+    public static final String OPT_RETRYABLE_JITTER = "retryableJitter";
+    public static final String OPT_RETRYABLE_PREDICATE = "retryablePredicate";
+    public static final String OPT_RETRYABLE_CAPTURED_EXCEPTION = "retryableCapturedException";
 
     public static final String NAME = "kotlin-micronaut-client";
 
@@ -84,6 +99,17 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
     protected boolean authFilter = true;
     protected boolean generateAuthClasses = true;
     protected boolean explicitApi;
+
+    protected boolean retryable;
+    protected List<String> retryableIncludes;
+    protected List<String> retryableExcludes;
+    protected int retryableAttempts;
+    protected String retryableDelay;
+    protected String retryableMaxDelay;
+    protected String retryableMultiplier;
+    protected String retryableJitter;
+    protected String retryablePredicate;
+    protected String retryableCapturedException;
 
     KotlinMicronautClientCodegen() {
 
@@ -109,6 +135,18 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         cliOptions.add(CliOption.newBoolean(OPT_AUTH_FILTER, "Generate AuthorizationFilter or not"));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_AUTH_CLASSES, "Generate authorization classes or not"));
         cliOptions.add(CliOption.newBoolean(OPT_EXPLICIT_API, "Generates code with explicit access modifiers to comply with Kotlin Explicit API Mode."));
+
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE, "Add or not @Retryable annotation to client class"));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_INCLUDES, "Set includes parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_EXCLUDES, "Set excludes parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_ATTEMPTS, "Set attempts parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_DELAY, "Set delay parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_MAX_DELAY, "Set maxDelay parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_MULTIPLIER, "Set multiplier parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_JITTER, "Set jitter parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_PREDICATE, "Set predicate parameter for Retryable annotation."));
+        cliOptions.add(CliOption.newString(OPT_RETRYABLE_CAPTURED_EXCEPTION, "Set capturedException parameter for Retryable annotation."));
+
         GlobalSettings.setProperty(CodegenConstants.API_DOCS, "false");
         GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, "false");
 
@@ -153,6 +191,10 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         objs = super.postProcessOperationsWithModels(objs, allModels);
+
+        if (retryable) {
+            objs.getImports().add(Map.of("import", "io.micronaut.retry.annotation.Retryable", "classname", "Retryable"));
+        }
 
         OperationMap operations = objs.getOperations();
         List<CodegenOperation> operationList = operations.getOperation();
@@ -232,33 +274,30 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
 
         final String invokerFolder = (sourceFolder + '/' + packageName).replace(".", "/");
 
+        // Retryable annotation
+        retryable = readBooleanProperty(OPT_RETRYABLE, additionalProperties, retryable);
+        if (retryable) {
+            retryableIncludes = readListOfStringsProperty(OPT_RETRYABLE_INCLUDES, additionalProperties, retryableIncludes);
+            retryableExcludes = readListOfStringsProperty(OPT_RETRYABLE_EXCLUDES, additionalProperties, retryableExcludes);
+            retryableAttempts = readIntProperty(OPT_RETRYABLE_ATTEMPTS, additionalProperties, retryableAttempts);
+            retryableDelay = readProperty(OPT_RETRYABLE_DELAY, additionalProperties, retryableDelay);
+            retryableMaxDelay = readProperty(OPT_RETRYABLE_MAX_DELAY, additionalProperties, retryableMaxDelay);
+            retryableMultiplier = readProperty(OPT_RETRYABLE_MULTIPLIER, additionalProperties, retryableMultiplier);
+            retryableJitter = readProperty(OPT_RETRYABLE_JITTER, additionalProperties, retryableJitter);
+            retryablePredicate = readProperty(OPT_RETRYABLE_PREDICATE, additionalProperties, retryablePredicate);
+            retryableCapturedException = readProperty(OPT_RETRYABLE_CAPTURED_EXCEPTION, additionalProperties, retryableCapturedException);
+
+            writePropertyBack(RETRYABLE_ANNOTATION, calcRetryableAnnotation());
+        }
+
         // Authorization files
         if (configureAuthorization) {
 
-            if (additionalProperties.containsKey(OPT_GENERATE_AUTH_CLASSES)) {
-                generateAuthClasses = convertPropertyToBoolean(OPT_GENERATE_AUTH_CLASSES);
-            }
-            writePropertyBack(OPT_GENERATE_AUTH_CLASSES, generateAuthClasses);
-
-            if (additionalProperties.containsKey(OPT_AUTH_FILTER)) {
-                authFilter = convertPropertyToBoolean(OPT_AUTH_FILTER);
-            }
-            writePropertyBack(OPT_AUTH_FILTER, authFilter);
-
-            if (additionalProperties.containsKey(OPT_USE_OAUTH)) {
-                useOauth = convertPropertyToBoolean(OPT_USE_OAUTH);
-            }
-            writePropertyBack(OPT_USE_OAUTH, useOauth);
-
-            if (additionalProperties.containsKey(OPT_USE_BASIC_AUTH)) {
-                useBasicAuth = convertPropertyToBoolean(OPT_USE_BASIC_AUTH);
-            }
-            writePropertyBack(OPT_USE_BASIC_AUTH, useBasicAuth);
-
-            if (additionalProperties.containsKey(OPT_USE_API_KEY_AUTH)) {
-                useApiKeyAuth = convertPropertyToBoolean(OPT_USE_API_KEY_AUTH);
-            }
-            writePropertyBack(OPT_USE_API_KEY_AUTH, useApiKeyAuth);
+            generateAuthClasses = readBooleanProperty(OPT_GENERATE_AUTH_CLASSES, additionalProperties, generateAuthClasses);
+            authFilter = readBooleanProperty(OPT_AUTH_FILTER, additionalProperties, authFilter);
+            useOauth = readBooleanProperty(OPT_USE_OAUTH, additionalProperties, useOauth);
+            useBasicAuth = readBooleanProperty(OPT_USE_BASIC_AUTH, additionalProperties, useBasicAuth);
+            useApiKeyAuth = readBooleanProperty(OPT_USE_API_KEY_AUTH, additionalProperties, useApiKeyAuth);
 
             if (generateAuthClasses) {
                 final String authFolder = invokerFolder + "/auth";
@@ -375,6 +414,73 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         }
     }
 
+    public String calcRetryableAnnotation() {
+
+        if (!retryable) {
+            return null;
+        }
+
+        var retryable = new StringBuilder("@Retryable");
+        var retryableParams = new StringBuilder();
+        var isFirst = true;
+        if (retryableIncludes != null && !retryableIncludes.isEmpty()) {
+            var normalizedRetryableIncludes = retryableIncludes.stream()
+                .map(Utils::normalizeKotlinClass)
+                .toList();
+            retryableParams.append("(");
+            retryableParams.append("\n    ").append(String.join(", ", normalizedRetryableIncludes));
+            isFirst = false;
+        }
+        if (retryableExcludes != null && !retryableExcludes.isEmpty()) {
+            var normalizedRetryableExcludes = retryableExcludes.stream()
+                .map(Utils::normalizeKotlinClass)
+                .toList();
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    excludes = [").append(String.join(", ", normalizedRetryableExcludes)).append(']');
+            isFirst = false;
+        }
+        if (retryableAttempts > 0) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    attempts = \"").append(retryableAttempts).append('"');
+            isFirst = false;
+        }
+        if (retryableDelay != null && !retryableDelay.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    delay = \"").append(retryableDelay).append('"');
+            isFirst = false;
+        }
+        if (retryableMaxDelay != null && !retryableMaxDelay.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    maxDelay = \"").append(retryableMaxDelay).append('"');
+            isFirst = false;
+        }
+        if (retryableMultiplier != null && !retryableMultiplier.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    multiplier = \"").append(retryableMultiplier).append('"');
+            isFirst = false;
+        }
+        if (retryableJitter != null && !retryableJitter.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    jitter = \"").append(retryableJitter).append('"');
+            isFirst = false;
+        }
+        if (retryablePredicate != null && !retryablePredicate.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    predicate = ").append(normalizeKotlinClass(retryablePredicate));
+            isFirst = false;
+        }
+        if (retryableCapturedException != null && !retryableCapturedException.isBlank()) {
+            retryableParams.append(isFirst ? '(' : ',');
+            retryableParams.append("\n    capturedException = ").append(normalizeKotlinClass(retryableCapturedException));
+        }
+        if (!retryableParams.isEmpty()) {
+            retryableParams.append(",\n)");
+            retryable.append(retryableParams);
+        }
+
+        return retryable.toString();
+    }
+
     @Override
     public boolean isServer() {
         return false;
@@ -456,6 +562,46 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         this.explicitApi = explicitApi;
     }
 
+    public void setRetryable(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    public void setRetryableIncludes(List<String> retryableIncludes) {
+        this.retryableIncludes = retryableIncludes;
+    }
+
+    public void setRetryableExcludes(List<String> retryableExcludes) {
+        this.retryableExcludes = retryableExcludes;
+    }
+
+    public void setRetryableAttempts(int retryableAttempts) {
+        this.retryableAttempts = retryableAttempts;
+    }
+
+    public void setRetryableDelay(String retryableDelay) {
+        this.retryableDelay = retryableDelay;
+    }
+
+    public void setRetryableMaxDelay(String retryableMaxDelay) {
+        this.retryableMaxDelay = retryableMaxDelay;
+    }
+
+    public void setRetryableMultiplier(String retryableMultiplier) {
+        this.retryableMultiplier = retryableMultiplier;
+    }
+
+    public void setRetryableJitter(String retryableJitter) {
+        this.retryableJitter = retryableJitter;
+    }
+
+    public void setRetryablePredicate(String retryablePredicate) {
+        this.retryablePredicate = retryablePredicate;
+    }
+
+    public void setRetryableCapturedException(String retryableCapturedException) {
+        this.retryableCapturedException = retryableCapturedException;
+    }
+
     @Override
     public KotlinMicronautClientOptionsBuilder optionsBuilder() {
         return new DefaultClientOptionsBuilder();
@@ -489,6 +635,17 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         private boolean modelMutable = true;
         private boolean explicitApi;
         private boolean nonPublicApi;
+
+        private boolean retryable;
+        private List<String> retryableIncludes;
+        private List<String> retryableExcludes;
+        private int retryableAttempts;
+        private String retryableDelay;
+        private String retryableMaxDelay;
+        private String retryableMultiplier;
+        private String retryableJitter;
+        private String retryablePredicate;
+        private String retryableCapturedException;
 
         @Override
         public KotlinMicronautClientOptionsBuilder withAuthorization(boolean useAuth) {
@@ -646,6 +803,66 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
             return this;
         }
 
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryable(boolean retryable) {
+            this.retryable = retryable;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableIncludes(List<String> retryableIncludes) {
+            this.retryableIncludes = retryableIncludes;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableExcludes(List<String> retryableExcludes) {
+            this.retryableExcludes = retryableExcludes;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableAttempts(int retryableAttempts) {
+            this.retryableAttempts = retryableAttempts;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableDelay(String retryableDelay) {
+            this.retryableDelay = retryableDelay;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableMaxDelay(String retryableMaxDelay) {
+            this.retryableMaxDelay = retryableMaxDelay;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableMultiplier(String retryableMultiplier) {
+            this.retryableMultiplier = retryableMultiplier;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableJitter(String retryableJitter) {
+            this.retryableJitter = retryableJitter;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryablePredicate(String retryablePredicate) {
+            this.retryablePredicate = retryablePredicate;
+            return this;
+        }
+
+        @Override
+        public KotlinMicronautClientOptionsBuilder withRetryableCapturedException(String retryableCapturedException) {
+            this.retryableCapturedException = retryableCapturedException;
+            return this;
+        }
+
         ClientOptions build() {
             return new ClientOptions(
                 additionalClientTypeAnnotations,
@@ -673,7 +890,17 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
                 javaCompatibility,
                 modelMutable,
                 explicitApi,
-                nonPublicApi
+                nonPublicApi,
+                retryable,
+                retryableIncludes,
+                retryableExcludes,
+                retryableAttempts,
+                retryableDelay,
+                retryableMaxDelay,
+                retryableMultiplier,
+                retryableJitter,
+                retryablePredicate,
+                retryableCapturedException
             );
         }
     }
@@ -704,7 +931,17 @@ public class KotlinMicronautClientCodegen extends AbstractMicronautKotlinCodegen
         boolean javaCompatibility,
         boolean modelMutable,
         boolean explicitApi,
-        boolean nonPublicApi
+        boolean nonPublicApi,
+        boolean retryable,
+        List<String> retryableIncludes,
+        List<String> retryableExcludes,
+        int retryableAttempts,
+        String retryableDelay,
+        String retryableMaxDelay,
+        String retryableMultiplier,
+        String retryableJitter,
+        String retryablePredicate,
+        String retryableCapturedException
     ) {
     }
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautClientOptionsBuilder.java
@@ -264,4 +264,94 @@ public interface KotlinMicronautClientOptionsBuilder extends GeneratorOptionsBui
      * @return this builder
      */
     KotlinMicronautClientOptionsBuilder withNonPublicApi(boolean nonPublicApi);
+
+    /**
+     * Add or not @Retryable annotation to client interface. Default: false
+     *
+     * @param retryable if true, then @Retryable annotation will be added to client interface
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryable(boolean retryable);
+
+    /**
+     * Set includes parameter for Retryable annotation.
+     *
+     * @param retryableIncludes includes value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableIncludes(List<String> retryableIncludes);
+
+    /**
+     * Set excludes parameter for Retryable annotation.
+     *
+     * @param retryableExcludes excludes value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableExcludes(List<String> retryableExcludes);
+
+    /**
+     * Set attempts parameter for Retryable annotation.
+     *
+     * @param retryableAttempts attempts value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableAttempts(int retryableAttempts);
+
+    /**
+     * Set delay parameter for Retryable annotation.
+     *
+     * @param retryableDelay delay value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableDelay(String retryableDelay);
+
+    /**
+     * Set maxDelay parameter for Retryable annotation.
+     *
+     * @param retryableMaxDelay maxDelay value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableMaxDelay(String retryableMaxDelay);
+
+    /**
+     * Set multiplier parameter for Retryable annotation.
+     *
+     * @param retryableMultiplier multiplier value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableMultiplier(String retryableMultiplier);
+
+    /**
+     * Set jitter parameter for Retryable annotation.
+     *
+     * @param retryableJitter jitter value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableJitter(String retryableJitter);
+
+    /**
+     * Set predicate parameter for Retryable annotation.
+     *
+     * @param retryablePredicate predicate value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryablePredicate(String retryablePredicate);
+
+    /**
+     * Set capturedException parameter for Retryable annotation.
+     *
+     * @param retryableCapturedException capturedException value for Retryable annotation
+     *
+     * @return this builder
+     */
+    KotlinMicronautClientOptionsBuilder withRetryableCapturedException(String retryableCapturedException);
 }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -402,6 +402,17 @@ public final class MicronautCodeGeneratorEntryPoint {
             javaClientCodegen.setFluxForArrays(javaClientOptions.fluxForArrays());
             javaClientCodegen.setLombok(javaClientOptions.lombok());
             javaClientCodegen.setNoArgsConstructor(javaClientOptions.noArgsConstructor());
+
+            javaClientCodegen.setRetryable(javaClientOptions.retryable());
+            javaClientCodegen.setRetryableIncludes(javaClientOptions.retryableIncludes());
+            javaClientCodegen.setRetryableExcludes(javaClientOptions.retryableExcludes());
+            javaClientCodegen.setRetryableAttempts(javaClientOptions.retryableAttempts());
+            javaClientCodegen.setRetryableDelay(javaClientOptions.retryableDelay());
+            javaClientCodegen.setRetryableMaxDelay(javaClientOptions.retryableMaxDelay());
+            javaClientCodegen.setRetryableMultiplier(javaClientOptions.retryableMultiplier());
+            javaClientCodegen.setRetryableJitter(javaClientOptions.retryableJitter());
+            javaClientCodegen.setRetryablePredicate(javaClientOptions.retryablePredicate());
+            javaClientCodegen.setRetryableCapturedException(javaClientOptions.retryableCapturedException());
         }
     }
 
@@ -470,6 +481,17 @@ public final class MicronautCodeGeneratorEntryPoint {
             kotlinClientCodegen.setModelMutable(kotlinClientOptions.modelMutable());
             kotlinClientCodegen.setExplicitApi(kotlinClientOptions.explicitApi());
             kotlinClientCodegen.setNonPublicApi(kotlinClientOptions.nonPublicApi());
+
+            kotlinClientCodegen.setRetryable(kotlinClientOptions.retryable());
+            kotlinClientCodegen.setRetryableIncludes(kotlinClientOptions.retryableIncludes());
+            kotlinClientCodegen.setRetryableExcludes(kotlinClientOptions.retryableExcludes());
+            kotlinClientCodegen.setRetryableAttempts(kotlinClientOptions.retryableAttempts());
+            kotlinClientCodegen.setRetryableDelay(kotlinClientOptions.retryableDelay());
+            kotlinClientCodegen.setRetryableMaxDelay(kotlinClientOptions.retryableMaxDelay());
+            kotlinClientCodegen.setRetryableMultiplier(kotlinClientOptions.retryableMultiplier());
+            kotlinClientCodegen.setRetryableJitter(kotlinClientOptions.retryableJitter());
+            kotlinClientCodegen.setRetryablePredicate(kotlinClientOptions.retryablePredicate());
+            kotlinClientCodegen.setRetryableCapturedException(kotlinClientOptions.retryableCapturedException());
         }
     }
 

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
@@ -500,6 +500,14 @@ public final class Utils {
         return str.replace("$", "\\$");
     }
 
+    public static String normalizeJavaClass(String className) {
+        return className.endsWith(".class") ? className : className + ".class";
+    }
+
+    public static String normalizeKotlinClass(String className) {
+        return className.endsWith("::class") ? className : className + "::class";
+    }
+
     public static String toApiName(String name, String prefix, String suffix) {
         if (name.isEmpty()) {
             return "DefaultApi";
@@ -558,16 +566,25 @@ public final class Utils {
     }
 
     public static List<String> readListOfStringsProperty(String property, Map<String, Object> additionalProperties) {
+        return readListOfStringsProperty(property, additionalProperties, Collections.emptyList());
+    }
+
+    public static List<String> readListOfStringsProperty(String property, Map<String, Object> additionalProperties, List<String> defaultValue) {
         var value = additionalProperties.get(property);
         if (value == null) {
-            return Collections.emptyList();
+            additionalProperties.put(property, defaultValue);
+            return defaultValue;
         }
         return readListOfStringsProperty(value);
     }
 
     public static List<String> readListOfStringsProperty(Object value) {
+        return readListOfStringsProperty(value, Collections.emptyList());
+    }
+
+    public static List<String> readListOfStringsProperty(Object value, List<String> defaultValue) {
         if (value == null) {
-            return Collections.emptyList();
+            return defaultValue;
         }
         List<String> parsedValues;
         if (value instanceof Collection<?> valueCol) {
@@ -593,19 +610,47 @@ public final class Utils {
         return parsedValues;
     }
 
-    public static boolean readBooleanProperty(String propertyKey, Map<String, Object> additionalProperties, boolean defaultValue) {
-        var value = additionalProperties.get(propertyKey);
+    public static String readProperty(String property, Map<String, Object> additionalProperties, String defaultValue) {
+        var value = additionalProperties.get(property);
+        if (value == null) {
+            additionalProperties.put(property, defaultValue);
+            return defaultValue;
+        }
+        return value.toString();
+    }
+
+    public static boolean readBooleanProperty(String property, Map<String, Object> additionalProperties, boolean defaultValue) {
+        var value = additionalProperties.get(property);
+        if (value == null) {
+            additionalProperties.put(property, defaultValue);
+            return defaultValue;
+        }
         if (value instanceof Boolean boolValue) {
             return boolValue;
         } else if (value instanceof String strValue) {
+            return Boolean.parseBoolean(strValue);
+        }
+        LOG.warn("The value (generator's option {}) must be either boolean or string. Default to `{}`.", property, defaultValue);
+        return defaultValue;
+    }
+
+    public static int readIntProperty(String property, Map<String, Object> additionalProperties, int defaultValue) {
+        var value = additionalProperties.get(property);
+        if (value == null) {
+            additionalProperties.put(property, defaultValue);
+            return defaultValue;
+        }
+        if (value instanceof Integer intValue) {
+            return intValue;
+        } else if (value instanceof String strValue) {
             try {
-                return Boolean.parseBoolean(strValue);
+                return Integer.parseInt(strValue);
             } catch (NumberFormatException e) {
-                LOG.warn("Can't parse generator's option {}. Value: {}", propertyKey, value);
+                LOG.warn("Can't parse generator's option {}. Value: {}", property, value);
                 return defaultValue;
             }
         }
-        LOG.warn("The value (generator's option {}) must be either boolean or string. Default to `{}`.", propertyKey, defaultValue);
+        LOG.warn("The value (generator's option {}) must be either int or string. Default to `{}`.", property, defaultValue);
         return defaultValue;
     }
 

--- a/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/client/api.mustache
@@ -45,6 +45,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 {{#generatedAnnotation}}
 {{>common/generatedAnnotation}}
 {{/generatedAnnotation}}
+{{#retryableAnnotation}}
+{{{.}}}
+{{/retryableAnnotation}}
 @Client({{#configureClientId}}{{#clientPath}}id = {{/clientPath}}{{/configureClientId}}"{{#configureClientId}}{{clientId}}{{/configureClientId}}{{^configureClientId}}${{openbrace}}{{{applicationName}}}{{basePathSeparator}}base-path{{closebrace}}{{/configureClientId}}"{{#configureClientId}}{{#clientPath}}, path = "${{openbrace}}{{#configureClientId}}{{{clientId}}}{{/configureClientId}}{{^configureClientId}}{{{applicationName}}}{{/configureClientId}}{{basePathSeparator}}base-path{{closebrace}}"{{/clientPath}}{{/configureClientId}})
 public interface {{classname}} {
 {{#operations}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/client/api.mustache
@@ -41,6 +41,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 {{#generatedAnnotation}}
 {{>common/generatedAnnotation}}
 {{/generatedAnnotation}}
+{{#retryableAnnotation}}
+{{{.}}}
+{{/retryableAnnotation}}
 @Client({{#configureClientId}}{{#clientPath}}id = {{/clientPath}}{{/configureClientId}}"{{#configureClientId}}{{{clientIdNormalized}}}{{/configureClientId}}{{^configureClientId}}\${{openbrace}}{{{applicationName}}}{{basePathSeparator}}base-path{{closebrace}}{{/configureClientId}}"{{#configureClientId}}{{#clientPath}}, path = "\${{openbrace}}{{#configureClientId}}{{{clientIdNormalized}}}{{/configureClientId}}{{^configureClientId}}{{{appNameNormalized}}}{{/configureClientId}}{{basePathSeparator}}base-path{{closebrace}}"{{/clientPath}}{{/configureClientId}})
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}interface {{classname}} {
 {{#operations}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -2431,4 +2431,79 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             }
         """);
     }
+
+    @Test
+    void testRetryable() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.retryable = true;
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/java/org/openapitools/";
+        assertFileContains(path + "api/PetApi.java", """
+            @Retryable
+            @Client("${openapi-micronaut-client.base-path}")
+            """,
+            "import io.micronaut.retry.annotation.Retryable;");
+    }
+
+    @Test
+    void testRetryableAll() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.retryable = true;
+        codegen.retryableIncludes = List.of("java.lang.IllegalAccessException", "java.lang.RuntimeException.class");
+        codegen.retryableExcludes = List.of("java.lang.IllegalAccessException", "java.lang.RuntimeException.class");
+        codegen.retryableAttempts = 10;
+        codegen.retryableDelay = "10s";
+        codegen.retryableMaxDelay = "100s";
+        codegen.retryableMultiplier = "2.32";
+        codegen.retryableJitter = "5.43";
+        codegen.retryablePredicate = "io.micronaut.retry.annotation.DefaultRetryPredicate";
+        codegen.retryableCapturedException = "Exception";
+
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/java/org/openapitools/";
+        assertFileContains(path + "api/PetApi.java", """
+            @Retryable(
+                includes = {java.lang.IllegalAccessException.class, java.lang.RuntimeException.class},
+                excludes = {java.lang.IllegalAccessException.class, java.lang.RuntimeException.class},
+                attempts = "10",
+                delay = "10s",
+                maxDelay = "100s",
+                multiplier = "2.32",
+                jitter = "5.43",
+                predicate = io.micronaut.retry.annotation.DefaultRetryPredicate.class,
+                capturedException = Exception.class
+            )
+            @Client("${openapi-micronaut-client.base-path}")
+            """);
+    }
+
+    @Test
+    void testRetryableNotAll() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.retryable = true;
+        codegen.retryableAttempts = 10;
+        codegen.retryableDelay = "10s";
+        codegen.retryableMaxDelay = "100s";
+        codegen.retryableMultiplier = "2.32";
+        codegen.retryablePredicate = "io.micronaut.retry.annotation.DefaultRetryPredicate";
+
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/java/org/openapitools/";
+        assertFileContains(path + "api/PetApi.java", """
+            @Retryable(
+                attempts = "10",
+                delay = "10s",
+                maxDelay = "100s",
+                multiplier = "2.32",
+                predicate = io.micronaut.retry.annotation.DefaultRetryPredicate.class
+            )
+            @Client("${openapi-micronaut-client.base-path}")
+            """);
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -2950,4 +2950,79 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
             ) : ObjectSort(o, ascending) {
             """);
     }
+
+    @Test
+    void testRetryable() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.retryable = true;
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/PetApi.kt", """
+            @Retryable
+            @Client("\\${openapi-micronaut-client.base-path}")
+            """,
+            "import io.micronaut.retry.annotation.Retryable");
+    }
+
+    @Test
+    void testRetryableAll() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.retryable = true;
+        codegen.retryableIncludes = List.of("java.lang.IllegalAccessException", "java.lang.RuntimeException::class");
+        codegen.retryableExcludes = List.of("java.lang.IllegalAccessException", "java.lang.RuntimeException::class");
+        codegen.retryableAttempts = 10;
+        codegen.retryableDelay = "10s";
+        codegen.retryableMaxDelay = "100s";
+        codegen.retryableMultiplier = "2.32";
+        codegen.retryableJitter = "5.43";
+        codegen.retryablePredicate = "io.micronaut.retry.annotation.DefaultRetryPredicate";
+        codegen.retryableCapturedException = "Exception";
+
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/PetApi.kt", """
+            @Retryable(
+                java.lang.IllegalAccessException::class, java.lang.RuntimeException::class,
+                excludes = [java.lang.IllegalAccessException::class, java.lang.RuntimeException::class],
+                attempts = "10",
+                delay = "10s",
+                maxDelay = "100s",
+                multiplier = "2.32",
+                jitter = "5.43",
+                predicate = io.micronaut.retry.annotation.DefaultRetryPredicate::class,
+                capturedException = Exception::class,
+            )
+            @Client("\\${openapi-micronaut-client.base-path}")
+            """);
+    }
+
+    @Test
+    void testRetryableNotAll() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.retryable = true;
+        codegen.retryableAttempts = 10;
+        codegen.retryableDelay = "10s";
+        codegen.retryableMaxDelay = "100s";
+        codegen.retryableMultiplier = "2.32";
+        codegen.retryablePredicate = "io.micronaut.retry.annotation.DefaultRetryPredicate";
+
+        String outputPathApi = generateFiles(codegen, PETSTORE_PATH);
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/PetApi.kt", """
+            @Retryable(
+                attempts = "10",
+                delay = "10s",
+                maxDelay = "100s",
+                multiplier = "2.32",
+                predicate = io.micronaut.retry.annotation.DefaultRetryPredicate::class,
+            )
+            @Client("\\${openapi-micronaut-client.base-path}")
+            """);
+    }
 }


### PR DESCRIPTION
New properties:
```java
retryable - Add or not @Retryable annotation to client interface. Default: false
retryableIncludes - Set includes parameter for Retryable annotation.
retryableExcludes - Set excludes parameter for Retryable annotation.
retryableAttempts - Set attempts parameter for Retryable annotation.
retryableDelay - Set delay parameter for Retryable annotation.
retryableMaxDelay - Set maxDelay parameter for Retryable annotation.
retryableMultiplier - Set multiplier parameter for Retryable annotation.
retryableJitter - Set jitter parameter for Retryable annotation.
retryablePredicate - Set predicate parameter for Retryable annotation.
retryableCapturedException - Set capturedException parameter for Retryable annotation.
```

Fixed #2471