### PR TITLE
Improved wrapping in HttpResponse. Added `@Status` annotation to generated controllers

### DIFF
--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautJavaCodegen.java
@@ -81,6 +81,23 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_CLASS;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_FIELD;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_OPERATION;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_SETTER;
+import static io.micronaut.openapi.generator.Extension.EXT_DEPRECATED;
+import static io.micronaut.openapi.generator.Extension.EXT_DEPRECATED_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_DEPRECATED_MESSAGES;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_DESCRIPTIONS;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_VAR_NAMES;
+import static io.micronaut.openapi.generator.Extension.EXT_FORMAT;
+import static io.micronaut.openapi.generator.Extension.EXT_HTTP_RESPONSE_WRAPPER;
+import static io.micronaut.openapi.generator.Extension.EXT_TYPE;
+import static io.micronaut.openapi.generator.MicronautUtils.FLUX_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.HTTP_STATUS_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.MONO_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.STATUS_ANNOTATION_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.httpStatusConstName;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_INT16;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_INT8;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_LONG;
@@ -95,10 +112,6 @@ import static io.micronaut.openapi.generator.MnSchemaTypeUtil.TYPE_LONG;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.TYPE_SHORT;
 import static io.micronaut.openapi.generator.Utils.DEFAULT_BODY_PARAM_NAME;
 import static io.micronaut.openapi.generator.Utils.DIVIDE_OPERATIONS_BY_CONTENT_TYPE;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_CLASS;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_FIELD;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_OPERATION;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_SETTER;
 import static io.micronaut.openapi.generator.Utils.NULL_STRING;
 import static io.micronaut.openapi.generator.Utils.addEnumParamsForConverters;
 import static io.micronaut.openapi.generator.Utils.addStrValueToEnum;
@@ -156,6 +169,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
     public static final String OPT_GENERATE_HTTP_RESPONSE_ALWAYS = "generateHttpResponseAlways";
     public static final String OPT_GENERATE_CONTROLLER_AS_ABSTRACT = "generateControllerAsAbstract";
     public static final String OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED = "generateHttpResponseWhereRequired";
+    public static final String OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES = "generateHttpResponseOnlyForMultipleStatuses";
     public static final String OPT_APPLICATION_NAME = "applicationName";
     public static final String OPT_GENERATE_SWAGGER_ANNOTATIONS = "generateSwaggerAnnotations";
     public static final String OPT_GENERATE_SWAGGER_ANNOTATIONS_SWAGGER_1 = "swagger1";
@@ -169,9 +183,6 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
     public static final String CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data";
     public static final String CONTENT_TYPE_ANY = "*/*";
-
-    private static final String MONO_CLASS_NAME = "reactor.core.publisher.Mono";
-    private static final String FLUX_CLASS_NAME = "reactor.core.publisher.Flux";
 
     protected SecureRandom random = new SecureRandom();
     protected String title;
@@ -191,6 +202,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
     protected boolean useEnumCaseInsensitive;
     protected boolean generateHttpResponseAlways;
     protected boolean generateHttpResponseWhereRequired = true;
+    protected boolean generateHttpResponseOnlyForMultipleStatuses;
     protected boolean generateControllerAsAbstract;
     protected boolean jsonIncludeAlwaysForRequiredFields;
     protected String appName;
@@ -302,6 +314,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_ALWAYS, "Always wrap the operations response in HttpResponse object", generateHttpResponseAlways));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_CONTROLLER_AS_ABSTRACT, "If true, then controller interface will be without @Controller annotation", generateControllerAsAbstract));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED, "Wrap the operations response in HttpResponse object where non-200 HTTP status codes or additional headers are defined", generateHttpResponseWhereRequired));
+        cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES, "Wrap the operations response in HttpResponse object where possible multiple HTTP status codes or additional headers are defined", generateHttpResponseOnlyForMultipleStatuses));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_OPERATION_ONLY_FOR_FIRST_TAG, "When false, the operation method will be duplicated in each of the tags if multiple tags are assigned to this operation. " +
             "If true, each operation will be generated only once in the first assigned tag.", generateOperationOnlyForFirstTag));
         cliOptions.add(CliOption.newBoolean(OPT_USE_ENUM_CASE_INSENSITIVE, "Use `equalsIgnoreCase` when String for enum comparison", useEnumCaseInsensitive));
@@ -383,6 +396,10 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
 
     public void setGenerateHttpResponseWhereRequired(boolean generateHttpResponseWhereRequired) {
         this.generateHttpResponseWhereRequired = generateHttpResponseWhereRequired;
+    }
+
+    public void setGenerateHttpResponseOnlyForMultipleStatuses(boolean generateHttpResponseOnlyForMultipleStatuses) {
+        this.generateHttpResponseOnlyForMultipleStatuses = generateHttpResponseOnlyForMultipleStatuses;
     }
 
     public void setReactive(boolean reactive) {
@@ -625,6 +642,11 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             generateHttpResponseWhereRequired = convertPropertyToBoolean(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED);
         }
         writePropertyBack(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED, generateHttpResponseWhereRequired);
+
+        if (additionalProperties.containsKey(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES)) {
+            generateHttpResponseOnlyForMultipleStatuses = convertPropertyToBoolean(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES);
+        }
+        writePropertyBack(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES, generateHttpResponseOnlyForMultipleStatuses);
 
         if (additionalProperties.containsKey(OPT_GENERATE_CONTROLLER_AS_ABSTRACT)) {
             generateControllerAsAbstract = convertPropertyToBoolean(OPT_GENERATE_CONTROLLER_AS_ABSTRACT);
@@ -1620,7 +1642,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
                 if (param.isEnumRef) {
                     param.isEnum = true;
                 }
-                processGenericAnnotations(param, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false);
+                processGenericAnnotations(param, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false, null);
                 if (useBeanValidation && !param.isContainer && param.isModel) {
                     param.vendorExtensions.put("withValid", true);
                 }
@@ -1647,17 +1669,17 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
                 }
             }
             if (op.returnProperty != null) {
-                processGenericAnnotations(op.returnProperty, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false);
+                processGenericAnnotations(op.returnProperty, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false, null);
                 op.returnType = op.returnProperty.vendorExtensions.get("typeWithEnumWithGenericAnnotations").toString();
             }
 
-            var deprecatedMessage = op.vendorExtensions.get("x-deprecated-message");
-            var xDeprecated = op.vendorExtensions.get("x-deprecated");
+            var deprecatedMessage = op.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+            var xDeprecated = op.vendorExtensions.get(EXT_DEPRECATED);
             if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
                 deprecatedMessage = xDeprecatedStr;
             }
             if (deprecatedMessage != null) {
-                op.vendorExtensions.put("x-deprecated-message", deprecatedMessage.toString());
+                op.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, deprecatedMessage.toString());
             }
         }
 
@@ -1708,11 +1730,11 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         var isDouble = model != null ? model.isDouble : param != null ? param.isDouble : prop != null ? prop.isDouble : response.isDouble;
 
         var extensions = schema.getExtensions();
-        var format = extensions != null ? (String) extensions.get("x-format") : null;
+        var format = extensions != null ? (String) extensions.get(EXT_FORMAT) : null;
         if (format == null) {
             format = schema.getFormat() == null ? "object" : schema.getFormat();
         }
-        var schemaType = extensions != null ? (String) extensions.get("x-type") : null;
+        var schemaType = extensions != null ? (String) extensions.get(EXT_TYPE) : null;
         if (schemaType == null) {
             schemaType = schema.getType() == null ? "object" : schema.getType();
         }
