### PR TITLE
Use generated files for default OpenAPI resources

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
+++ b/openapi/src/main/java/io/micronaut/openapi/view/OpenApiViewConfig.java
@@ -21,6 +21,7 @@ import io.micronaut.core.io.scan.DefaultClassPathResourceLoader;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.openapi.visitor.ConfigUtils;
 import io.micronaut.openapi.visitor.ContextUtils;
 import io.micronaut.openapi.visitor.Pair;
@@ -46,6 +47,7 @@ import static io.micronaut.openapi.visitor.ConfigUtils.getProjectPath;
 import static io.micronaut.openapi.visitor.ContextUtils.addGeneratedResource;
 import static io.micronaut.openapi.visitor.ContextUtils.info;
 import static io.micronaut.openapi.visitor.ContextUtils.warn;
+import static io.micronaut.openapi.visitor.ContextUtils.visitMetaInfFile;
 import static io.micronaut.openapi.visitor.FileUtils.CLASSPATH_SCHEME;
 import static io.micronaut.openapi.visitor.FileUtils.FILE_SCHEME;
 import static io.micronaut.openapi.visitor.FileUtils.PROJECT_SCHEME;
@@ -237,6 +239,126 @@ public final class OpenApiViewConfig {
                 render(swaggerUIConfig, swaggerUiDir, TEMPLATES + SLASH + TEMPLATES_SWAGGER_UI + SLASH + TEMPLATE_OAUTH_2_REDIRECT_HTML, context);
             }
             copySwaggerUiTheme(swaggerUIConfig, swaggerUiDir, TEMPLATES_SWAGGER_UI, context);
