### PR TITLE
Fixed process URI templates with patterns for path and query variables

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -95,6 +95,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static io.micronaut.openapi.visitor.ConfigUtils.isJsonViewEnabled;
 import static io.micronaut.openapi.visitor.ConfigUtils.isOpenApiEnabled;
@@ -548,14 +549,14 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
 
                 setOperationOnPathItem(operationEntry.getKey(), httpMethod, swaggerOperation);
 
-                var queryParams = new HashMap<String, UriMatchVariable>();
-                var pathVariables = new HashMap<String, UriMatchVariable>();
+                var queryParams = new HashMap<String, VarMetadata>();
+                var pathVariables = new HashMap<String, VarMetadata>();
                 for (UriMatchTemplate matchTemplate : matchTemplates) {
-                    for (Map.Entry<String, UriMatchVariable> varEntry : uriVariables(matchTemplate).entrySet()) {
+                    for (Map.Entry<String, VarMetadata> varEntry : uriVariables(matchTemplate).entrySet()) {
                         if (pathItemEntry.getKey().contains(OPEN_BRACE + varEntry.getKey() + CLOSE_BRACE)) {
                             pathVariables.put(varEntry.getKey(), varEntry.getValue());
                         }
-                        if (varEntry.getValue().isQuery()) {
+                        if (varEntry.getValue().var.isQuery()) {
                             queryParams.put(varEntry.getKey(), varEntry.getValue());
                         }
                     }
@@ -579,15 +580,15 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         }
     }
 
-    private void addParamsByUriTemplate(String path, Map<String, UriMatchVariable> pathVariables,
-                                        Map<String, UriMatchVariable> queryParams,
+    private void addParamsByUriTemplate(String path, Map<String, VarMetadata> pathVariables,
+                                        Map<String, VarMetadata> queryParams,
                                         Operation operation) {
 
         // check path variables in URL template which do not map to method parameters
         for (var entry : pathVariables.entrySet()) {
             var varName = entry.getKey();
             var pathVar = entry.getValue();
-            if (pathVar.isExploded()
+            if (pathVar.var.isExploded()
                 || !path.contains(OPEN_BRACE + varName + CLOSE_BRACE)
                 // skip placeholders
                 || path.contains(DOLLAR + OPEN_BRACE + varName + CLOSE_BRACE)
@@ -605,7 +606,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         for (var entry : queryParams.entrySet()) {
             var varName = entry.getKey();
             var pathVar = entry.getValue();
-            if (pathVar.isExploded() || isAlreadyAdded(varName, operation)) {
+            if (pathVar.var.isExploded() || isAlreadyAdded(varName, operation)) {
                 continue;
             }
 
@@ -720,8 +721,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
     private void processParameters(MethodElement element, VisitorContext context, OpenAPI openApi,
                                    Operation swaggerOperation, JavadocDescription javadocDescription,
                                    boolean permitsRequestBody,
-                                   Map<String, UriMatchVariable> pathVariables,
-                                   Map<String, UriMatchVariable> queryParams,
+                                   Map<String, VarMetadata> pathVariables,
+                                   Map<String, VarMetadata> queryParams,
                                    List<MediaType> consumesMediaTypes,
                                    List<TypedElement> extraBodyParameters,
                                    HttpMethod httpMethod,
@@ -782,7 +783,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                                                     UriMatchTemplate matchTemplate,
                                                     HttpMethod httpMethod,
                                                     Operation operation,
-                                                    Map<String, UriMatchVariable> pathVariables,
+                                                    Map<String, VarMetadata> pathVariables,
                                                     VisitorContext context) {
 
         var parameterAnns = element.getDeclaredAnnotationValuesByType(io.swagger.v3.oas.annotations.Parameter.class);
@@ -824,7 +825,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                     } else if (paramEl.isAnnotationPresent(Header.class)) {
                         parameter.setIn(ParameterIn.HEADER.toString());
                     } else {
-                        UriMatchVariable pathVariable = pathVariables.get(parameter.getName());
+                        VarMetadata pathVariable = pathVariables.get(parameter.getName());
                         // check if this parameter is optional path variable
                         if (pathVariable == null) {
                             for (UriMatchVariable variable : matchTemplate.getVariables()) {
@@ -833,7 +834,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                                 }
                             }
                         }
-                        if (pathVariable != null && !pathVariable.isOptional() && !pathVariable.isQuery() && !pathVariable.isExploded()) {
+                        if (pathVariable != null && !pathVariable.var.isOptional() && !pathVariable.var.isQuery() && !pathVariable.var.isExploded()) {
                             parameter.setIn(ParameterIn.PATH.toString());
                         }
 
@@ -858,8 +859,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
     private void processParameter(VisitorContext context, OpenAPI openApi,
                                   Operation swaggerOperation, JavadocDescription javadocDescription,
                                   boolean permitsRequestBody,
-                                  Map<String, UriMatchVariable> pathVariables,
-                                  Map<String, UriMatchVariable> queryParams,
+                                  Map<String, VarMetadata> pathVariables,
+                                  Map<String, VarMetadata> queryParams,
                                   List<MediaType> consumesMediaTypes,
                                   List<Parameter> swaggerParameters, TypedElement parameter,
                                   List<TypedElement> extraBodyParameters,
@@ -931,6 +932,13 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                 newParameter.setName(parameter.getName());
             }
 
+            var urlVar = pathVariables.get(newParameter.getName());
+            if (urlVar == null) {
+                urlVar = queryParams.get(newParameter.getName());
+            }
+            var paramPattern = urlVar != null ? urlVar.pattern() : null;
+
+
             if (newParameter.getRequired() == null && (!isNullable(parameter) || isNotNullable(parameter))) {
                 // exception for spring actuator prometheus endpoint
                 if (!get(MICRONAUT_INTERNAL_ENDPOINT_IS_PROMETHEUS, Boolean.class, false, context)
@@ -973,6 +981,15 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                             newParameter.setRequired(null);
                         }
                     }
+                }
+            }
+            if (paramPattern != null) {
+                if (newParameter.getSchema() == null) {
+                    newParameter.setSchema(createSchema()
+                        .type(TYPE_STRING)
+                        .pattern(paramPattern));
+                } else if (StringUtils.isEmpty(newParameter.getSchema().getPattern())) {
+                    newParameter.getSchema().setPattern(paramPattern);
                 }
             }
         }
@@ -1021,8 +1038,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
 
     private Parameter processMethodParameterAnnotation(VisitorContext context, Operation swaggerOperation,
                                                        boolean permitsRequestBody,
-                                                       Map<String, UriMatchVariable> pathVariables,
-                                                       Map<String, UriMatchVariable> queryParams,
+                                                       Map<String, VarMetadata> pathVariables,
+                                                       Map<String, VarMetadata> queryParams,
                                                        TypedElement parameter,
                                                        List<TypedElement> extraBodyParameters,
                                                        HttpMethod httpMethod,
@@ -1032,10 +1049,10 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         Parameter newParameter = null;
         String parameterName = parameter.getName();
         if (!parameter.hasStereotype(Bindable.class) && pathVariables.containsKey(parameterName)) {
-            UriMatchVariable urlVar = pathVariables.get(parameterName);
-            newParameter = urlVar.isQuery() ? new QueryParameter() : new PathParameter();
+            VarMetadata urlVar = pathVariables.get(parameterName);
+            newParameter = urlVar.var.isQuery() ? new QueryParameter() : new PathParameter();
             newParameter.setName(parameterName);
-            final boolean exploded = urlVar.isExploded();
+            final boolean exploded = urlVar.var.isExploded();
             if (exploded) {
                 newParameter.setExplode(exploded);
             }
@@ -1044,7 +1061,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             if (paramName.isEmpty()) {
                 paramName = parameterName;
             }
-            UriMatchVariable variable = pathVariables.get(paramName);
+            VarMetadata variable = pathVariables.get(paramName);
             if (variable == null) {
                 if (!isNullable(parameter)) {
                     warn("Path variable name: '" + paramName + "' not found in path, operation: " + swaggerOperation.getOperationId(), context, parameter);
@@ -1053,7 +1070,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             }
             newParameter = new PathParameter();
             newParameter.setName(paramName);
-            final boolean exploded = variable.isExploded();
+            final boolean exploded = variable.var.isExploded();
             if (exploded) {
                 newParameter.setExplode(true);
             }
@@ -1121,7 +1138,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                     isBodyParameter = true;
                 } else {
 
-                    UriMatchVariable pathVariable = pathVariables.get(parameterName);
+                    var pathVariable = pathVariables.get(parameterName);
                     boolean isExploded = false;
                     // check if this parameter is optional path variable
                     if (pathVariable == null) {
@@ -1137,10 +1154,10 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
                             }
                         }
                     }
-                    if (pathVariable != null && !pathVariable.isOptional() && !pathVariable.isQuery()) {
+                    if (pathVariable != null && !pathVariable.var.isOptional() && !pathVariable.var.isQuery()) {
                         newParameter = new PathParameter();
                         newParameter.setName(parameterName);
-                        if (pathVariable.isExploded()) {
+                        if (pathVariable.var.isExploded()) {
                             newParameter.setExplode(true);
                         }
                     }
@@ -1371,8 +1388,8 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
     private void processRequestBean(VisitorContext context, OpenAPI openApi,
                                     Operation swaggerOperation, JavadocDescription javadocDescription,
                                     boolean permitsRequestBody,
-                                    Map<String, UriMatchVariable> pathVariables,
-                                    Map<String, UriMatchVariable> queryParams,
+                                    Map<String, VarMetadata> pathVariables,
+                                    Map<String, VarMetadata> queryParams,
                                     List<MediaType> consumesMediaTypes,
                                     List<Parameter> swaggerParameters, TypedElement parameter,
                                     List<TypedElement> extraBodyParameters,
@@ -1486,13 +1503,35 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         return returnType;
     }
 
-    private Map<String, UriMatchVariable> uriVariables(UriMatchTemplate matchTemplate) {
-        List<UriMatchVariable> pv = matchTemplate.getVariables();
-        var pathVariables = new LinkedHashMap<String, UriMatchVariable>(pv.size());
-        for (UriMatchVariable variable : pv) {
-            pathVariables.put(variable.getName(), variable);
+    private Map<String, VarMetadata> uriVariables(UriMatchTemplate matchTemplate) {
+        var pv = matchTemplate.getVariables();
+        var rawTemplate = matchTemplate.toString();
+
+        var variablesMetadata = new LinkedHashMap<String, VarMetadata>(pv.size());
+        for (var variable : pv) {
+            var rawName = variable.getName();
+            String extractedPattern = null;
+
+            // Micronaut bug/feature: name might contain RFC 6570 operators like '*' or '+'
+            // We must clean it for OpenAPI compliance
+            var cleanName = rawName;
+            if (cleanName.startsWith("*") || cleanName.startsWith("+") || cleanName.startsWith("/")) {
+                cleanName = cleanName.substring(1);
+            }
+            // 1. Extract pattern
+            var p = Pattern.compile("\\{" + Pattern.quote(rawName) + ":(.+?)}");
+            var m = p.matcher(rawTemplate);
+            if (m.find()) {
+                extractedPattern = m.group(1);
+            }
+
+            // 2. Map properties from UriMatchVariable
+            variablesMetadata.put(cleanName, new VarMetadata(
+                variable,
+                extractedPattern
+            ));
         }
-        return pathVariables;
+        return variablesMetadata;
     }
 
     private JavadocDescription getMethodDescription(MethodElement element, Operation swaggerOperation, VisitorContext context) {
@@ -1908,5 +1947,17 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
             content.addMediaType(mediaType.toString(), mt);
         }
         return content;
+    }
+
+    /**
+     * Metadata for a URI variable, including its Micronaut variable definition and regex pattern.
+     *
+     * @param var The Micronaut {@link UriMatchVariable} definition
+     * @param pattern The extracted regex pattern from the URI template (e.g., "[a-z]+")
+     */
+    public record VarMetadata(
+        UriMatchVariable var,
+        String pattern
+    ) {
     }
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ElementUtils.java
@@ -40,7 +40,6 @@ import io.micronaut.http.annotation.RequestAttribute;
 import io.micronaut.http.annotation.RequestBean;
 import io.micronaut.http.multipart.FileUpload;
 import io.micronaut.http.uri.UriMatchTemplate;
-import io.micronaut.http.uri.UriMatchVariable;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -49,6 +48,7 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.openapi.annotation.OpenAPIRequest;
+import io.micronaut.openapi.visitor.AbstractOpenApiEndpointVisitor.VarMetadata;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -233,8 +233,8 @@ public final class ElementUtils {
 
     public static boolean isExtraBodyParameter(@NonNull TypedElement parameter, boolean permitsRequestBody,
                                                List<UriMatchTemplate> matchTemplates,
-                                               Map<String, UriMatchVariable> pathVariables,
-                                               Map<String, UriMatchVariable> queryParams) {
+                                               Map<String, VarMetadata> pathVariables,
+                                               Map<String, VarMetadata> queryParams) {
 
         if (isWrappedBodyParameter(parameter)) {
             return false;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/UrlUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/UrlUtils.java
@@ -194,16 +194,22 @@ public final class UrlUtils {
                 continue;
             }
 
+            // 1. Identify segment type and check for greedy operator '*'
             SegmentType type = nextChar == '/' ? OPT_VAR : REQ_VAR;
+            var startBlockPos = varStartPos;
+            // Skip '/' for optional variables like {/path}
+            if (pathString.charAt(startBlockPos + 1) == '/') {
+                startBlockPos++;
+            }
+            // Skip '*' for greedy variables like {*path}
+            if (pathString.charAt(startBlockPos + 1) == '*') {
+                startBlockPos++;
+            }
 
             if (!constSegment.isEmpty()) {
                 addConstValue(constSegment, segments);
             }
 
-            var startBlockPos = varStartPos;
-            if (pathString.charAt(startBlockPos + 1) == '/') {
-                startBlockPos++;
-            }
             for (; ; ) {
                 var dotPos = pathString.indexOf(',', startBlockPos + 1);
                 var dotPos2 = pathString.indexOf(':', startBlockPos + 1);

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiControllerVisitorSpec.groovy
@@ -3135,24 +3135,24 @@ class MyBean {}
 
         then:
         op1
-        var paramA = op1.parameters.find {it.name == 'a' }
+        var paramA = op1.parameters.find { it.name == 'a' }
         paramA
         paramA.name == 'a'
         paramA.schema.type == 'array'
         paramA.schema.items.type == 'string'
 
-        var paramB = op1.parameters.find {it.name == 'b' }
+        var paramB = op1.parameters.find { it.name == 'b' }
         paramB.name == 'b'
         paramB.schema.type == 'array'
         paramB.schema.items.type == 'string'
 
         op2
-        var paramArg1 = op2.parameters.find {it.name == 'arg1' }
+        var paramArg1 = op2.parameters.find { it.name == 'arg1' }
         paramArg1
         paramArg1.name == 'arg1'
         paramArg1.schema.type == 'string'
 
-        var paramArg2 = op2.parameters.find {it.name == 'arg2' }
+        var paramArg2 = op2.parameters.find { it.name == 'arg2' }
         paramArg2
         paramArg2.name == 'arg2'
         paramArg2.schema.type == 'integer'
@@ -3245,5 +3245,137 @@ class MyBean {}
         openApi.components.schemas.MyDto.properties.payload.format == "byte"
         openApi.components.schemas.MyDto.properties.payload2.type == "string"
         !openApi.components.schemas.MyDto.properties.payload2.format
+    }
+
+    void "test controller interpretation - inline parameter validation"() {
+        given:
+        buildBeanDefinition('test.ValidationController', '''
+package test;
+
+import io.micronaut.http.annotation.*;
+import jakarta.validation.constraints.*;
+import jakarta.inject.Singleton;
+
+@Controller("/validation")
+class ValidationController {
+
+    /**
+     * Testing numeric constraints on query parameters.
+     */
+    @Get("/limit")
+    public String checkLimit(
+        @QueryValue @Min(1) @Max(100) int limit,
+        @QueryValue(defaultValue = "10") int offset
+    ) {
+        return "ok";
+    }
+
+    /**
+     * Testing string constraints and regex extraction from path variable.
+     */
+    @Get("/user/{username:[a-z]+}")
+    public String getUser(
+        @PathVariable @Size(min = 3, max = 20) String username
+    ) {
+        return username;
+    }
+
+    /**
+     * Testing format mapping for email and required status for NotBlank.
+     */
+    @Post("/subscribe")
+    public String subscribe(
+        @QueryValue @Email @NotBlank String email
+    ) {
+        return email;
+    }
+}
+''')
+        when:
+        var openApi = Utils.testReference
+
+        then:
+        // --- 1. Verify Numeric Constraints ---
+        var limitOp = openApi.paths."/validation/limit".get
+        var limitParam = limitOp.parameters.find { it.name == 'limit' }
+
+        limitParam.schema.minimum == 1
+        limitParam.schema.maximum == 100
+        limitParam.required == true
+
+        var offsetParam = limitOp.parameters.find { it.name == 'offset' }
+        // The processor should convert "10" string to Integer
+        offsetParam.schema.default instanceof Integer
+        offsetParam.schema.default == 10
+        offsetParam.required != true
+
+        // --- 2. Verify String Constraints & Path Regex ---
+        var userOp = openApi.paths."/validation/user/{username}".get
+        var userParam = userOp.parameters.find { it.name == 'username' }
+
+        userParam.in == 'path'
+        userParam.required == true
+        userParam.schema.minLength == 3
+        userParam.schema.maxLength == 20
+        // The regex from path template {username:[a-z]+} must be extracted to 'pattern'
+        userParam.schema.pattern == "[a-z]+"
+
+        // --- 3. Verify Email Format ---
+        var subOp = openApi.paths."/validation/subscribe".post
+        var emailParam = subOp.parameters.find { it.name == 'email' }
+
+        emailParam.required == true
+        emailParam.schema.format == 'email'
+    }
+
+    void "test controller interpretation - path templates and greedy variables"() {
+        given:
+        buildBeanDefinition('test.PathController', '''
+package test;
+
+import io.micronaut.http.annotation.*;
+import jakarta.inject.Singleton;
+
+@Controller("/path")
+class PathController {
+
+    /**
+     * Testing multiple variables in a single path segment with a hyphen.
+     */
+    @Get("/archive/{year}-{month}")
+    public String getArchive(@PathVariable int year, @PathVariable String month) {
+        return year + "/" + month;
+    }
+
+    /**
+     * Testing greedy path variable interpretation (*path).
+     */
+    @Get("/files/{*path}")
+    public String getFile(@PathVariable String path) {
+        return path;
+    }
+}
+
+@Singleton
+class MyBean {}
+''')
+
+        when:
+        var openApi = Utils.testReference
+
+        then:
+        // --- 1. Verify Multi-Variable Segment ---
+        // Path segment with hyphens: /path/archive/{year}-{month}
+        var archiveOp = openApi.paths['/path/archive/{year}-{month}'].get
+        archiveOp.parameters.any { it.name == 'year' && it.in == 'path' }
+        archiveOp.parameters.any { it.name == 'month' && it.in == 'path' }
+
+        // --- 2. Verify Greedy Path ({*path}) ---
+        // Micronaut's {*path} should be normalized to {path} in OpenAPI path key
+        var fileOp = openApi.paths['/path/files/{path}'].get
+        var pathParam = fileOp.parameters.find { it.name == 'path' }
+
+        pathParam != null
+        pathParam.in == 'path'
     }
 }


### PR DESCRIPTION
Also fixed interpret paths with star, like this: `/my/path/{*var}`