@@ -1799,11 +1821,11 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         }
 
         if (isEnum) {
-            var enumSchemaType = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get("x-type") : null;
+            var enumSchemaType = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get(EXT_TYPE) : null;
             if (enumSchemaType == null) {
                 enumSchemaType = enumSchema.getType();
             }
-            var enumSchemaFormat = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get("x-format") : null;
+            var enumSchemaFormat = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get(EXT_FORMAT) : null;
             if (enumSchemaFormat == null) {
                 enumSchemaFormat = enumSchema.getFormat();
             }
@@ -2110,7 +2132,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
      * @param isListWrapper Whether the wrapper should be around list items.
      */
     private void wrapOperationReturnType(CodegenOperation op, String wrapperType, boolean isValidated, boolean isListWrapper) {
-        CodegenProperty newReturnType = new CodegenProperty();
+        var newReturnType = new CodegenProperty();
         newReturnType.required = true;
         newReturnType.isModel = isValidated;
 
@@ -2147,12 +2169,29 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
     }
 
     private void processOperationWithResponseWrappers(CodegenOperation op) {
-        boolean hasNon200StatusCodes = op.responses.stream().anyMatch(
-            response -> !"200".equals(response.code) && response.code.startsWith("2")
-        );
+
+        var notDefaultRsCode = false;
+        var successResponsesCount = 0;
+        for (var rs : op.responses) {
+            if (rs.code.startsWith("2")) {
+                if (!"200".equals(rs.code)) {
+                    notDefaultRsCode = true;
+                }
+                successResponsesCount++;
+            }
+        }
+
         boolean hasNonMappedHeaders = !op.responseHeaders.isEmpty();
-        boolean requiresHttpResponse = hasNon200StatusCodes || hasNonMappedHeaders;
-        if (generateHttpResponseAlways || (generateHttpResponseWhereRequired && requiresHttpResponse)) {
+        boolean requiresHttpResponse = (notDefaultRsCode && (!generateHttpResponseOnlyForMultipleStatuses || successResponsesCount > 1))
+            || hasNonMappedHeaders;
+        if (generateHttpResponseOnlyForMultipleStatuses && successResponsesCount == 1 && notDefaultRsCode && !hasNonMappedHeaders) {
+            var httpStatusStr = httpStatusConstName(op.responses.get(0).code);
+            op.vendorExtensions.put("statusAnnotation", "@Status(HttpStatus." + httpStatusStr + ")");
+            makeSureImported(HTTP_STATUS_CLASS_NAME, op.imports);
+            makeSureImported(STATUS_ANNOTATION_CLASS_NAME, op.imports);
+        }
+        var withHttpResponseWrapper = (Boolean) op.vendorExtensions.get(EXT_HTTP_RESPONSE_WRAPPER);
+        if ((withHttpResponseWrapper == null && (generateHttpResponseAlways || generateHttpResponseWhereRequired && requiresHttpResponse)) || (withHttpResponseWrapper != null && withHttpResponseWrapper)) {
             wrapOperationReturnType(op, "io.micronaut.http.HttpResponse", false, false);
         }
 
@@ -2314,13 +2353,13 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             }
             model.allVars = allVars;
 
-            var deprecatedMessage = model.vendorExtensions.get("x-deprecated-message");
-            var xDeprecated = model.vendorExtensions.get("x-deprecated");
+            var deprecatedMessage = model.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+            var xDeprecated = model.vendorExtensions.get(EXT_DEPRECATED);
             if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
                 deprecatedMessage = xDeprecatedStr;
             }
             if (deprecatedMessage != null) {
-                model.vendorExtensions.put("x-deprecated-message", deprecatedMessage.toString());
+                model.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, deprecatedMessage.toString());
             }
 
             model.vendorExtensions.put("requiredVars", requiredVars);
@@ -2417,10 +2456,10 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             return;
         }
 
-        processEnumExt(enumVars, vendorExtensions, "enumDescription", List.of("x-enum-descriptions", "x-xl4-enum-doc"));
-        processEnumExt(enumVars, vendorExtensions, "enumDeprecatedMessage", List.of("x-enum-deprecated-messages", "x-xl4-enum-deprecated"));
+        processEnumExt(enumVars, vendorExtensions, "enumDescription", List.of(EXT_ENUM_DESCRIPTIONS, "x-xl4-enum-doc"));
+        processEnumExt(enumVars, vendorExtensions, "enumDeprecatedMessage", List.of(EXT_ENUM_DEPRECATED_MESSAGES, "x-xl4-enum-deprecated"));
 
-        var deprecatedExt = vendorExtensions.get("x-deprecated");
+        var deprecatedExt = vendorExtensions.get(EXT_DEPRECATED);
         List<?> xDeprecated = null;
         Map<?, ?> xDeprecatedMap = null;
         if (deprecatedExt instanceof List<?> deprecatedList) {
@@ -2429,7 +2468,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             xDeprecated = new ArrayList<>(deprecatedMap.keySet());
             xDeprecatedMap = deprecatedMap;
         }
-        var deprecatedMessagesExt = vendorExtensions.get("x-enum-deprecated-messages");
+        var deprecatedMessagesExt = vendorExtensions.get(EXT_ENUM_DEPRECATED_MESSAGES);
         if (deprecatedMessagesExt == null) {
             deprecatedMessagesExt = vendorExtensions.get("x-xl4-enum-deprecated");
         }
@@ -2453,7 +2492,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             }
         }
 
-        processEnumExt(enumVars, vendorExtensions, "name", List.of("x-enum-varnames"));
+        processEnumExt(enumVars, vendorExtensions, "name", List.of(EXT_ENUM_VAR_NAMES));
 
         var baseType = (String) vendorExtensions.get("baseType");
         for (var enumVar : enumVars) {
@@ -2569,18 +2608,18 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
         prop.dataType = discriminator.getPropertyType();
         prop.datatypeWithEnum = discriminator.getPropertyType();
         prop.baseType = discriminator.getPropertyType();
-        processGenericAnnotations(prop, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false);
+        processGenericAnnotations(prop, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false, null);
     }
 
     private void processProperty(CodegenProperty property, boolean isServer, CodegenModel model, Map<String, ModelsMap> models) {
 
-        var deprecatedMessage = property.vendorExtensions.get("x-deprecated-message");
-        var xDeprecated = property.vendorExtensions.get("x-deprecated");
+        var deprecatedMessage = property.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+        var xDeprecated = property.vendorExtensions.get(EXT_DEPRECATED);
         if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
             deprecatedMessage = xDeprecatedStr;
         }
         if (deprecatedMessage != null) {
-            property.vendorExtensions.put("x-deprecated-message", deprecatedMessage.toString());
+            property.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, deprecatedMessage.toString());
         }
 
         property.vendorExtensions.put("inRequiredArgsConstructor", !property.isReadOnly || isServer);
@@ -2607,7 +2646,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             property.maxLength = null;
         }
 
-        processGenericAnnotations(property, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false);
+        processGenericAnnotations(property, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false, null);
 
         normalizeExtraAnnotations(EXT_ANNOTATIONS_FIELD, false, property.vendorExtensions);
         normalizeExtraAnnotations(EXT_ANNOTATIONS_SETTER, false, property.vendorExtensions);
@@ -2641,7 +2680,7 @@ public abstract class AbstractMicronautJavaCodegen<T extends GeneratorOptionsBui
             var parentVars = new ArrayList<CodegenProperty>();
             for (var v : parent.allVars) {
                 if (notContainsProp(v, model.vars)) {
-                    processGenericAnnotations(v, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false);
+                    processGenericAnnotations(v, useBeanValidation, isGenerateHardNullable(), false, false, false, false, false, false, null);
                     parentVars.add(v);
                 }
             }

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/AbstractMicronautKotlinCodegen.java
@@ -90,6 +90,30 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_CLASS;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_FIELD;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_OPERATION;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_SETTER;
+import static io.micronaut.openapi.generator.Extension.EXT_DEPRECATED;
+import static io.micronaut.openapi.generator.Extension.EXT_DEPRECATED_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_DEPRECATED_MESSAGES;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_DESCRIPTIONS;
+import static io.micronaut.openapi.generator.Extension.EXT_ENUM_VAR_NAMES;
+import static io.micronaut.openapi.generator.Extension.EXT_FORMAT;
+import static io.micronaut.openapi.generator.Extension.EXT_HTTP_RESPONSE_WRAPPER;
+import static io.micronaut.openapi.generator.Extension.EXT_MAXIMUM_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_MINIMUM_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_NOT_NULL;
+import static io.micronaut.openapi.generator.Extension.EXT_NOT_NULL_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_PATTERN_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_ROLES;
+import static io.micronaut.openapi.generator.Extension.EXT_SIZE_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_TYPE;
+import static io.micronaut.openapi.generator.MicronautUtils.FLUX_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.HTTP_STATUS_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.MONO_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.STATUS_ANNOTATION_CLASS_NAME;
+import static io.micronaut.openapi.generator.MicronautUtils.httpStatusConstName;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_INT16;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_INT8;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.FORMAT_LONG;
@@ -104,10 +128,6 @@ import static io.micronaut.openapi.generator.MnSchemaTypeUtil.TYPE_LONG;
 import static io.micronaut.openapi.generator.MnSchemaTypeUtil.TYPE_SHORT;
 import static io.micronaut.openapi.generator.Utils.DEFAULT_BODY_PARAM_NAME;
 import static io.micronaut.openapi.generator.Utils.DIVIDE_OPERATIONS_BY_CONTENT_TYPE;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_CLASS;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_FIELD;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_OPERATION;
-import static io.micronaut.openapi.generator.Utils.EXT_ANNOTATIONS_SETTER;
 import static io.micronaut.openapi.generator.Utils.NULL_STRING;
 import static io.micronaut.openapi.generator.Utils.addEnumParamsForConverters;
 import static io.micronaut.openapi.generator.Utils.addStrValueToEnum;
@@ -168,6 +188,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     public static final String OPT_GENERATE_HTTP_RESPONSE_ALWAYS = "generateHttpResponseAlways";
     public static final String OPT_GENERATE_CONTROLLER_AS_ABSTRACT = "generateControllerAsAbstract";
     public static final String OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED = "generateHttpResponseWhereRequired";
