### PR TITLE
Fix OpenAPI incremental processing inputs

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/AbstractOpenApiEndpointVisitor.java
@@ -224,10 +224,10 @@ public abstract class AbstractOpenApiEndpointVisitor extends AbstractOpenApiVisi
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {
             return;
         }
-        ContextUtils.addOriginatingElement(element, context);
         if (ignore(element, context)) {
             return;
         }
+        ContextUtils.addOriginatingElement(element, context);
         incrementVisitedElements(context);
         processSecuritySchemes(element, context);
         processTags(element, context);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -174,6 +174,15 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     }
 
     @Override
+    public @NonNull Set<String> getSupportedAnnotationNames() {
+        return Set.of(
+            OpenAPIDefinition.class.getName(),
+            OpenAPIGroupInfo.class.getName(),
+            OpenAPIGroupInfos.class.getName()
+        );
+    }
+
+    @Override
     public void visitClass(@NonNull ClassElement element, @NonNull VisitorContext context) {
         try {
             if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -176,7 +176,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
     @Override
     public @NonNull Set<String> getSupportedAnnotationNames() {
         return Set.of(
-            OpenAPIDefinition.class.getName(),
+            "io.swagger.v3.oas.annotations.*",
             OpenAPIGroupInfo.class.getName(),
             OpenAPIGroupInfos.class.getName()
         );

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -110,7 +110,10 @@ public class OpenApiControllerVisitor extends AbstractOpenApiEndpointVisitor imp
 
     @Override
     public Set<String> getSupportedAnnotationNames() {
-        return Set.of(Controller.class.getName());
+        return Set.of(
+            "io.micronaut.http.annotation.*",
+            "io.swagger.v3.oas.annotations.*"
+        );
     }
 
     private boolean ignoreByRequires(Element element, VisitorContext context) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiControllerVisitor.java
@@ -108,6 +108,11 @@ public class OpenApiControllerVisitor extends AbstractOpenApiEndpointVisitor imp
         Utils.init(context);
     }
 
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(Controller.class.getName());
+    }
+
     private boolean ignoreByRequires(Element element, VisitorContext context) {
         List<AnnotationValue<Requires>> requiresAnnotations = element.getDeclaredAnnotationValuesByType(Requires.class);
         if (CollectionUtils.isEmpty(requiresAnnotations)) {

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiEndpointVisitor.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.micronaut.openapi.visitor.ConfigUtils.ALL_ENDPOINTS_NAME;
 import static io.micronaut.openapi.visitor.ConfigUtils.getEndpointsConfig;
@@ -119,6 +120,14 @@ public class OpenApiEndpointVisitor extends AbstractOpenApiEndpointVisitor imple
     @Override
     public void start(@NonNull VisitorContext context) {
         Utils.init(context);
+    }
+
+    @Override
+    public @NonNull Set<String> getSupportedAnnotationNames() {
+        return Set.of(
+            "io.micronaut.management.endpoint.annotation.Endpoint",
+            "org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint"
+        );
     }
 
     @Override

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiGroupInfoVisitor.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiGroupInfoVisitor.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.micronaut.openapi.visitor.ConfigUtils.isOpenApiEnabled;
 import static io.micronaut.openapi.visitor.ConfigUtils.isSpecGenerationEnabled;
@@ -71,6 +72,11 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
     }
 
     @Override
+    public @NonNull Set<String> getSupportedAnnotationNames() {
+        return Set.of(OpenAPIGroupInfo.class.getName());
+    }
+
+    @Override
     public int getOrder() {
         return Ordered.LOWEST_PRECEDENCE;
     }
@@ -80,9 +86,8 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
         if (!isOpenApiEnabled(context) || !isSpecGenerationEnabled(context)) {
             return;
         }
-        ContextUtils.addOriginatingElement(classEl, context);
-
         if (CollectionUtils.isNotEmpty(groups)) {
+            ContextUtils.addOriginatingElement(classEl, context);
             Map<String, List<String>> includedClassesGroups = Utils.getIncludedClassesGroups();
             if (includedClassesGroups == null) {
                 includedClassesGroups = new HashMap<>();
@@ -92,6 +97,7 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
         }
 
         if (CollectionUtils.isNotEmpty(groupsExcluded)) {
+            ContextUtils.addOriginatingElement(classEl, context);
             Map<String, List<String>> includedClassesGroupsExcluded = Utils.getIncludedClassesGroupsExcluded();
             if (includedClassesGroupsExcluded == null) {
                 includedClassesGroupsExcluded = new HashMap<>();
@@ -103,7 +109,10 @@ public class OpenApiGroupInfoVisitor implements TypeElementVisitor<Object, Objec
         PackageElement packageEl = classEl.getPackage();
         var classAnns = classEl.getAnnotationValuesByType(OpenAPIGroupInfo.class);
         var packageAnns = packageEl.getAnnotationValuesByType(OpenAPIGroupInfo.class);
-        if (CollectionUtils.isNotEmpty(classAnns) || CollectionUtils.isNotEmpty(packageAnns)) {
+        if (CollectionUtils.isNotEmpty(classAnns)) {
+            ContextUtils.addOriginatingElement(classEl, context);
+        }
+        if (CollectionUtils.isNotEmpty(packageAnns)) {
             ContextUtils.addOriginatingElement(packageEl, context);
         }
         if (CollectionUtils.isEmpty(classAnns) && CollectionUtils.isEmpty(packageAnns)) {

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
@@ -15,12 +15,13 @@ class OpenApiApplicationVisitorSpec extends AbstractOpenApiTypeElementSpec {
     void "visitors declare the annotations that can contribute to aggregating output"() {
         expect:
         new OpenApiApplicationVisitor().supportedAnnotationNames == [
-            "io.swagger.v3.oas.annotations.OpenAPIDefinition",
+            "io.swagger.v3.oas.annotations.*",
             "io.micronaut.openapi.annotation.OpenAPIGroupInfo",
             "io.micronaut.openapi.annotation.OpenAPIGroupInfos"
         ] as Set
         new OpenApiControllerVisitor().supportedAnnotationNames == [
-            "io.micronaut.http.annotation.Controller"
+            "io.micronaut.http.annotation.*",
+            "io.swagger.v3.oas.annotations.*"
         ] as Set
         new OpenApiEndpointVisitor().supportedAnnotationNames == [
             "io.micronaut.management.endpoint.annotation.Endpoint",

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiApplicationVisitorSpec.groovy
@@ -1,12 +1,89 @@
 package io.micronaut.openapi.visitor
 
 import io.micronaut.context.env.Environment
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.PackageElement
+import io.micronaut.inject.visitor.VisitorContext
 import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.micronaut.openapi.annotation.OpenAPIGroupInfo
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityScheme
 import spock.util.environment.RestoreSystemProperties
 
 class OpenApiApplicationVisitorSpec extends AbstractOpenApiTypeElementSpec {
+
+    void "visitors declare the annotations that can contribute to aggregating output"() {
+        expect:
+        new OpenApiApplicationVisitor().supportedAnnotationNames == [
+            "io.swagger.v3.oas.annotations.OpenAPIDefinition",
+            "io.micronaut.openapi.annotation.OpenAPIGroupInfo",
+            "io.micronaut.openapi.annotation.OpenAPIGroupInfos"
+        ] as Set
+        new OpenApiControllerVisitor().supportedAnnotationNames == [
+            "io.micronaut.http.annotation.Controller"
+        ] as Set
+        new OpenApiEndpointVisitor().supportedAnnotationNames == [
+            "io.micronaut.management.endpoint.annotation.Endpoint",
+            "org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint"
+        ] as Set
+        new OpenApiGroupInfoVisitor().supportedAnnotationNames == [
+            "io.micronaut.openapi.annotation.OpenAPIGroupInfo"
+        ] as Set
+    }
+
+    void "group visitor does not record an unrelated class as an originating element"() {
+        given:
+        Map<String, Object> contextValues = [:]
+        def context = Mock(VisitorContext) {
+            get(_, _) >> { CharSequence name, argument ->
+                Optional.ofNullable(contextValues[name.toString()])
+            }
+            put(_, _) >> { CharSequence name, Object value ->
+                contextValues[name.toString()] = value
+                null
+            }
+            getOptions() >> [:]
+        }
+        def packageElement = Mock(PackageElement) {
+            getAnnotationValuesByType(OpenAPIGroupInfo) >> []
+        }
+        def unrelated = Mock(ClassElement) {
+            getPackage() >> packageElement
+            getAnnotationValuesByType(OpenAPIGroupInfo) >> []
+        }
+
+        when:
+        new OpenApiGroupInfoVisitor().visitClass(unrelated, context)
+
+        then:
+        ContextUtils.getOriginatingElements(context).length == 0
+    }
+
+    void "controller visitor does not record an unrelated class as an originating element"() {
+        given:
+        Map<String, Object> contextValues = [:]
+        def context = Mock(VisitorContext) {
+            get(_, _) >> { CharSequence name, argument ->
+                Optional.ofNullable(contextValues[name.toString()])
+            }
+            put(_, _) >> { CharSequence name, Object value ->
+                contextValues[name.toString()] = value
+                null
+            }
+            getOptions() >> [:]
+        }
+        def unrelated = Mock(ClassElement) {
+            getName() >> "test.Unrelated"
+            getPackageName() >> "test"
+            isAnnotationPresent(_) >> false
+        }
+
+        when:
+        new OpenApiControllerVisitor().visitClass(unrelated, context)
+
+        then:
+        ContextUtils.getOriginatingElements(context).length == 0
+    }
 
     @RestoreSystemProperties
     void "test build OpenAPI doc for simple endpoint"() {


### PR DESCRIPTION
## Summary

- declare the annotations supported by aggregating OpenAPI visitors instead of inheriting the wildcard
- record only endpoint and group elements that actually contribute to generated OpenAPI output
- add regression coverage for supported annotations and unrelated originating elements

## Why

Wildcard matching and eagerly recorded origins cause incremental compilers to treat every source as an input to the shared OpenAPI document. This prevents unrelated source changes from compiling incrementally.