+        }
+    }
+
+    /**
+     * Generates views as META-INF resources through the visitor context.
+     *
+     * @param context The visitor context
+     * @param basePath The META-INF-relative base path
+     * @param originatingElements The elements contributing to the generated views
+     * @throws IOException If a resource cannot be generated
+     * @since 7.1.1
+     */
+    public void renderMetaInf(VisitorContext context, String basePath, Element... originatingElements) throws IOException {
+        if (redocConfig != null) {
+            generatedCopyResources(context, basePath, REDOC, TEMPLATES_REDOC, redocConfig, redocConfig.rapiPDFConfig, originatingElements);
+        }
+        if (rapidocConfig != null) {
+            generatedCopyResources(context, basePath, RAPIDOC, TEMPLATES_RAPIDOC, rapidocConfig, rapidocConfig.rapiPDFConfig, originatingElements);
+        }
+        if (openApiExplorerConfig != null) {
+            generatedRender(openApiExplorerConfig, context, basePath + SLASH + OPENAPI_EXPLORER,
+                TEMPLATES + SLASH + TEMPLATES_OPENAPI_EXPLORER + SLASH + TEMPLATE_INDEX_HTML, originatingElements);
+            generatedCopyResources(openApiExplorerConfig, context, basePath + SLASH + OPENAPI_EXPLORER,
+                TEMPLATES_OPENAPI_EXPLORER, openApiExplorerConfig.getResources(), originatingElements);
+            if (openApiExplorerConfig.rapiPDFConfig.enabled) {
+                generatedCopyResources(openApiExplorerConfig.rapiPDFConfig, context, basePath + SLASH + OPENAPI_EXPLORER,
+                    TEMPLATES_RAPIPDF, openApiExplorerConfig.rapiPDFConfig.getResources(), originatingElements);
+            }
+        }
+        if (scalarConfig != null) {
+            generatedRender(scalarConfig, context, basePath + SLASH + SCALAR,
+                TEMPLATES + SLASH + TEMPLATES_SCALAR + SLASH + TEMPLATE_INDEX_HTML, originatingElements);
+            generatedCopyResources(scalarConfig, context, basePath + SLASH + SCALAR,
+                TEMPLATES_SCALAR, scalarConfig.getResources(), originatingElements);
+            if (scalarConfig.rapiPDFConfig.enabled) {
+                generatedCopyResources(scalarConfig.rapiPDFConfig, context, basePath + SLASH + SCALAR,
+                    TEMPLATES_RAPIPDF, scalarConfig.rapiPDFConfig.getResources(), originatingElements);
+            }
+        }
+        if (swaggerUIConfig != null) {
+            generatedCopyResources(context, basePath, SWAGGER_UI, TEMPLATES_SWAGGER_UI,
+                swaggerUIConfig, swaggerUIConfig.rapiPDFConfig, originatingElements);
+            if (SwaggerUIConfig.hasOauth2Option(swaggerUIConfig.options)) {
+                generatedRender(swaggerUIConfig, context, basePath + SLASH + SWAGGER_UI,
+                    TEMPLATES + SLASH + TEMPLATES_SWAGGER_UI + SLASH + TEMPLATE_OAUTH_2_REDIRECT_HTML, originatingElements);
+            }
+            generatedCopyTheme(swaggerUIConfig, context, basePath + SLASH + SWAGGER_UI, originatingElements);
+        }
+    }
+
+    private void generatedCopyResources(VisitorContext context, String basePath, String otherDir, String templates,
+                                        AbstractViewConfig viewConfig, AbstractViewConfig rapidPDFConfig,
+                                        Element... originatingElements) throws IOException {
+        generatedRender(viewConfig, context, basePath + SLASH + otherDir,
+            TEMPLATES + SLASH + templates + SLASH + TEMPLATE_INDEX_HTML, originatingElements);
+        generatedCopyResources(viewConfig, context, basePath + SLASH + otherDir, templates,
+            viewConfig.getResources(), originatingElements);
+        if (rapidPDFConfig.isEnabled()) {
+            generatedCopyResources(rapidPDFConfig, context, basePath + SLASH + otherDir,
+                TEMPLATES_RAPIPDF, rapidPDFConfig.getResources(), originatingElements);
+        }
+    }
+
+    private void generatedCopyTheme(SwaggerUIConfig cfg, VisitorContext context, String outputDir,
+                                    Element... originatingElements) throws IOException {
+        if (!cfg.copyTheme) {
+            return;
+        }
+        String themeFileName = cfg.theme.getCss() + ".css";
+        String resource = outputDir + SLASH + RESOURCE_DIR + SLASH + themeFileName;
+        copyGeneratedResource(context, resource, TEMPLATES + SLASH + TEMPLATES_SWAGGER_UI + SLASH + THEMES_DIR + SLASH + themeFileName, originatingElements);
+    }
+
+    private void generatedCopyResources(AbstractViewConfig cfg, VisitorContext context, String outputDir,
+                                        String templateDir, List<String> resources,
+                                        Element... originatingElements) throws IOException {
+        if (!cfg.copyResources || CollectionUtils.isEmpty(resources)) {
+            return;
+        }
+        for (String resource : resources) {
+            copyGeneratedResource(context, outputDir + SLASH + resource,
+                TEMPLATES + SLASH + templateDir + SLASH + resource, originatingElements);
+        }
+    }
+
+    private void generatedRender(AbstractViewConfig cfg, VisitorContext context, String outputDir,
+                                 String templateName, Element... originatingElements) throws IOException {
+        String template = StringUtils.isEmpty(cfg.templatePath)
+            ? readTemplateFromClasspath(templateName)
+            : readTemplateFromCustomPath(cfg.templatePath, context);
+        cfg.specUrl = getSpecURL(cfg, context);
+        template = replacePlaceHolder(replacePlaceHolder(cfg.render(template, context), "specURL", cfg.specUrl), "title", title);
+        String fileName = templateName.substring(templateName.lastIndexOf(SLASH) + 1);
+        writeGeneratedResource(context, outputDir + SLASH + fileName, template, originatingElements);
+    }
+
+    private void copyGeneratedResource(VisitorContext context, String path, String classpathResource,
+                                       Element... originatingElements) throws IOException {
+        try (var is = getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+            if (is == null) {
+                throw new IOException("Missing resource: " + classpathResource);
+            }
+            var file = visitMetaInfFile(path, context, originatingElements);
+            if (file == null) {
+                throw new IOException("Unable to create resource: " + path);
+            }
+            try (var outputStream = file.openOutputStream()) {
+                is.transferTo(outputStream);
+            }
+        }
+    }
+
+    private void writeGeneratedResource(VisitorContext context, String path, String content,
+                                        Element... originatingElements) throws IOException {
+        var file = visitMetaInfFile(path, context, originatingElements);
+        if (file == null) {
+            throw new IOException("Unable to create resource: " + path);
+        }
+        try (var writer = file.openWriter()) {
+            writer.write(content);
         }
     }
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -224,6 +224,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {
             return;
         }