+    public static final String OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES = "generateHttpResponseOnlyForMultipleStatuses";
     public static final String OPT_APPLICATION_NAME = "applicationName";
     public static final String OPT_GENERATE_SWAGGER_ANNOTATIONS = "generateSwaggerAnnotations";
     public static final String OPT_GENERATE_SWAGGER_ANNOTATIONS_SWAGGER_2 = "swagger2";
@@ -187,9 +208,6 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     public static final String CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data";
     public static final String CONTENT_TYPE_ANY = "*/*";
 
-    private static final String MONO_CLASS_NAME = "reactor.core.publisher.Mono";
-    private static final String FLUX_CLASS_NAME = "reactor.core.publisher.Flux";
-
     protected ObjectMapper objectMapper = ObjectMapperFactory.createJson();
     protected SecureRandom random = new SecureRandom();
     protected String dateLibrary;
@@ -207,6 +225,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     protected boolean coroutines;
     protected boolean generateHttpResponseAlways;
     protected boolean generateHttpResponseWhereRequired = true;
+    protected boolean generateHttpResponseOnlyForMultipleStatuses;
     protected boolean generateControllerAsAbstract;
     protected boolean useEnumCaseInsensitive;
     protected boolean ksp;
@@ -363,6 +382,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_ALWAYS, "Always wrap the operations response in HttpResponse object", generateHttpResponseAlways));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_CONTROLLER_AS_ABSTRACT, "If true, then controller interface will be without @Controller annotation", generateControllerAsAbstract));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED, "Wrap the operations response in HttpResponse object where non-200 HTTP status codes or additional headers are defined", generateHttpResponseWhereRequired));
+        cliOptions.add(CliOption.newBoolean(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES, "Wrap the operations response in HttpResponse object where possible multiple HTTP status codes or additional headers are defined", generateHttpResponseOnlyForMultipleStatuses));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, isHideGenerationTimestamp()));
         cliOptions.add(CliOption.newBoolean(OPT_GENERATE_OPERATION_ONLY_FOR_FIRST_TAG, "When false, the operation method will be duplicated in each of the tags if multiple tags are assigned to this operation. " +
             "If true, each operation will be generated only once in the first assigned tag.", generateOperationOnlyForFirstTag));
@@ -482,6 +502,10 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
 
     public void setGenerateHttpResponseWhereRequired(boolean generateHttpResponseWhereRequired) {
         this.generateHttpResponseWhereRequired = generateHttpResponseWhereRequired;
+    }
+
+    public void setGenerateHttpResponseOnlyForMultipleStatuses(boolean generateHttpResponseOnlyForMultipleStatuses) {
+        this.generateHttpResponseOnlyForMultipleStatuses = generateHttpResponseOnlyForMultipleStatuses;
     }
 
     public void setGenerateControllerAsAbstract(boolean generateControllerAsAbstract) {
@@ -746,6 +770,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             generateHttpResponseWhereRequired = convertPropertyToBoolean(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED);
         }
         writePropertyBack(OPT_GENERATE_HTTP_RESPONSE_WHERE_REQUIRED, generateHttpResponseWhereRequired);
+
+        if (additionalProperties.containsKey(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES)) {
+            generateHttpResponseOnlyForMultipleStatuses = convertPropertyToBoolean(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES);
+        }
+        writePropertyBack(OPT_GENERATE_HTTP_RESPONSE_ONLY_FOR_MULTIPLE_STATUSES, generateHttpResponseOnlyForMultipleStatuses);
 
         if (additionalProperties.containsKey(OPT_GENERATE_CONTROLLER_AS_ABSTRACT)) {
             generateControllerAsAbstract = convertPropertyToBoolean(OPT_GENERATE_CONTROLLER_AS_ABSTRACT);
@@ -1304,7 +1333,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                     param.isEnum = true;
                 }
                 processGenericAnnotations(param, useBeanValidation, false, param.isNullable || !param.required,
-                    param.required, false, true, true, ksp);
+                    param.required, false, true, true, ksp, null);
                 param.vendorExtensions.put("isString", "string".equalsIgnoreCase(param.dataType));
                 param.vendorExtensions.put("withoutExample", param.example == null || param.example.equals(NULL_STRING));
                 if (useBeanValidation && ((!param.isContainer && param.isModel)
@@ -1340,7 +1369,14 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             additionalProperties.put("enumParams", enumParams);
 
             if (op.returnProperty != null) {
-                processGenericAnnotations(op.returnProperty, useBeanValidation, false, false, false, false, false, true, ksp);
+                var isNotNull = (Boolean) op.vendorExtensions.get(EXT_NOT_NULL);
+                var wrapped = (Boolean) op.returnProperty.vendorExtensions.get("wrapped");
+                var isNullable = op.returnProperty.isNullable;
+                if (wrapped != null && wrapped) {
+                    isNotNull = true;
+                    isNullable = false;
+                }
+                processGenericAnnotations(op.returnProperty, useBeanValidation, false, isNullable, false, false, true, true, ksp, isNotNull);
                 op.returnType = op.returnProperty.vendorExtensions.get("typeWithEnumWithGenericAnnotations").toString();
             }
 
@@ -1356,18 +1392,18 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
 
     private void normalizeTextsInOperation(CodegenOperation op) {
 
-        var deprecatedMessage = op.vendorExtensions.get("x-deprecated-message");
-        var xDeprecated = op.vendorExtensions.get("x-deprecated");
+        var deprecatedMessage = op.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+        var xDeprecated = op.vendorExtensions.get(EXT_DEPRECATED);
         if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
             deprecatedMessage = xDeprecatedStr;
-            op.vendorExtensions.put("x-deprecated-message", xDeprecatedStr);
+            op.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, xDeprecatedStr);
         }
         if (deprecatedMessage != null) {
             op.vendorExtensions.put("x-deprecated-message-normalized", normalizeStr(deprecatedMessage.toString()));
         }
 
-        if (op.vendorExtensions.containsKey("x-roles")) {
-            var roles = (List<String>) op.vendorExtensions.get("x-roles");
+        if (op.vendorExtensions.containsKey(EXT_ROLES)) {
+            var roles = (List<String>) op.vendorExtensions.get(EXT_ROLES);
             var normalizedRoles = new ArrayList<String>(roles.size());
             for (var role : roles) {
                 normalizedRoles.add(normalizeStr(role));
@@ -1425,11 +1461,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 if (param.defaultValue != null) {
                     param.vendorExtensions.put("defaultValueNormalized", normalizeStr(param.defaultValue));
                 }
-                normalizeStrValue("x-pattern-message", param.vendorExtensions);
-                normalizeStrValue("x-size-message", param.vendorExtensions);
-                normalizeStrValue("x-not-null-message", param.vendorExtensions);
-                normalizeStrValue("x-minimum-message", param.vendorExtensions);
-                normalizeStrValue("x-maximum-message", param.vendorExtensions);
+                normalizeStrValue(EXT_PATTERN_MESSAGE, param.vendorExtensions);
+                normalizeStrValue(EXT_SIZE_MESSAGE, param.vendorExtensions);
+                normalizeStrValue(EXT_NOT_NULL_MESSAGE, param.vendorExtensions);
+                normalizeStrValue(EXT_MINIMUM_MESSAGE, param.vendorExtensions);
+                normalizeStrValue(EXT_MAXIMUM_MESSAGE, param.vendorExtensions);
             }
         }
     }
@@ -1520,11 +1556,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         var isDouble = model != null ? model.isDouble : param != null ? param.isDouble : prop != null ? prop.isDouble : response.isDouble;
 
         var extensions = schema.getExtensions();
-        var format = extensions != null ? extensions.get("x-format") : null;
+        var format = extensions != null ? extensions.get(EXT_FORMAT) : null;
         if (format == null) {
             format = schema.getFormat() == null ? "object" : schema.getFormat();
         }
-        var schemaType = extensions != null ? extensions.get("x-type") : null;
+        var schemaType = extensions != null ? extensions.get(EXT_TYPE) : null;
         if (schemaType == null) {
             schemaType = schema.getType() == null ? "object" : schema.getType();
         }
@@ -1603,11 +1639,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         }
 
         if (isEnum) {
-            var enumSchemaType = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get("x-type") : null;
+            var enumSchemaType = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get(EXT_TYPE) : null;
             if (enumSchemaType == null) {
                 enumSchemaType = enumSchema.getType();
             }
-            var enumSchemaFormat = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get("x-format") : null;
+            var enumSchemaFormat = enumSchema.getExtensions() != null ? (String) enumSchema.getExtensions().get(EXT_FORMAT) : null;
             if (enumSchemaFormat == null) {
                 enumSchemaFormat = enumSchema.getFormat();
             }
@@ -1742,6 +1778,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
      * Output the type declaration of the property.
      *
      * @param p OpenAPI Property object
+     *
      * @return a string presentation of the property type
      */
     @Override
@@ -2250,7 +2287,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         }
 
         if (bodyMapping != null) {
-            wrapOperationReturnType(op, bodyMapping.mappedBodyType(), bodyMapping.isValidated(), bodyMapping.isListWrapper());
+            wrapOperationReturnType(op, bodyMapping.mappedBodyType(), bodyMapping.isValidated(), bodyMapping.isListWrapper(), false);
         }
     }
 
