### PR TITLE
Fix KSP2 PSI lifecycle exception in processEndpoints

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -921,6 +921,7 @@ public final class ConfigUtils {
             if (className == null) {
                 continue;
             }
+            endpointProperties.setClassName(className);
             var classEl = ContextUtils.getClassElement(className, context);
             endpointProperties.setElement(classEl);
         }
@@ -1007,6 +1008,7 @@ public final class ConfigUtils {
                 break;
             case "class":
                 if (endpointProperties.getElement() == null) {
+                    endpointProperties.setClassName(valueStr);
                     endpointProperties.setElement(ContextUtils.getClassElement(valueStr, context));
                 }
                 break;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ConfigUtils.java
@@ -914,7 +914,7 @@ public final class ConfigUtils {
                 endpointProperties = new EndpointProperties(endpointName);
                 endpointPropertiesMap.put(endpointName, endpointProperties);
             }
-            if (endpointProperties.getElement() != null) {
+            if (endpointProperties.getClassName() != null) {
                 continue;
             }
             var className = entry.getValue();
@@ -922,8 +922,6 @@ public final class ConfigUtils {
                 continue;
             }
             endpointProperties.setClassName(className);
-            var classEl = ContextUtils.getClassElement(className, context);
-            endpointProperties.setElement(classEl);
         }
 
         return endpointPropertiesMap;
@@ -1007,9 +1005,8 @@ public final class ConfigUtils {
                 endpointProperties.getTags().addAll(parseTags(valueStr));
                 break;
             case "class":
-                if (endpointProperties.getElement() == null) {
+                if (endpointProperties.getClassName() == null) {
                     endpointProperties.setClassName(valueStr);
-                    endpointProperties.setElement(ContextUtils.getClassElement(valueStr, context));
                 }
                 break;
             default:

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -1037,11 +1037,17 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             if (!isAllEnabled || (endpointProps.getEnabled() != null && !endpointProps.getEnabled())) {
                 continue;
             }
-            ClassElement classEl = endpointProps.getElement();
-            if (classEl == null) {
+            // Resolve ClassElement fresh from the class name to avoid KSP2 PSI lifecycle issues.
+            // Stored ClassElement references from previous phases may have stale PSI tokens.
+            String className = endpointProps.getClassName();
+            if (className == null) {
                 continue;
             }
-            if (!canProcessEndpoint(classEl, context)) {
+            if (!canProcessEndpoint(className, context)) {
+                continue;
+            }
+            ClassElement classEl = ContextUtils.getClassElement(className, context);
+            if (classEl == null) {
                 continue;
             }
 
@@ -1086,8 +1092,8 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         }
     }
 
-    private boolean canProcessEndpoint(ClassElement classEl, VisitorContext context) {
-        var classToCheck = SPECIFIC_ENDPOINTS.get(classEl.getName());
+    private boolean canProcessEndpoint(String className, VisitorContext context) {
+        var classToCheck = SPECIFIC_ENDPOINTS.get(className);
         if (classToCheck == null) {
             return true;
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/management/EndpointProperties.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/management/EndpointProperties.java
@@ -54,6 +54,10 @@ public final class EndpointProperties {
      */
     private String contextPath;
     /**
+     * Fully qualified class name of the endpoint.
+     */
+    private String className;
+    /**
      * ClassElement of the endpoint.
      */
     private ClassElement element;
@@ -120,6 +124,14 @@ public final class EndpointProperties {
 
     public void setContextPath(String contextPath) {
         this.contextPath = contextPath;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
     }
 
     public void setElement(ClassElement element) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/management/EndpointProperties.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/management/EndpointProperties.java
@@ -16,7 +16,6 @@
 package io.micronaut.openapi.visitor.management;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.ast.ClassElement;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
@@ -57,10 +56,6 @@ public final class EndpointProperties {
      * Fully qualified class name of the endpoint.
      */
     private String className;
-    /**
-     * ClassElement of the endpoint.
-     */
-    private ClassElement element;
     /**
      * Description to add to the Endpoint entry in the spec file.
      */
@@ -134,15 +129,7 @@ public final class EndpointProperties {
         this.className = className;
     }
 
-    public void setElement(ClassElement element) {
-        this.element = element;
-    }
-
-    public ClassElement getElement() {
-        return element;
-    }
-
-    public String getDescription() {
+public String getDescription() {
         return description;
     }
 
@@ -189,7 +176,7 @@ public final class EndpointProperties {
             ", enabled=" + enabled +
             ", sensitive=" + sensitive +
             ", path='" + path + '\'' +
-            ", element=" + element +
+            ", className='" + className + '\'' +
             ", description='" + description + '\'' +
             ", extensions=" + extensions +
             ", tags=" + tags +

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/management/SpringActuatorConfigUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/management/SpringActuatorConfigUtils.java
@@ -196,11 +196,8 @@ public final class SpringActuatorConfigUtils {
                 endpointProperties = new EndpointProperties(endpointName);
                 endpointPropertiesMap.put(endpointName, endpointProperties);
             }
-            if (endpointProperties.getElement() == null) {
-                var classEl = ContextUtils.getClassElement(entry.getValue(), context);
-                if (classEl != null) {
-                    endpointProperties.setElement(classEl);
-                }
+            if (endpointProperties.getClassName() == null) {
+                endpointProperties.setClassName(entry.getValue());
             }
             if (endpointProperties.getEnabled() == null) {
                 endpointProperties.setEnabled(true);


### PR DESCRIPTION
## Summary

Fixes the `KaInvalidLifetimeOwnerAccessException` in `OpenApiApplicationVisitor.finish()` when using KSP2 (`ksp.useKSP2=true`).

The fix in #2568 (released in 6.20.0) addressed element access in logging/file writing paths, but `processEndpoints()` still accessed stale `ClassElement` references through `canProcessEndpoint()` → `getName()` and then passed them to visitors.

## Changes

- Add a `className` (String) field to `EndpointProperties`, replacing the `ClassElement element` field which held stale PSI references
- Store the class name when registering endpoints in `ConfigUtils.endpointsProperties()`, `setEndpointProperty()`, and `SpringActuatorConfigUtils`
- In `canProcessEndpoint()`, use the stored String instead of calling `classEl.getName()` (which triggers PSI access)
- In `processEndpoints()`, re-resolve the `ClassElement` fresh from the class name instead of using a stored reference

## Root cause

In KSP2, `ClassElement` references captured during previous processing phases have invalidated PSI tokens by the time `finish()` runs. Accessing any property (like `getName()`) on these stale elements triggers:

```
KaInvalidLifetimeOwnerAccessException: Access to invalid KotlinAlwaysAccessibleLifetimeToken: PSI has changed since creation
    at KotlinClassElement.getName(KotlinClassElement.kt:330)
    at OpenApiApplicationVisitor.canProcessEndpoint(OpenApiApplicationVisitor.java:1090)
    at OpenApiApplicationVisitor.processEndpoints(OpenApiApplicationVisitor.java:1044)
    at OpenApiApplicationVisitor.finish(OpenApiApplicationVisitor.java:588)
```

This is the same class of issue fixed in micronaut-core#11928.

## Test plan

**No regression on KSP1:**
- `OpenApiEndpointVisitorSpec` (endpoint unit tests): 4 passed, 1 skipped (pre-existing `@Ignore` for Spring actuator dep)
- `test-suite-spring-kotlin-ksp` (Spring + Kotlin + KSP1 integration): all passed

**KSP2 validation:**
- Tested with a ~170-dependency Micronaut 4.10.6 service with ~30 controllers
- KSP2 compilation previously failed 100% of the time, now succeeds
- Full test suite passes with KSP2 enabled

**Note:** Enabling KSP2 across the existing test suites is not yet possible due to unrelated KSP2 issues in micronaut-core's Spring annotation processing (`KSAnnotationJavaImpl` null cast, `AliasFor` member type errors). Those are separate from this fix.

Fixes #2276