+        ContextUtils.addOriginatingElement(element, context);
         if (ignore(element, context)) {
             return;
         }
@@ -437,6 +438,7 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {
             return;
         }
+        ContextUtils.addOriginatingElement(element, context);
         if (ignore(element, context)) {
             return;
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AdocModule.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AdocModule.java
@@ -17,24 +17,25 @@ package io.micronaut.openapi.visitor;
 
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.openapi.adoc.OpenApiToAdocConverter;
 import io.micronaut.openapi.visitor.group.OpenApiInfo;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
-import static io.micronaut.openapi.visitor.ContextUtils.addGeneratedResource;
 import static io.micronaut.openapi.visitor.ContextUtils.info;
+import static io.micronaut.openapi.visitor.ContextUtils.visitMetaInfFile;
 import static io.micronaut.openapi.visitor.ContextUtils.warn;
 import static io.micronaut.openapi.visitor.FileUtils.EXT_ADOC;
 import static io.micronaut.openapi.visitor.FileUtils.EXT_JSON;
 import static io.micronaut.openapi.visitor.FileUtils.EXT_YAML;
 import static io.micronaut.openapi.visitor.FileUtils.EXT_YML;
 import static io.micronaut.openapi.visitor.FileUtils.createDirectories;
-import static io.micronaut.openapi.visitor.FileUtils.getDefaultFilePath;
 import static io.micronaut.openapi.visitor.FileUtils.resolve;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_OUTPUT_FILENAME;
@@ -45,6 +46,8 @@ import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENA
  * @since 5.2.0
  */
 public final class AdocModule {
+
+    private static final String GENERATED_ADOC_CONTENT = "io.micronaut.OPENAPI.generated.adoc.content.";
 
     private AdocModule() {
     }
@@ -57,6 +60,18 @@ public final class AdocModule {
      * @param context visitor context
      */
     public static void convert(OpenApiInfo openApiInfo, Map<String, String> props, VisitorContext context) {
+        convert(openApiInfo, props, context, Element.EMPTY_ELEMENT_ARRAY);
+    }
+
+    /**
+     * Convert and save to file openAPI object in adoc format.
+     *
+     * @param openApiInfo openApiInfo object
+     * @param props openapi-adoc properties
+     * @param context visitor context
+     * @param originatingElements elements contributing to the generated document
+     */
+    static void convert(OpenApiInfo openApiInfo, Map<String, String> props, VisitorContext context, Element... originatingElements) {
 
         try {
             var writer = new StringWriter();
@@ -64,19 +79,29 @@ public final class AdocModule {
 
             var adoc = writer.toString();
 
-            var outputPath = getOutputPath(openApiInfo, props, context);
-            info("Writing AsciiDoc OpenAPI file to destination: " + outputPath, context);
-            var classesOutputPath = ContextUtils.getClassesOutputPath(context);
-            if (classesOutputPath != null) {
-                // add relative paths for the specPath, and its parent META-INF/swagger
-                // so that micronaut-graal visitor knows about them
-                addGeneratedResource(classesOutputPath.relativize(outputPath).toString(), context);
-            }
-
-            if (Files.exists(outputPath)) {
-                Files.writeString(outputPath, adoc, StandardOpenOption.APPEND);
+            var outputDir = props.get(MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH);
+            if (StringUtils.isEmpty(outputDir)) {
+                var fileName = getFileName(openApiInfo, props);
+                var generatedFile = visitMetaInfFile("swagger/" + fileName, context, originatingElements);
+                if (generatedFile == null) {
+                    throw new IOException("Unable to create AsciiDoc resource: " + fileName);
+                }
+                var generatedContentKey = GENERATED_ADOC_CONTENT + fileName;
+                var previousContent = ContextUtils.get(generatedContentKey, String.class, null, context);
+                var generatedContent = previousContent == null ? adoc : previousContent + adoc;
+                try (var generatedWriter = generatedFile.openWriter()) {
+                    generatedWriter.write(generatedContent);
+                }
+                ContextUtils.put(generatedContentKey, generatedContent, context);
+                info("Writing AsciiDoc OpenAPI file to destination: " + generatedFile.toURI(), context);
             } else {
-                Files.writeString(outputPath, adoc);
+                var outputPath = getOutputPath(openApiInfo, props, context);
+                info("Writing AsciiDoc OpenAPI file to destination: " + outputPath, context);
+                if (Files.exists(outputPath)) {
+                    Files.writeString(outputPath, adoc, StandardOpenOption.APPEND);
+                } else {
+                    Files.writeString(outputPath, adoc);
+                }
             }
         } catch (Exception e) {
             warn("Can't convert to Adoc format\n" + Utils.printStackTrace(e), context);
@@ -84,7 +109,15 @@ public final class AdocModule {
     }
 
     private static Path getOutputPath(OpenApiInfo openApiInfo, Map<String, String> props, VisitorContext context) {
+        var fileName = getFileName(openApiInfo, props);
+        String outputDir = props.get(MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH);
+        Path outputPath = resolve(context, Path.of(outputDir));
+        outputPath = outputPath.resolve(fileName);
+        createDirectories(outputPath, context);
+        return outputPath;
+    }
 
+    private static String getFileName(OpenApiInfo openApiInfo, Map<String, String> props) {
         var fileName = props.get(MICRONAUT_OPENAPI_ADOC_OUTPUT_FILENAME);
         if (StringUtils.isEmpty(fileName)) {
 
@@ -97,22 +130,6 @@ public final class AdocModule {
             }
             fileName += EXT_ADOC;
         }
-
-        Path outputPath;
-        String outputDir = props.get(MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH);
-        if (StringUtils.isNotEmpty(outputDir)) {
-            outputPath = resolve(context, Path.of(outputDir));
-        } else {
-            var defaultFilePath = getDefaultFilePath(fileName, context);
-            if (defaultFilePath == null) {
-                warn("Can't read defaultFilePath property", context);
-                throw new RuntimeException("Can't read defaultFilePath property");
-            }
-            outputPath = defaultFilePath.getParent();
-        }
-        outputPath = outputPath.resolve(fileName);
-        createDirectories(outputPath, context);
-
-        return outputPath;
+        return fileName;
     }
 }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AdocModule.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AdocModule.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
+import static io.micronaut.openapi.visitor.ContextUtils.addGeneratedResource;
 import static io.micronaut.openapi.visitor.ContextUtils.info;
 import static io.micronaut.openapi.visitor.ContextUtils.visitMetaInfFile;
 import static io.micronaut.openapi.visitor.ContextUtils.warn;
@@ -86,6 +87,8 @@ public final class AdocModule {
                 if (generatedFile == null) {
                     throw new IOException("Unable to create AsciiDoc resource: " + fileName);
                 }
+                addGeneratedResource("swagger/" + fileName, context);
+                addGeneratedResource("swagger", context);
                 var generatedContentKey = GENERATED_ADOC_CONTENT + fileName;
                 var previousContent = ContextUtils.get(generatedContentKey, String.class, null, context);
                 var generatedContent = previousContent == null ? adoc : previousContent + adoc;

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/ContextUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/ContextUtils.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.tags.Tag;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -64,6 +65,8 @@ public final class ContextUtils {
     };
     public static final Argument<Map<String, EndpointProperties>> ARGUMENT_ENDPOINT_PROPERTIES_MAP = new GenericArgument<>() {
     };
+
+    private static final String ORIGINATING_ELEMENTS = "io.micronaut.OPENAPI.originating.elements";
 
     private ContextUtils() {
     }
@@ -155,16 +158,61 @@ public final class ContextUtils {
     }
 
     public static GeneratedFile visitMetaInfFile(String path, VisitorContext context) {
+        return visitMetaInfFile(path, context, false, Element.EMPTY_ELEMENT_ARRAY);
+    }
+
+    /**
+     * Locate or create a META-INF resource and associate it with the contributing elements.
+     *
+     * @param path The META-INF-relative resource path
+     * @param context The visitor context
+     * @param originatingElements The elements contributing to the resource
+     * @return The generated file, or {@code null} when the visitor context cannot create it
+     */
+    public static GeneratedFile visitMetaInfFile(String path, VisitorContext context, Element... originatingElements) {
+        return visitMetaInfFile(path, context, true, originatingElements);
+    }
+
+    private static GeneratedFile visitMetaInfFile(String path, VisitorContext context, boolean allowMemory, Element... originatingElements) {
         var generatedFile = get(MICRONAUT_INTERNAL_GENERATED_FILE + "META-INF/" + path, GeneratedFile.class, null, context);
         if (generatedFile == null) {
-            generatedFile = context.visitMetaInfFile(path, Element.EMPTY_ELEMENT_ARRAY).orElse(null);
-            if (generatedFile == null || (generatedFile.toURI().getScheme() != null && generatedFile.toURI().getScheme().equals("mem"))) {
+            generatedFile = context.visitMetaInfFile(path, originatingElements).orElse(null);
+            if (generatedFile == null || (!allowMemory && generatedFile.toURI().getScheme() != null && generatedFile.toURI().getScheme().equals("mem"))) {
                 return null;
             }
             put(MICRONAUT_INTERNAL_GENERATED_FILE + "META-INF/" + path, generatedFile, context);
         }
         calcProjectPath(generatedFile, context);
         return generatedFile;
+    }
+
+    /**
+     * Records an element contributing to the OpenAPI output for the current visitor context.
+     *
+     * @param element The contributing element
+     * @param context The visitor context
+     */
+    public static void addOriginatingElement(Element element, VisitorContext context) {
+        if (element == null) {
+            return;
+        }
+        var elements = get(ORIGINATING_ELEMENTS, LinkedHashSet.class, null, context);
+        if (elements == null) {
+            elements = new LinkedHashSet<>();
+            put(ORIGINATING_ELEMENTS, elements, context);
+        }
+        elements.add(element);
+    }
+
+    /**
+     * Returns the deduplicated elements contributing to the current OpenAPI output.
+     *
+     * @param context The visitor context
+     * @return The contributing elements in their deterministic insertion order
+     */
+    public static Element[] getOriginatingElements(VisitorContext context) {
+        var elements = get(ORIGINATING_ELEMENTS, LinkedHashSet.class, null, context);
+        return elements == null ? Element.EMPTY_ELEMENT_ARRAY : (Element[]) elements.toArray(new Element[0]);
     }
 
     public static Path getProjectDir(VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -25,6 +25,7 @@ import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.inject.writer.GeneratedFile;
 import io.micronaut.openapi.OpenApiUtils;
 import io.micronaut.openapi.annotation.OpenAPIGroupInfo;
 import io.micronaut.openapi.annotation.OpenAPIGroupInfos;
@@ -102,6 +103,8 @@ import static io.micronaut.openapi.visitor.ContextProperty.MICRONAUT_INTERNAL_OP
 import static io.micronaut.openapi.visitor.ContextProperty.MICRONAUT_INTERNAL_OPENAPI_ENDPOINT_SECURITY_REQUIREMENTS;
 import static io.micronaut.openapi.visitor.ContextProperty.MICRONAUT_INTERNAL_OPENAPI_ENDPOINT_SERVERS;
 import static io.micronaut.openapi.visitor.ContextUtils.addGeneratedResource;
+import static io.micronaut.openapi.visitor.ContextUtils.addOriginatingElement;
+import static io.micronaut.openapi.visitor.ContextUtils.getOriginatingElements;
 import static io.micronaut.openapi.visitor.ContextUtils.info;
 import static io.micronaut.openapi.visitor.ContextUtils.put;
 import static io.micronaut.openapi.visitor.ContextUtils.remove;
@@ -114,7 +117,7 @@ import static io.micronaut.openapi.visitor.FileUtils.PROJECT_SCHEME;
 import static io.micronaut.openapi.visitor.FileUtils.calcFinalFilename;
 import static io.micronaut.openapi.visitor.FileUtils.getViewsDestDir;
 import static io.micronaut.openapi.visitor.FileUtils.normalizePath;
-import static io.micronaut.openapi.visitor.FileUtils.openApiSpecFile;
+import static io.micronaut.openapi.visitor.FileUtils.userDefinedSpecFile;
 import static io.micronaut.openapi.visitor.FileUtils.readFile;
 import static io.micronaut.openapi.visitor.FileUtils.resolve;
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.ALL;
@@ -179,6 +182,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             if (ignore(element)) {
                 return;
             }
+            addOriginatingElement(element, context);
             incrementVisitedElements(context);
 
             info("Generating OpenAPI Documentation", context);
@@ -933,15 +937,25 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     }
 
     private void generateViews(@Nullable String documentTitle, @Nullable Map<Pair<String, String>, OpenApiInfo> openApiInfos, VisitorContext context) {
-        Path viewsDestDirs = getViewsDestDir(context);
-        if (viewsDestDirs == null) {
-            return;
-        }
         String viewSpecification = getConfigProperty(MICRONAUT_OPENAPI_VIEWS_SPEC, context);
         OpenApiViewConfig cfg = OpenApiViewConfig.fromSpecification(viewSpecification, openApiInfos, readOpenApiConfigFile(context), context);
         if (!cfg.isEnabled()) {
             return;
         }
+        String configuredViewsDestDir = getConfigProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_VIEWS_DEST_DIR, context);
+        if (StringUtils.isEmpty(configuredViewsDestDir)) {
+            try {
+                cfg.setTitle(documentTitle);
+                if (CollectionUtils.isNotEmpty(openApiInfos)) {
+                    cfg.setSpecFile(openApiInfos.values().iterator().next().getSpecFilePath());
+                }
+                cfg.renderMetaInf(context, "swagger/views", getOriginatingElements(context));
+            } catch (Exception e) {
+                warn("Unable to render OpenAPI views: " + e.getMessage() + ".\n" + Utils.printStackTrace(e), context);
+            }
+            return;
+        }
+        Path viewsDestDirs = getViewsDestDir(context);
         if (context != null) {
             info("Writing OpenAPI views to destination: " + viewsDestDirs, context);
             var classesOutputPath = ContextUtils.getClassesOutputPath(context);
@@ -980,8 +994,16 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         var objectMapper = isYaml ? Utils.getYamlMapper() : Utils.getJsonMapper();
 
         for (OpenApiInfo openApiInfo : openApiInfos.values()) {
-            Path specFile = openApiSpecFile(openApiInfo.getFilename(), context);
-            try (Writer writer = getFileWriter(specFile)) {
+            var targetFile = userDefinedSpecFile(context);
+            GeneratedFile generatedFile = null;
+            Path specFile = targetFile;
+            if (!Utils.isTestMode() && targetFile == null) {
+                generatedFile = ContextUtils.visitMetaInfFile("swagger/" + openApiInfo.getFilename(), context, getOriginatingElements(context));
+                if (generatedFile == null) {
+                    throw new IllegalStateException("Unable to create OpenAPI resource: " + openApiInfo.getFilename());
+                }
+            }
+            try (Writer writer = generatedFile != null ? generatedFile.openWriter() : getFileWriter(specFile)) {
                 objectMapper.writeValue(writer, openApiInfo.getOpenApi());
                 if (Utils.isTestMode()) {
                     Utils.setTestFileName(openApiInfo.getFilename());
@@ -991,19 +1013,19 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
                         Utils.setTestJsonReference(writer.toString());
                     }
                 } else {
-                    info("Writing OpenAPI file to destination: " + specFile, context);
+                    info("Writing OpenAPI file to destination: " + (generatedFile != null ? generatedFile.toURI() : specFile), context);
                     var classesOutputPath = ContextUtils.getClassesOutputPath(context);
-                    if (classesOutputPath != null) {
+                    if (classesOutputPath != null && specFile != null) {
                         // add relative paths for the specFile, and its parent META-INF/swagger
                         // so that micronaut-graal visitor knows about them
                         addGeneratedResource(classesOutputPath.relativize(specFile).toString(), context);
                         addGeneratedResource(classesOutputPath.relativize(specFile.getParent()).toString(), context);
                     }
-                    openApiInfo.setSpecFilePath(specFile.getFileName().toString());
+                    openApiInfo.setSpecFilePath(specFile != null ? specFile.getFileName().toString() : openApiInfo.getFilename());
                 }
                 if (isAdocModuleInClassPath && isGlobalAdocEnabled && openApiInfo.isAdocEnabled()) {
                     var adocProperties = getAdocProperties(openApiInfo, openApiInfos.size() == 1, context);
-                    AdocModule.convert(openApiInfo, adocProperties, context);
+                    AdocModule.convert(openApiInfo, adocProperties, context, getOriginatingElements(context));
                 }
             } catch (Exception e) {
                 warn("Unable to generate swagger" + (isYaml ? EXT_YML : EXT_JSON) + ": " + specFile + " - " + e.getMessage() + ".\n" + Utils.printStackTrace(e), context);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -949,6 +949,9 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
                 if (CollectionUtils.isNotEmpty(openApiInfos)) {
                     cfg.setSpecFile(openApiInfos.values().iterator().next().getSpecFilePath());
                 }
+                // Keep the generated-resource metadata for native-image processing in sync with the output path.
+                addGeneratedResource("swagger/views", context);
+                addGeneratedResource("swagger", context);
                 cfg.renderMetaInf(context, "swagger/views", getOriginatingElements(context));
             } catch (Exception e) {
                 warn("Unable to render OpenAPI views: " + e.getMessage() + ".\n" + Utils.printStackTrace(e), context);
@@ -1002,6 +1005,8 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
                 if (generatedFile == null) {
                     throw new IllegalStateException("Unable to create OpenAPI resource: " + openApiInfo.getFilename());
                 }
+                addGeneratedResource("swagger/" + openApiInfo.getFilename(), context);
+                addGeneratedResource("swagger", context);
             }
             try (Writer writer = generatedFile != null ? generatedFile.openWriter() : getFileWriter(specFile)) {
                 objectMapper.writeValue(writer, openApiInfo.getOpenApi());

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiExtraSchemaVisitor.java
@@ -133,6 +133,7 @@ public class OpenApiExtraSchemaVisitor implements TypeElementVisitor<OpenAPIExtr
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context) || !isExtraSchemasEnabled(context)) {
             return;
         }
+        ContextUtils.addOriginatingElement(element, context);
 
         for (var extraSchemaAnn : element.getAnnotationValuesByType(OpenAPIExtraSchema.class)) {
             String[] classes = extraSchemaAnn.stringValues();
@@ -189,6 +190,7 @@ public class OpenApiExtraSchemaVisitor implements TypeElementVisitor<OpenAPIExtr
         if (classEl == null) {
             return;
         }
+        ContextUtils.addOriginatingElement(classEl, context);
 
         var nameFromAnn = getNameFromAnn(classEl);
         String schemaName = computeDefaultSchemaName(nameFromAnn, null, classEl, classEl.getTypeArguments(), context, null);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiGroupInfoVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiGroupInfoVisitor.java
@@ -80,6 +80,7 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {
             return;
         }
+        ContextUtils.addOriginatingElement(classEl, context);
 
         if (CollectionUtils.isNotEmpty(groups)) {
             Map<String, List<String>> includedClassesGroups = Utils.getIncludedClassesGroups();
@@ -102,6 +103,9 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
         PackageElement packageEl = classEl.getPackage();
         var classAnns = classEl.getAnnotationValuesByType(OpenAPIGroupInfo.class);
         var packageAnns = packageEl.getAnnotationValuesByType(OpenAPIGroupInfo.class);
+        if (CollectionUtils.isNotEmpty(classAnns) || CollectionUtils.isNotEmpty(packageAnns)) {
+            ContextUtils.addOriginatingElement(packageEl, context);
+        }
         if (CollectionUtils.isEmpty(classAnns) && CollectionUtils.isEmpty(packageAnns)) {
             return;
         }

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewMultipleDocumentsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewMultipleDocumentsSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.openapi.view
 
 import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.micronaut.openapi.visitor.Utils
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -80,5 +81,47 @@ class MyBean {}
         var scalarContent = scalarIndexPath.toFile().getText(StandardCharsets.UTF_8.displayName())
 
         scalarContent.contains("sources: [{title: \"api-v2\",url: contextPath + \"/swagger/service-1.0.0-api-v2.yml\",},{title: \"api-v1\",url: contextPath + \"/swagger/service-1.0.0-api-v1.yml\",default: true}],")
+    }
+
+    @RestoreSystemProperties
+    void "test default multiple documents and views are generated as classpath resources"() {
+
+        given:
+        System.clearProperty(Utils.ATTR_TEST_MODE)
+        System.setProperty(MICRONAUT_OPENAPI_GROUPS + ".api-v1.primary", "true")
+        System.setProperty(MICRONAUT_OPENAPI_VIEWS_SPEC, "swagger-ui.enabled=true,scalar.enabled=true")
+        System.clearProperty(MICRONAUT_OPENAPI_VIEWS_DEST_DIR)
+
+        when:
+        def classLoader = buildClassLoader('test.MyBean', '''
+package test;
+
+import io.micronaut.openapi.annotation.OpenAPIGroup;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@OpenAPIGroup("api-v1")
+@Controller
+class ApiV1Controller {
+    @Get("/v1/create")
+    String getPet() { return null; }
+}
+
+@OpenAPIGroup("api-v2")
+@Controller
+class ApiV2Controller {
+    @Get("/v2/create")
+    String getPet() { return null; }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        then:
+        classLoader.getResources('META-INF/swagger/service-1.0.0-api-v1.yml').toList().size() == 1
+        classLoader.getResources('META-INF/swagger/service-1.0.0-api-v2.yml').toList().size() == 1
+        classLoader.getResources('META-INF/swagger/views/swagger-ui/index.html').toList().size() == 1
+        classLoader.getResources('META-INF/swagger/views/scalar/index.html').toList().size() == 1
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/view/OpenApiViewSpec.groovy
@@ -20,6 +20,40 @@ class OpenApiViewSpec extends AbstractOpenApiTypeElementSpec {
     }
 
     @RestoreSystemProperties
+    void "test default views and specification are generated as classpath resources"() {
+        given:
+        System.clearProperty(Utils.ATTR_TEST_MODE)
+        System.setProperty(MICRONAUT_OPENAPI_VIEWS_SPEC, "swagger-ui.enabled=true")
+
+        when:
+        def classLoader = buildClassLoader('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(info = @Info(title = "the title", version = "0.0"))
+class Application {}
+
+@Controller("/hello")
+class HelloController {
+    @Get
+    String hello() { return "hello"; }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        then:
+        classLoader.getResources('META-INF/swagger/the-title-0.0.yml').toList().size() == 1
+        classLoader.getResources('META-INF/swagger/views/swagger-ui/index.html').toList().size() == 1
+        classLoader.getResources('META-INF/swagger/views/swagger-ui/res/swagger-ui.css').toList().size() == 1
+    }
+
+    @RestoreSystemProperties
     void "test disable generation spec and enabled views"() {
 
         given:

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiAdocModuleSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiAdocModuleSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import spock.util.environment.RestoreSystemProperties
 
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_ENABLED
 import static io.micronaut.openapi.visitor.OpenApiConfigProperty.MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH
@@ -135,5 +136,39 @@ class MyBean {}
 
         cleanup:
         System.clearProperty(MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH)
+    }
+
+    @RestoreSystemProperties
+    void "test default ADoc output is generated as a classpath resource"() {
+
+        given:
+        System.clearProperty(Utils.ATTR_TEST_MODE)
+        System.clearProperty(MICRONAUT_OPENAPI_ADOC_OUTPUT_DIR_PATH)
+        System.clearProperty(MICRONAUT_OPENAPI_ADOC_OUTPUT_FILENAME)
+
+        when:
+        def classLoader = buildClassLoader('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(info = @Info(title = "the title", version = "0.0"))
+class Application {}
+
+@Controller("/hello")
+class HelloController {
+    @Get
+    String hello() { return "hello"; }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        then:
+        classLoader.getResources('META-INF/swagger/the-title-0.0.adoc').toList().size() == 1
     }
 }


### PR DESCRIPTION
## Summary

- Generate default OpenAPI specifications, views, themes, and AsciiDoc through VisitorContext.visitMetaInfFile.
- Track contributing application, endpoint, group, version, and extra-schema elements for incremental compilation.
- Preserve explicit filesystem destinations and AsciiDoc append behavior.
- Add classloader-based coverage for default specifications, views, multiple documents, nested resources, and AsciiDoc output.

## Motivation

The current implementation writes files to the classes directory without javac being aware of those outputs. This breaks incremental compilation and also means the processor cannot be used in in-memory scenarios where there is no disk access.

## Verification

- ./gradlew :micronaut-openapi:test — 504 tests passed, 3 skipped
- ./gradlew :micronaut-openapi:spotlessCheck :micronaut-openapi:check
- ./gradlew check docs
- git diff --check