@@ -2262,10 +2299,39 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
      * @param isValidated Whether the wrapper requires validation.
      * @param isListWrapper Whether the wrapper should be around list items.
      */
-    private void wrapOperationReturnType(CodegenOperation op, String wrapperType, boolean isValidated, boolean isListWrapper) {
-        CodegenProperty newReturnType = new CodegenProperty();
+    private void wrapOperationReturnType(CodegenOperation op, String wrapperType, boolean isValidated, boolean isListWrapper, boolean alreadyWrapped) {
+        var newReturnType = new CodegenProperty();
         newReturnType.required = true;
         newReturnType.isModel = isValidated;
+        newReturnType.vendorExtensions.put("wrapped", true);
+
+        if (!alreadyWrapped) {
+            var isNotNull = (Boolean) op.vendorExtensions.get(EXT_NOT_NULL);
+            if (isNotNull != null) {
+                if (isNotNull) {
+                    if (op.returnBaseType.endsWith("?")) {
+                        op.returnBaseType = op.returnBaseType.substring(0, op.returnBaseType.length() - 1);
+                    }
+                    if (op.returnType != null && op.returnType.endsWith("?")) {
+                        op.returnType = op.returnType.substring(0, op.returnType.length() - 1);
+                    }
+                } else {
+                    if (!op.returnBaseType.endsWith("?")) {
+                        op.returnBaseType = op.returnBaseType + "?";
+                    }
+                    if (op.returnType != null && !op.returnType.endsWith("?")) {
+                        op.returnType = op.returnType + "?";
+                    }
+                }
+            } else if (op.returnProperty != null && op.returnProperty.isNullable) {
+                if (!op.returnBaseType.endsWith("?")) {
+                    op.returnBaseType = op.returnBaseType + "?";
+                }
+                if (op.returnType != null && !op.returnType.endsWith("?")) {
+                    op.returnType = op.returnType + "?";
+                }
+            }
+        }
 
         String typeName = makeSureImported(wrapperType, op.imports);
 
@@ -2276,6 +2342,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 op.vendorExtensions.put("isReturnFlux", true);
             }
             originalReturnType = op.returnBaseType;
+            newReturnType.isNullable = op.returnProperty.isNullable;
             newReturnType.dataType = typeName + '<' + op.returnBaseType + '>';
             newReturnType.items = op.returnProperty.items;
         } else {
@@ -2285,6 +2352,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 op.returnProperty = new CodegenProperty();
                 op.returnProperty.dataType = "Void";
             }
+            newReturnType.isNullable = op.returnProperty.isNullable;
             newReturnType.dataType = typeName + '<' + originalReturnType + '>';
             newReturnType.items = op.returnProperty;
         }
@@ -2296,17 +2364,36 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
     }
 
     private void processOperationWithResponseWrappers(CodegenOperation op) {
-        boolean hasNon200StatusCodes = op.responses.stream().anyMatch(
-            response -> !"200".equals(response.code) && response.code.startsWith("2")
-        );
+
+        var notDefaultRsCode = false;
+        var successResponsesCount = 0;
+        for (var rs : op.responses) {
+            if (rs.code.startsWith("2")) {
+                if (!"200".equals(rs.code)) {
+                    notDefaultRsCode = true;
+                }
+                successResponsesCount++;
+            }
+        }
+
         boolean hasNonMappedHeaders = !op.responseHeaders.isEmpty();
-        boolean requiresHttpResponse = hasNon200StatusCodes || hasNonMappedHeaders;
-        if (generateHttpResponseAlways || (generateHttpResponseWhereRequired && requiresHttpResponse)) {
-            wrapOperationReturnType(op, "io.micronaut.http.HttpResponse", false, false);
+        boolean requiresHttpResponse = (notDefaultRsCode && (!generateHttpResponseOnlyForMultipleStatuses || successResponsesCount > 1))
+            || hasNonMappedHeaders;
+        if (generateHttpResponseOnlyForMultipleStatuses && successResponsesCount == 1 && notDefaultRsCode && !hasNonMappedHeaders) {
+            var httpStatusStr = httpStatusConstName(op.responses.get(0).code);
+            op.vendorExtensions.put("statusAnnotation", "@Status(HttpStatus." + httpStatusStr + ")");
+            makeSureImported(HTTP_STATUS_CLASS_NAME, op.imports);
+            makeSureImported(STATUS_ANNOTATION_CLASS_NAME, op.imports);
+        }
+        var alreadyWrapped = false;
+        var withHttpResponseWrapper = (Boolean) op.vendorExtensions.get(EXT_HTTP_RESPONSE_WRAPPER);
+        if ((withHttpResponseWrapper == null && (generateHttpResponseAlways || generateHttpResponseWhereRequired && requiresHttpResponse)) || (withHttpResponseWrapper != null && withHttpResponseWrapper)) {
+            wrapOperationReturnType(op, "io.micronaut.http.HttpResponse", false, false, false);
+            alreadyWrapped = true;
         }
 
         if (reactive) {
-            wrapOperationReturnType(op, MONO_CLASS_NAME, false, false);
+            wrapOperationReturnType(op, MONO_CLASS_NAME, false, false, alreadyWrapped);
         }
     }
 
@@ -2440,11 +2527,11 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
                 model.vendorExtensions.put("requiredParentVarsWithoutDiscriminator", requiredParentVarsWithoutDiscriminator);
             }
 
-            var deprecatedMessage = model.vendorExtensions.get("x-deprecated-message");
-            var xDeprecated = model.vendorExtensions.get("x-deprecated");
+            var deprecatedMessage = model.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+            var xDeprecated = model.vendorExtensions.get(EXT_DEPRECATED);
             if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
                 deprecatedMessage = xDeprecatedStr;
-                model.vendorExtensions.put("x-deprecated-message", xDeprecatedStr);
+                model.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, xDeprecatedStr);
             }
             if (deprecatedMessage != null) {
                 model.vendorExtensions.put("x-deprecated-message-normalized", normalizeStr(deprecatedMessage.toString()));
@@ -2575,10 +2662,10 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             return;
         }
 
-        processEnumExt(enumVars, vendorExtensions, "enumDescription", List.of("x-enum-descriptions", "x-xl4-enum-doc"));
-        processEnumExt(enumVars, vendorExtensions, "enumDeprecatedMessage", List.of("x-enum-deprecated-messages", "x-xl4-enum-deprecated"), true);
+        processEnumExt(enumVars, vendorExtensions, "enumDescription", List.of(EXT_ENUM_DESCRIPTIONS, "x-xl4-enum-doc"));
+        processEnumExt(enumVars, vendorExtensions, "enumDeprecatedMessage", List.of(EXT_ENUM_DEPRECATED_MESSAGES, "x-xl4-enum-deprecated"), true);
 
-        var deprecatedExt = vendorExtensions.get("x-deprecated");
+        var deprecatedExt = vendorExtensions.get(EXT_DEPRECATED);
         List<?> xDeprecated = null;
         Map<?, ?> xDeprecatedMap = null;
         if (deprecatedExt instanceof List<?> deprecatedList) {
@@ -2587,7 +2674,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             xDeprecated = new ArrayList<>(deprecatedMap.keySet());
             xDeprecatedMap = deprecatedMap;
         }
-        var deprecatedMessagesExt = vendorExtensions.get("x-enum-deprecated-messages");
+        var deprecatedMessagesExt = vendorExtensions.get(EXT_ENUM_DEPRECATED_MESSAGES);
         if (deprecatedMessagesExt == null) {
             deprecatedMessagesExt = vendorExtensions.get("x-xl4-enum-deprecated");
         }
@@ -2612,7 +2699,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
             }
         }
 
