### PR TITLE
Restore application.yml config for OpenAPI processors

### DIFF
--- a/openapi/build.gradle.kts
+++ b/openapi/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(mn.micronaut.core)
     implementation(mn.micronaut.inject)
     implementation(mn.micronaut.http)
+    implementation(mn.snakeyaml)
 
     api(projects.micronautOpenapiAnnotations)
     api(projects.micronautOpenapiCommon)

--- a/openapi/build.gradle.kts
+++ b/openapi/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(mn.micronaut.core)
     implementation(mn.micronaut.inject)
     implementation(mn.micronaut.http)
-    implementation(mn.snakeyaml)
+    runtimeOnly(mn.snakeyaml)
 
     api(projects.micronautOpenapiAnnotations)
     api(projects.micronautOpenapiCommon)

--- a/test-suite-spring-kotlin-kapt/src/main/kotlin/io/micronaut/openapi/spring/api/dto/User.kt
+++ b/test-suite-spring-kotlin-kapt/src/main/kotlin/io/micronaut/openapi/spring/api/dto/User.kt
@@ -3,5 +3,6 @@ package io.micronaut.openapi.spring.api.dto
 class User(
     var id: Long = 0,
     var name: String? = null,
+    var displayName: String? = null,
     var age: Int = 0,
 )

--- a/test-suite-spring-kotlin-kapt/src/main/resources/application.yml
+++ b/test-suite-spring-kotlin-kapt/src/main/resources/application.yml
@@ -4,6 +4,12 @@ spring:
   main:
     banner-mode: off
 
+micronaut:
+  openapi:
+    property:
+      naming:
+        strategy: SNAKE_CASE
+
 server:
   port: 8091
 

--- a/test-suite-spring-kotlin-kapt/src/test/kotlin/io/micronaut/openapi/spring/OpenApiExposedTest.kt
+++ b/test-suite-spring-kotlin-kapt/src/test/kotlin/io/micronaut/openapi/spring/OpenApiExposedTest.kt
@@ -47,6 +47,18 @@ class OpenApiExposedTest {
 
     @Test
     @Throws(IOException::class)
+    fun testOpenApiSpecUsesApplicationYml() {
+        javaClass.getResourceAsStream("/META-INF/swagger/" + TestConfig.APP_NAME + '-' + TestConfig.APP_VERSION + ".yml")
+            .use {
+                assertNotNull(it)
+                val openApiSpec = String(it!!.readAllBytes())
+                assertTrue(openApiSpec.contains("display_name:"))
+                assertFalse(openApiSpec.contains("displayName:"))
+            }
+    }
+
+    @Test
+    @Throws(IOException::class)
     fun testSwaggerUiEndpoint() {
         val openApiSpec: String
         javaClass.getResourceAsStream("/META-INF/swagger/views/swagger-ui/index.html")

--- a/test-suite-spring-kotlin-ksp/build.gradle.kts
+++ b/test-suite-spring-kotlin-ksp/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     ksp(mnSpring.micronaut.spring.web.annotation)
     ksp(mnSpring.micronaut.spring.boot.annotation)
     ksp(mn.micronaut.inject.kotlin)
-    ksp(mn.snakeyaml)
     ksp(projects.micronautOpenapi)
 
     compileOnly(projects.micronautOpenapiAnnotations)

--- a/test-suite-spring-kotlin-ksp/src/main/kotlin/io/micronaut/openapi/spring/api/dto/User.kt
+++ b/test-suite-spring-kotlin-ksp/src/main/kotlin/io/micronaut/openapi/spring/api/dto/User.kt
@@ -3,5 +3,6 @@ package io.micronaut.openapi.spring.api.dto
 class User(
     var id: Long = 0,
     var name: String? = null,
+    var displayName: String? = null,
     var age: Int = 0,
 )

--- a/test-suite-spring-kotlin-ksp/src/main/resources/application.yml
+++ b/test-suite-spring-kotlin-ksp/src/main/resources/application.yml
@@ -4,6 +4,12 @@ spring:
   main:
     banner-mode: off
 
+micronaut:
+  openapi:
+    property:
+      naming:
+        strategy: SNAKE_CASE
+
 server:
   port: 8092
 

--- a/test-suite-spring-kotlin-ksp/src/test/kotlin/io/micronaut/openapi/spring/OpenApiExposedTest.kt
+++ b/test-suite-spring-kotlin-ksp/src/test/kotlin/io/micronaut/openapi/spring/OpenApiExposedTest.kt
@@ -2,7 +2,9 @@ package io.micronaut.openapi.spring
 
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -33,6 +35,8 @@ class OpenApiExposedTest {
                 assertNotNull(it)
                 openApiSpec = String(it!!.readAllBytes())
             }
+        assertTrue(openApiSpec.contains("display_name:"))
+        assertFalse(openApiSpec.contains("displayName:"))
         val recievedOpenApiSpec = AtomicReference<String>()
 
         assertDoesNotThrow {


### PR DESCRIPTION
## Summary
- Add SnakeYAML as a transitive dependency of micronaut-openapi so annotation processing can load application.yml without user-side ksp/kapt SnakeYAML dependencies.
- Cover KSP and KAPT application.yml configuration with a naming-strategy regression test.
- Remove the explicit KSP SnakeYAML dependency from the Spring KSP test suite to prove micronaut-openapi supplies YAML loading.

Closes #2729