-        processEnumExt(enumVars, vendorExtensions, "name", List.of("x-enum-varnames"));
+        processEnumExt(enumVars, vendorExtensions, "name", List.of(EXT_ENUM_VAR_NAMES));
 
         var baseType = (String) vendorExtensions.get("baseType");
         for (var enumVar : enumVars) {
@@ -2744,20 +2831,20 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         if (property.description != null) {
             property.vendorExtensions.put("descriptionNormalized", normalizeStr(property.description));
         }
-        var deprecatedMessage = property.vendorExtensions.get("x-deprecated-message");
-        var xDeprecated = property.vendorExtensions.get("x-deprecated");
+        var deprecatedMessage = property.vendorExtensions.get(EXT_DEPRECATED_MESSAGE);
+        var xDeprecated = property.vendorExtensions.get(EXT_DEPRECATED);
         if (deprecatedMessage == null && xDeprecated instanceof String xDeprecatedStr) {
             deprecatedMessage = xDeprecatedStr;
-            property.vendorExtensions.put("x-deprecated-message", xDeprecatedStr);
+            property.vendorExtensions.put(EXT_DEPRECATED_MESSAGE, xDeprecatedStr);
         }
         if (deprecatedMessage != null) {
             property.vendorExtensions.put("x-deprecated-message-normalized", normalizeStr(deprecatedMessage.toString()));
         }
-        normalizeStrValue("x-pattern-message", property.vendorExtensions);
-        normalizeStrValue("x-size-message", property.vendorExtensions);
-        normalizeStrValue("x-not-null-message", property.vendorExtensions);
-        normalizeStrValue("x-minimum-message", property.vendorExtensions);
-        normalizeStrValue("x-maximum-message", property.vendorExtensions);
+        normalizeStrValue(EXT_PATTERN_MESSAGE, property.vendorExtensions);
+        normalizeStrValue(EXT_SIZE_MESSAGE, property.vendorExtensions);
+        normalizeStrValue(EXT_NOT_NULL_MESSAGE, property.vendorExtensions);
+        normalizeStrValue(EXT_MINIMUM_MESSAGE, property.vendorExtensions);
+        normalizeStrValue(EXT_MAXIMUM_MESSAGE, property.vendorExtensions);
 
         property.vendorExtensions.put("withRequiredAndOptionalVars", model.vendorExtensions.get("withRequiredAndOptionalVars"));
         property.vendorExtensions.put("inRequiredArgsConstructor", !property.isReadOnly || isServer);
@@ -2796,7 +2883,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
         }
 
         processGenericAnnotations(property, useBeanValidation, false, property.isNullable || property.isDiscriminator,
-            property.required, property.isReadOnly, true, true, ksp);
+            property.required, property.isReadOnly, true, true, ksp, null);
 
         normalizeExtraAnnotations(EXT_ANNOTATIONS_FIELD, true, property.vendorExtensions);
         normalizeExtraAnnotations(EXT_ANNOTATIONS_SETTER, true, property.vendorExtensions);
@@ -3364,6 +3451,7 @@ public abstract class AbstractMicronautKotlinCodegen<T extends GeneratorOptionsB
      * Sanitize against Kotlin specific naming conventions, which may differ from those required by {@link DefaultCodegen#sanitizeName}.
      *
      * @param name string to be sanitize
+     *
      * @return sanitized string
      */
     private String normalizeKotlinSpecificNames(final String name) {

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/Extension.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/Extension.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.generator;
+
+/**
+ * OpenAPI extensions, supported by Micronaut OpenAPI Generator.
+ *
+ * @since 6.20.0
+ */
+@SuppressWarnings("checkstyle:MissingJavadocType")
+public interface Extension {
+
+    String EXT_HTTP_RESPONSE_WRAPPER = "x-http-response-wrapper";
+    String EXT_NOT_NULL = "x-not-null";
+    String EXT_DEPRECATED_MESSAGE = "x-deprecated-message";
+    String EXT_DEPRECATED = "x-deprecated";
+    String EXT_FORMAT = "x-format";
+    String EXT_TYPE = "x-type";
+    String EXT_ROLES = "x-roles";
+    String EXT_ENUM_DESCRIPTIONS = "x-enum-descriptions";
+    String EXT_ENUM_DEPRECATED_MESSAGES = "x-enum-deprecated-messages";
+    String EXT_ENUM_VAR_NAMES = "x-enum-varnames";
+
+    String EXT_ANNOTATIONS_OPERATION = "x-operation-extra-annotation";
+    String EXT_ANNOTATIONS_CLASS = "x-class-extra-annotation";
+    String EXT_ANNOTATIONS_FIELD = "x-field-extra-annotation";
+    String EXT_ANNOTATIONS_SETTER = "x-setter-extra-annotation";
+
+    String EXT_PATTERN_MESSAGE = "x-pattern-message";
+    String EXT_SIZE_MESSAGE = "x-size-message";
+    String EXT_NOT_NULL_MESSAGE = "x-not-null-message";
+    String EXT_MINIMUM_MESSAGE = "x-minimum-message";
+    String EXT_MAXIMUM_MESSAGE = "x-maximum-message";
+
+}

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/JavaMicronautServerCodegen.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.micronaut.openapi.generator.Extension.EXT_ROLES;
 import static io.micronaut.openapi.generator.Utils.addUserParameter;
 import static org.openapitools.codegen.CodegenConstants.API_PACKAGE;
 
@@ -52,7 +53,6 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
     public static final String OPT_USER_PARAMETER_MODE = "userParameterMode";
     public static final String OPT_USER_PARAMETER_CLASS = "userParameterClass";
 
-    public static final String EXTENSION_ROLES = "x-roles";
     public static final String ANONYMOUS_ROLE_KEY = "isAnonymous()";
     public static final String ANONYMOUS_ROLE = "SecurityRule.IS_ANONYMOUS";
     public static final String AUTHORIZED_ROLE_KEY = "isAuthorized()";
@@ -314,7 +314,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
 
                 List<String> roles = new ArrayList<>();
 
-                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
+                if (!operation.vendorExtensions.containsKey(EXT_ROLES)) {
                     var authMethods = operation.authMethods;
                     if (authMethods != null && !authMethods.isEmpty()) {
                         var scopes = authMethods.get(0).scopes;
@@ -329,7 +329,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
                         roles.add(ANONYMOUS_ROLE);
                     }
                 } else {
-                    roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
+                    roles = (List<String>) operation.vendorExtensions.get(EXT_ROLES);
                     roles = roles.stream()
                         .map(role -> switch (role) {
                             case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
@@ -339,7 +339,7 @@ public class JavaMicronautServerCodegen extends AbstractMicronautJavaCodegen<Jav
                         }).toList();
                 }
 
-                operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+                operation.vendorExtensions.put(EXT_ROLES, roles);
 
                 if (userParameterMode != UserParameterMode.NONE) {
                     var isAnonymous = roles.contains(ANONYMOUS_ROLE);

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegen.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.micronaut.openapi.generator.Extension.EXT_ROLES;
 import static io.micronaut.openapi.generator.Utils.addUserParameter;
 import static org.openapitools.codegen.CodegenConstants.API_PACKAGE;
 
@@ -51,7 +52,6 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
     public static final String OPT_USER_PARAMETER_MODE = "userParameterMode";
     public static final String OPT_USER_PARAMETER_CLASS = "userParameterClass";
 
-    public static final String EXTENSION_ROLES = "x-roles";
     public static final String ANONYMOUS_ROLE_KEY = "isAnonymous()";
     public static final String ANONYMOUS_ROLE = "SecurityRule.IS_ANONYMOUS";
     public static final String AUTHORIZED_ROLE_KEY = "isAuthorized()";
@@ -306,7 +306,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
 
                 List<String> roles = new ArrayList<>();
 
-                if (!operation.vendorExtensions.containsKey(EXTENSION_ROLES)) {
+                if (!operation.vendorExtensions.containsKey(EXT_ROLES)) {
                     var authMethods = operation.authMethods;
                     if (authMethods != null && !authMethods.isEmpty()) {
                         var scopes = authMethods.get(0).scopes;
@@ -321,7 +321,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
                         roles.add(ANONYMOUS_ROLE);
                     }
                 } else {
-                    roles = (List<String>) operation.vendorExtensions.get(EXTENSION_ROLES);
+                    roles = (List<String>) operation.vendorExtensions.get(EXT_ROLES);
                     roles = roles.stream()
                         .map(role -> switch (role) {
                             case ANONYMOUS_ROLE_KEY -> ANONYMOUS_ROLE;
@@ -331,7 +331,7 @@ public class KotlinMicronautServerCodegen extends AbstractMicronautKotlinCodegen
                         }).toList();
                 }
 
-                operation.vendorExtensions.put(EXTENSION_ROLES, roles);
+                operation.vendorExtensions.put(EXT_ROLES, roles);
 
                 if (userParameterMode != UserParameterMode.NONE) {
                     var isAnonymous = roles.contains(ANONYMOUS_ROLE);

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorEntryPoint.java
@@ -226,6 +226,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             javaCodeGen.setGenerateHttpResponseAlways(options.generateHttpResponseAlways);
             javaCodeGen.setGenerateControllerAsAbstract(options.generateControllerAsAbstract);
             javaCodeGen.setGenerateHttpResponseWhereRequired(options.generateHttpResponseWhereRequired);
+            javaCodeGen.setGenerateHttpResponseOnlyForMultipleStatuses(options.generateHttpResponseOnlyForMultipleStatuses);
             javaCodeGen.setUseOptional(options.optional);
             javaCodeGen.setUseBeanValidation(options.beanValidation);
             javaCodeGen.setUseEnumCaseInsensitive(options.useEnumCaseInsensitive);
@@ -325,6 +326,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             kotlinCodeGen.setGenerateHttpResponseAlways(options.generateHttpResponseAlways);
             kotlinCodeGen.setGenerateControllerAsAbstract(options.generateControllerAsAbstract);
             kotlinCodeGen.setGenerateHttpResponseWhereRequired(options.generateHttpResponseWhereRequired);
+            kotlinCodeGen.setGenerateHttpResponseOnlyForMultipleStatuses(options.generateHttpResponseOnlyForMultipleStatuses);
             kotlinCodeGen.setGenerateSwaggerAnnotations(options.generateSwaggerAnnotations);
             kotlinCodeGen.setUseBeanValidation(options.beanValidation);
             kotlinCodeGen.setUseEnumCaseInsensitive(options.useEnumCaseInsensitive);
@@ -690,6 +692,7 @@ public final class MicronautCodeGeneratorEntryPoint {
             private boolean generateHttpResponseAlways;
             private boolean generateControllerAsAbstract;
             private boolean generateHttpResponseWhereRequired = true;
+            private boolean generateHttpResponseOnlyForMultipleStatuses;
             private boolean generateSwaggerAnnotations;
             private TestFramework testFramework = TestFramework.JUNIT5;
             private SerializationLibraryKind serializationLibraryKind = SerializationLibraryKind.MICRONAUT_SERDE_JACKSON;
@@ -897,6 +900,12 @@ public final class MicronautCodeGeneratorEntryPoint {
             }
 
             @Override
+            public MicronautCodeGeneratorOptionsBuilder withGenerateHttpResponseOnlyForMultipleStatuses(boolean generateHttpResponseOnlyForMultipleStatuses) {
+                this.generateHttpResponseOnlyForMultipleStatuses = generateHttpResponseOnlyForMultipleStatuses;
+                return this;
+            }
+
+            @Override
             public MicronautCodeGeneratorOptionsBuilder withGenerateSwaggerAnnotations(boolean generateSwaggerAnnotations) {
                 this.generateSwaggerAnnotations = generateSwaggerAnnotations;
                 return this;
@@ -1083,6 +1092,7 @@ public final class MicronautCodeGeneratorEntryPoint {
                     generateHttpResponseAlways,
                     generateControllerAsAbstract,
                     generateHttpResponseWhereRequired,
+                    generateHttpResponseOnlyForMultipleStatuses,
                     generateSwaggerAnnotations,
                     testFramework,
                     serializationLibraryKind,
@@ -1164,6 +1174,7 @@ public final class MicronautCodeGeneratorEntryPoint {
         boolean generateHttpResponseAlways,
         boolean generateControllerAsAbstract,
         boolean generateHttpResponseWhereRequired,
+        boolean generateHttpResponseOnlyForMultipleStatuses,
         boolean generateSwaggerAnnotations,
         TestFramework testFramework,
         SerializationLibraryKind serializationLibraryKind,

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautCodeGeneratorOptionsBuilder.java
@@ -281,6 +281,14 @@ public interface MicronautCodeGeneratorOptionsBuilder {
     MicronautCodeGeneratorOptionsBuilder withGenerateHttpResponseWhereRequired(boolean generateHttpResponseWhereRequired);
 
     /**
+     * Wrap the operations response in HttpResponse object where possible multiple HTTP status codes or additional headers are defined.
+     *
+     * @param generateHttpResponseOnlyForMultipleStatuses the wrapping flag
+     * @return this builder
+     */
+    MicronautCodeGeneratorOptionsBuilder withGenerateHttpResponseOnlyForMultipleStatuses(boolean generateHttpResponseOnlyForMultipleStatuses);
+
+    /**
      * If set to true, controller and client method will be generated with openAPI annotations.
      *
      * @param generateSwaggerAnnotations the generate swagger annotations flag

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautUtils.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/MicronautUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.openapi.generator;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Utilities methods for micronaut generator.
+ *
+ * @since 6.20.0
+ */
+public final class MicronautUtils {
+
+    public static final String MONO_CLASS_NAME = "reactor.core.publisher.Mono";
+    public static final String FLUX_CLASS_NAME = "reactor.core.publisher.Flux";
+    public static final String HTTP_STATUS_CLASS_NAME = "io.micronaut.http.HttpStatus";
+    public static final String STATUS_ANNOTATION_CLASS_NAME = "io.micronaut.http.annotation.Status";
+
+    @Nullable
+    public static String httpStatusConstName(String code) {
+        return switch (code) {
+            case "200" -> "OK";
+            case "201" -> "CREATED";
+            case "202" -> "ACCEPTED";
+            case "203" -> "NON_AUTHORITATIVE_INFORMATION";
+            case "204" -> "NO_CONTENT";
+            case "205" -> "RESET_CONTENT";
+            case "206" -> "PARTIAL_CONTENT";
+            case "207" -> "MULTI_STATUS";
+            case "208" -> "ALREADY_IMPORTED";
+            case "226" -> "IM_USED";
+            default -> null;
+        };
+    }
+}

--- a/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
+++ b/openapi-generator/src/main/java/io/micronaut/openapi/generator/Utils.java
@@ -37,6 +37,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_FIELD;
+import static io.micronaut.openapi.generator.Extension.EXT_ANNOTATIONS_SETTER;
+import static io.micronaut.openapi.generator.Extension.EXT_MAXIMUM_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_MINIMUM_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_NOT_NULL_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_PATTERN_MESSAGE;
+import static io.micronaut.openapi.generator.Extension.EXT_SIZE_MESSAGE;
+
 /**
  * Utilities methods to generators.
  *
@@ -57,11 +65,6 @@ public final class Utils {
     public static final String DIVIDE_OPERATIONS_BY_CONTENT_TYPE = "divideOperationsByContentType";
 
     public static final String DEFAULT_BODY_PARAM_NAME = "requestBody";
-    public static final String EXT_ANNOTATIONS_OPERATION = "x-operation-extra-annotation";
-    public static final String EXT_ANNOTATIONS_CLASS = "x-class-extra-annotation";
-    public static final String EXT_ANNOTATIONS_FIELD = "x-field-extra-annotation";
-    public static final String EXT_ANNOTATIONS_SETTER = "x-setter-extra-annotation";
-
     public static final String NULL_STRING = "null";
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
@@ -114,7 +117,7 @@ public final class Utils {
 
     public static void processGenericAnnotations(CodegenParameter parameter, boolean useBeanValidation, boolean isGenerateHardNullable,
                                                  boolean isNullable, boolean isRequired, boolean isReadonly, boolean withNullablePostfix,
-                                                 boolean isKotlin, boolean ksp) {
+                                                 boolean isKotlin, boolean ksp, Boolean isNotNullExt) {
         var ext = parameter.vendorExtensions;
         if (!ext.containsKey("isPrimitiveArray")) {
             ext.put("isPrimitiveArray", isJavaPrimitiveArray(parameter.dataType) || isKotlinPrimitiveArray(parameter.dataType));
@@ -122,16 +125,16 @@ public final class Utils {
         CodegenProperty items = parameter.isMap ? parameter.additionalProperties : parameter.items;
         String datatypeWithEnum = parameter.datatypeWithEnum == null ? parameter.dataType : parameter.datatypeWithEnum;
         processGenericAnnotations(parameter.dataType, datatypeWithEnum, parameter.isMap, parameter.containerTypeMapped,
-            items, parameter.vendorExtensions, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp);
+            items, parameter.vendorExtensions, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp, isNotNullExt);
 
         if (parameter.items != null) {
-            processGenericAnnotations(parameter.items, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp);
+            processGenericAnnotations(parameter.items, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp, null);
         }
     }
 
     public static void processGenericAnnotations(CodegenProperty property, boolean useBeanValidation, boolean isGenerateHardNullable,
                                                  boolean isNullable, boolean isRequired, boolean isReadonly, boolean withNullablePostfix,
-                                                 boolean isKotlin, boolean ksp) {
+                                                 boolean isKotlin, boolean ksp, Boolean isNotNullExt) {
         var ext = property.vendorExtensions;
         if (!ext.containsKey("isPrimitiveArray")) {
             ext.put("isPrimitiveArray", isJavaPrimitiveArray(property.dataType) || isKotlinPrimitiveArray(property.dataType));
@@ -139,17 +142,17 @@ public final class Utils {
         CodegenProperty items = property.isMap ? property.additionalProperties : property.items;
         String datatypeWithEnum = property.datatypeWithEnum == null ? property.dataType : property.datatypeWithEnum;
         processGenericAnnotations(property.dataType, datatypeWithEnum, property.isMap, property.containerTypeMapped,
-            items, ext, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp);
+            items, ext, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp, isNotNullExt);
 
         if (property.items != null) {
-            processGenericAnnotations(property.items, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp);
+            processGenericAnnotations(property.items, useBeanValidation, isGenerateHardNullable, isNullable, isRequired, isReadonly, withNullablePostfix, isKotlin, ksp, null);
         }
     }
 
     public static void processGenericAnnotations(String dataType, String dataTypeWithEnum, boolean isMap, String containerType, CodegenProperty itemsProp, Map<String, Object> ext,
                                                  boolean useBeanValidation, boolean isGenerateHardNullable, boolean isNullable,
                                                  boolean isRequired, boolean isReadonly,
-                                                 boolean withNullablePostfix, boolean isKotlin, boolean ksp) {
+                                                 boolean withNullablePostfix, boolean isKotlin, boolean ksp, Boolean isNotNullExt) {
         String genericAnnotations = null;
         dataType = addAnnotationsToPrimitiveArray(dataType, isNullable, isRequired, isReadonly, isGenerateHardNullable);
         dataTypeWithEnum = addAnnotationsToPrimitiveArray(dataTypeWithEnum, isNullable, isRequired, isReadonly, isGenerateHardNullable);
@@ -157,7 +160,7 @@ public final class Utils {
         var typeWithEnumWithGenericAnnotations = dataTypeWithEnum;
         if (useBeanValidation && itemsProp != null && dataType.contains("<")) {
             genericAnnotations = genericAnnotations(itemsProp, isGenerateHardNullable, isKotlin, ksp);
-            processGenericAnnotations(itemsProp, useBeanValidation, isGenerateHardNullable, itemsProp.isNullable, itemsProp.required, itemsProp.isReadOnly, withNullablePostfix, isKotlin, ksp);
+            processGenericAnnotations(itemsProp, useBeanValidation, isGenerateHardNullable, itemsProp.isNullable, itemsProp.required, itemsProp.isReadOnly, withNullablePostfix, isKotlin, ksp, null);
             if (isMap) {
                 typeWithGenericAnnotations = "Map<String, " + genericAnnotations + itemsProp.vendorExtensions.get("typeWithGenericAnnotations") + ">";
                 typeWithEnumWithGenericAnnotations = "Map<String, " + genericAnnotations + itemsProp.vendorExtensions.get("typeWithEnumWithGenericAnnotations") + ">";
@@ -167,11 +170,18 @@ public final class Utils {
             }
         }
 
-        var isNullableType = withNullablePostfix && (isNullable || isRequired && isReadonly || (genericAnnotations != null && !genericAnnotations.contains("NotNull") && !isRequired));
+        var isNullableType = false;
+        if (isNotNullExt == null) {
+            isNullableType = withNullablePostfix && (isNullable || isRequired && isReadonly || (genericAnnotations != null && !genericAnnotations.contains("NotNull") && !isRequired));
+        } else {
+            isNullableType = !isNotNullExt;
+        }
         // properties with default value are optional, but it works fine only with KSP
         if (ksp) {
             var hasDefaultValue = (Boolean) ext.get("defaultValueIsNotNull");
-            isNullableType = isNullableType && (hasDefaultValue == null || !hasDefaultValue);
+            if (isNotNullExt == null) {
+                isNullableType = isNullableType && (hasDefaultValue == null || !hasDefaultValue);
+            }
         }
 
         ext.put("typeWithGenericAnnotations", typeWithGenericAnnotations + (isNullableType ? "?" : ""));
@@ -201,7 +211,8 @@ public final class Utils {
             return false;
         }
         return switch (dataType) {
-            case "byte[]", "short[]", "int[]", "long[]", "boolean[]", "char[]", "float[]", "double[]" -> true;
+            case "byte[]", "short[]", "int[]", "long[]", "boolean[]", "char[]", "float[]",
+                 "double[]" -> true;
             default -> false;
         };
     }
@@ -231,11 +242,11 @@ public final class Utils {
             return result.toString();
         }
 
-        var patternMsg = (String) prop.vendorExtensions.get("x-pattern-message");
-        var sizeMsg = (String) prop.vendorExtensions.get("x-size-message");
-        var notNullMsg = (String) prop.vendorExtensions.get("x-not-null-message");
-        var minMsg = (String) prop.vendorExtensions.get("x-minimum-message");
-        var maxMsg = (String) prop.vendorExtensions.get("x-maximum-message");
+        var patternMsg = (String) prop.vendorExtensions.get(EXT_PATTERN_MESSAGE);
+        var sizeMsg = (String) prop.vendorExtensions.get(EXT_SIZE_MESSAGE);
+        var notNullMsg = (String) prop.vendorExtensions.get(EXT_NOT_NULL_MESSAGE);
+        var minMsg = (String) prop.vendorExtensions.get(EXT_MINIMUM_MESSAGE);
+        var maxMsg = (String) prop.vendorExtensions.get(EXT_MAXIMUM_MESSAGE);
         if (isKotlin) {
             patternMsg = normalizeStr(patternMsg);
             sizeMsg = normalizeStr(sizeMsg);

--- a/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/java-micronaut/server/controller-interface.mustache
@@ -59,6 +59,9 @@ public interface {{classname}} {
         {{#formatNoEmptyLines}}
 {{>common/operationAnnotations}}
     @{{#lambda.pascalcase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.pascalcase}}("{{{path}}}")
+    {{#vendorExtensions.statusAnnotation}}
+    {{{.}}}
+    {{/vendorExtensions.statusAnnotation}}
     {{^vendorExtensions.onlyDefaultProduceOrEmpty}}
     @Produces({{#produces.1}}{{openbrace}}{{/produces.1}}{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}{{#produces.1}}{{closebrace}}{{/produces.1}})
     {{/vendorExtensions.onlyDefaultProduceOrEmpty}}

--- a/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
+++ b/openapi-generator/src/main/resources/templates/kotlin-micronaut/server/controller-interface.mustache
@@ -54,6 +54,9 @@ interface {{classname}} {
         {{#formatNoEmptyLines}}
 {{>common/operationAnnotations}}
     @{{#lambda.pascalcase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.pascalcase}}("{{{vendorExtensions.pathNormalized}}}")
+    {{#vendorExtensions.statusAnnotation}}
+    {{{.}}}
+    {{/vendorExtensions.statusAnnotation}}
     {{^vendorExtensions.onlyDefaultProduceOrEmpty}}
     @Produces({{#produces}}"{{{mediaTypeNormalized}}}"{{^-last}}, {{/-last}}{{/produces}})
     {{/vendorExtensions.onlyDefaultProduceOrEmpty}}

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautClientCodegenTest.java
@@ -2556,4 +2556,43 @@ class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 """
         );
     }
+
+    @Test
+    void testHttpResponseWrapperExt() {
+
+        var codegen = new JavaMicronautClientCodegen();
+        codegen.generateHttpResponseOnlyForMultipleStatuses = true;
+        String outputPathApi = generateFiles(codegen, "src/test/resources/3_0/spec.yml");
+
+        String path = outputPathApi + "src/main/java/org/openapitools/";
+        assertFileContains(path + "api/ParametersApi.java",
+            """
+                    @Get("/sendPrimitives/{name}")
+                    Mono<HttpResponse<@Valid SendPrimitivesResponse>> sendPrimitives(
+                        @PathVariable("name") @NotNull String name,
+                        @QueryValue("age") @NotNull BigDecimal age,
+                        @Header("height") @NotNull Float height,
+                        @QueryValue("isPositive") @NotNull Boolean isPositive
+                    );
+                """,
+            """
+                    @Get("/getIgnoredHeader")
+                    @Consumes("text/plain")
+                    Mono<HttpResponse<@NotNull String>> getIgnoredHeader();
+                """
+        );
+
+        assertFileContains(path + "api/ResponseBodyApi.java",
+            """
+                    @Get("/getPaginatedSimpleModel")
+                    Mono<HttpResponse<@NotNull List<@Valid SimpleModel>>> getPaginatedSimpleModel(
+                        @QueryValue(value = "page", defaultValue = "0") @Nullable @Min(0) Integer page
+                    );
+                """,
+            """
+                    @Get("/getSimpleModelWithNonMappedHeader")
+                    Mono<@Valid SimpleModel> getSimpleModelWithNonMappedHeader();
+                """
+        );
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/JavaMicronautServerCodegenTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 
-import java.io.File;
-
 import static io.micronaut.openapi.generator.assertions.TestUtils.assertExtraAnnotationFiles;
 import static java.util.stream.Collectors.groupingBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1415,5 +1413,31 @@ class JavaMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
                     private Map<String, @NotNull String> myMap = new HashMap<>();
                 """
         );
+    }
+
+    @Test
+    void testNonDefaultResponseStatus() {
+
+        var codegen = new JavaMicronautServerCodegen();
+        codegen.generateHttpResponseOnlyForMultipleStatuses = true;
+        String outputPathApi = generateFiles(codegen, "src/test/resources/3_0/spec.yml");
+
+        String path = outputPathApi + "src/main/java/org/openapitools/";
+        assertFileContains(path + "api/ResponseBodyApi.java", """
+                @Operation(
+                    operationId = "getSimpleModelWithNonStandardStatus",
+                    description = "A method to get a simple model as a response",
+                    responses = {
+                        @ApiResponse(responseCode = "201", description = "Success", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SimpleModel.class))),
+                        @ApiResponse(responseCode = "default", description = "An unexpected error has occurred")
+                    }
+                )
+                @Get("/getSimpleModelWithNonStandardStatus")
+                @Status(HttpStatus.CREATED)
+                @Secured(SecurityRule.IS_ANONYMOUS)
+                Mono<@Valid SimpleModel> getSimpleModelWithNonStandardStatus();
+            """,
+            "import io.micronaut.http.annotation.Status;",
+            "import io.micronaut.http.HttpStatus;");
     }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautClientCodegenTest.java
@@ -3256,4 +3256,76 @@ class KotlinMicronautClientCodegenTest extends AbstractMicronautCodegenTest {
                 """
         );
     }
+
+    @Test
+    void testHttpResponseWrapperExt() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.generateHttpResponseOnlyForMultipleStatuses = true;
+        String outputPathApi = generateFiles(codegen, "src/test/resources/3_0/spec.yml");
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/ParametersApi.kt",
+            """
+                    @Get("/sendPrimitives/{name}")
+                    fun sendPrimitives(
+                        @PathVariable("name") @NotNull name: String,
+                        @QueryValue("age") @NotNull age: BigDecimal,
+                        @Header("height") @NotNull height: Float,
+                        @QueryValue("isPositive") @NotNull isPositive: Boolean,
+                    ): Mono<HttpResponse<SendPrimitivesResponse>>
+                """,
+            """
+                    @Get("/getIgnoredHeader")
+                    @Consumes("text/plain")
+                    fun getIgnoredHeader(): Mono<HttpResponse<String?>>
+                """,
+            """
+                    @Get("/sendValidatedPrimitives")
+                    @Consumes("text/plain")
+                    fun sendValidatedPrimitives(
+                        @QueryValue("name") @Nullable @Pattern(regexp = "[a-zA-Z]+") @Size(min = 3) name: String? = null,
+                        @QueryValue("age") @Nullable @Min(10) @Max(200) age: Int? = null,
+                        @QueryValue("favoriteNumber") @Nullable @DecimalMin("-100.5") @DecimalMax("100.5") favoriteNumber: BigDecimal? = null,
+                        @QueryValue("height") @Nullable @DecimalMin("0.1", inclusive = false) @DecimalMax("3", inclusive = false) height: Double? = null,
+                    ): Mono<String?>
+                """
+        );
+
+        assertFileContains(path + "api/ResponseBodyApi.kt",
+            """
+                    @Get("/getPaginatedSimpleModel")
+                    fun getPaginatedSimpleModel(
+                        @QueryValue("page", defaultValue = "0") @Nullable @Min(0) page: Int? = 0,
+                    ): Mono<HttpResponse<List<SimpleModel>>>
+                """,
+            """
+                    @Get("/getSimpleModelWithNonMappedHeader")
+                    fun getSimpleModelWithNonMappedHeader(): Mono<SimpleModel>
+                """
+        );
+    }
+
+    @Test
+    void testNullableOperationReturnType() {
+
+        var codegen = new KotlinMicronautClientCodegen();
+        codegen.generateHttpResponseOnlyForMultipleStatuses = true;
+        codegen.reactive = false;
+        String outputPathApi = generateFiles(codegen, "src/test/resources/3_0/spec.yml");
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/ParametersApi.kt",
+            """
+                    @Get("/sendValidatedPrimitives")
+                    @Consumes("text/plain")
+                    fun sendValidatedPrimitives(
+                        @QueryValue("name") @Nullable @Pattern(regexp = "[a-zA-Z]+") @Size(min = 3) name: String? = null,
+                        @QueryValue("age") @Nullable @Min(10) @Max(200) age: Int? = null,
+                        @QueryValue("favoriteNumber") @Nullable @DecimalMin("-100.5") @DecimalMax("100.5") favoriteNumber: BigDecimal? = null,
+                        @QueryValue("height") @Nullable @DecimalMin("0.1", inclusive = false) @DecimalMax("3", inclusive = false) height: Double? = null,
+                    ): String?
+                """
+        );
+    }
 }

--- a/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
+++ b/openapi-generator/src/test/java/io/micronaut/openapi/generator/KotlinMicronautServerCodegenTest.java
@@ -1898,4 +1898,32 @@ class KotlinMicronautServerCodegenTest extends AbstractMicronautCodegenTest {
                 """
         );
     }
+
+    @Test
+    void testNonDefaultResponseStatus() {
+
+        var codegen = new KotlinMicronautServerCodegen();
+        codegen.generateHttpResponseOnlyForMultipleStatuses = true;
+        String outputPathApi = generateFiles(codegen, "src/test/resources/3_0/spec.yml");
+
+        String path = outputPathApi + "src/main/kotlin/org/openapitools/";
+        assertFileContains(path + "api/ResponseBodyApi.kt", """
+                @Operation(
+                    operationId = "getSimpleModelWithNonStandardStatus",
+                    description = "A method to get a simple model as a response",
+                    responses = [
+                        ApiResponse(responseCode = "201", description = "Success", content = [
+                            Content(mediaType = "application/json", schema = Schema(implementation = SimpleModel::class)),
+                        ]),
+                        ApiResponse(responseCode = "default", description = "An unexpected error has occurred"),
+                    ],
+                )
+                @Get("/getSimpleModelWithNonStandardStatus")
+                @Status(HttpStatus.CREATED)
+                @Secured(SecurityRule.IS_ANONYMOUS)
+                fun getSimpleModelWithNonStandardStatus(): Mono<SimpleModel>
+            """,
+            "import io.micronaut.http.annotation.Status",
+            "import io.micronaut.http.HttpStatus");
+    }
 }

--- a/openapi-generator/src/test/resources/3_0/spec.yml
+++ b/openapi-generator/src/test/resources/3_0/spec.yml
@@ -13,6 +13,8 @@ paths:
       operationId: sendPrimitives
       tags: [ parameters ]
       description: A method to send primitives as request parameters
+      x-http-response-wrapper: true
+      x-not-null: true
       parameters:
         - name: name
           in: path
@@ -42,8 +44,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SendPrimitivesResponse'
-        default:
-          $ref: '#/components/responses/Error'
+        404:
+          description: Not found
   /sendValidatedPrimitives:
     get:
       operationId: sendValidatedPrimitives
@@ -85,6 +87,7 @@ paths:
             text/plain:
               schema:
                 type: string
+                nullable: true
         default:
           $ref: '#/components/responses/Error'
   /sendDates:
@@ -152,6 +155,7 @@ paths:
     get:
       operationId: getIgnoredHeader
       tags: [ parameters ]
+      x-not-null: false
       description: |
         A method that returns a header that should be ignored.
         It will be ignored, this behavior is most likely used when it will be set in a filter.
@@ -568,6 +572,7 @@ paths:
   /getPaginatedSimpleModel:
     get:
       operationId: getPaginatedSimpleModel
+      x-not-null: true
       parameters:
         - $ref: '#/components/parameters/PageQueryParam'
       tags: [ responseBody ]
@@ -608,6 +613,7 @@ paths:
   /getSimpleModelWithNonMappedHeader:
     get:
       operationId: getSimpleModelWithNonMappedHeader
+      x-http-response-wrapper: false
       tags: [ responseBody ]
       description: A method to get a simple model as a response
       responses:
@@ -675,6 +681,7 @@ components:
   schemas:
     SendPrimitivesResponse:
       type: object
+      nullable: true
       properties:
         name:
           type: string

--- a/test-suite-server-generator-java/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
+++ b/test-suite-server-generator-java/src/main/java/io/micronaut/openapi/test/api/ResponseBodyController.java
@@ -1,12 +1,5 @@
 package io.micronaut.openapi.test.api;
 
-import java.io.ByteArrayInputStream;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.List;
-
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
@@ -21,9 +14,15 @@ import io.micronaut.openapi.test.model.DateModel;
 import io.micronaut.openapi.test.model.ModelWithValidatedListProperty;
 import io.micronaut.openapi.test.model.SimpleModel;
 import io.micronaut.openapi.test.model.StateEnum;
-
 import io.swagger.v3.oas.annotations.Hidden;
 import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
 
 @Hidden
 @Controller


### PR DESCRIPTION
Fixed #2563

Ok, one PR for everything related to HttpResponse wrapping.

1. It now checks for a single 2xx response, and if so, the response is NOT automatically wrapped in the client and controller, and a Status annotation with the return code is added to the controller.

2. I added support for two extensions: `x-http-response-wrapper` and `x-not-null`.

3. Now return type will be with question mark (nullable), if response schema with `nullable: true` flag

You can now explicitly enable or disable the response wrapper in HttpResponse for each operation individually:

If `x-http-response-wrapper: true`, then the HttpResponse wrapper will definitely be added.

If `x-http-response-wrapper: false`, then the HttpResponse wrapper will definitely NOT be added.

If `x-http-response-wrapper` is missing, then the HttpResponse wrapper will be added depending on the global settings - generateHttpResponseAlways or generateHttpResponseWhereRequired.

`x-not-null` works the same way, but currently only works with the return value of operations and only in the Kotlin generator. This was added to allow manual adjustments to the generator if the return type should be nullable but not-nullable is generated. Basically, whether or not to add a question mark at the end of the type