### PR TITLE
feat(openapi): fold type-variable $dynamicRef into oneOf for polymorphic array items

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -2256,7 +2256,18 @@ public final class SchemaDefinitionUtils {
                 itemsSchemaAnn);
             if (!SchemaUtils.isEmptySchema(itemsSchemaFromAnn)) {
                 var itemsSchema = schemaToBind.getItems();
-                if (itemsSchemaFromAnn.get$ref() != null || itemsSchema.get$ref() != null) {
+                // Dynamic-refs: when array items are a type-variable $dynamicRef slot (only produced
+                // while a generic template is being built) and the items annotation carries a oneOf,
+                // fold the $dynamicRef in as an additional oneOf branch instead of merging it as a
+                // sibling. A schema with both $dynamicRef and oneOf is not well-defined (JSON Schema
+                // 2020-12 short-circuits on $dynamicRef); folding yields the intended
+                // oneOf[concrete, $dynamicRef] shape for polymorphic template children.
+                if (itemsSchema != null
+                    && itemsSchema.get$dynamicRef() != null
+                    && CollectionUtils.isNotEmpty(itemsSchemaFromAnn.getOneOf())) {
+                    itemsSchemaFromAnn.addOneOfItem(itemsSchema);
+                    schemaToBind.setItems(itemsSchemaFromAnn);
+                } else if (itemsSchemaFromAnn.get$ref() != null || itemsSchema.get$ref() != null) {
                     var allOf = createComposedSchema();
                     allOf.addAllOfItem(itemsSchema);
                     allOf.addAllOfItem(itemsSchemaFromAnn);

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -2256,14 +2256,16 @@ public final class SchemaDefinitionUtils {
                 itemsSchemaAnn);
             if (!SchemaUtils.isEmptySchema(itemsSchemaFromAnn)) {
                 var itemsSchema = schemaToBind.getItems();
-                // Dynamic-refs: when array items are a type-variable $dynamicRef slot (only produced
-                // while a generic template is being built) and the items annotation carries a oneOf,
-                // fold the $dynamicRef in as an additional oneOf branch instead of merging it as a
-                // sibling. A schema with both $dynamicRef and oneOf is not well-defined (JSON Schema
-                // 2020-12 short-circuits on $dynamicRef); folding yields the intended
-                // oneOf[concrete, $dynamicRef] shape for polymorphic template children.
-                if (itemsSchema != null
-                    && itemsSchema.get$dynamicRef() != null
+                if (itemsSchema == null) {
+                    // No existing items to merge with; adopt the annotation's items schema.
+                    schemaToBind.setItems(itemsSchemaFromAnn);
+                } else if (itemsSchema.get$dynamicRef() != null
+                    // Dynamic-refs: when array items are a type-variable $dynamicRef slot (only
+                    // produced while a generic template is being built) and the items annotation
+                    // carries a oneOf, fold the $dynamicRef in as an additional oneOf branch instead
+                    // of merging it as a sibling. A schema with both $dynamicRef and oneOf is not
+                    // well-defined (JSON Schema 2020-12 short-circuits on $dynamicRef); folding
+                    // yields the intended oneOf[concrete, $dynamicRef] shape for polymorphic children.
                     && CollectionUtils.isNotEmpty(itemsSchemaFromAnn.getOneOf())) {
                     itemsSchemaFromAnn.addOneOfItem(itemsSchema);
                     schemaToBind.setItems(itemsSchemaFromAnn);

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
@@ -1,9 +1,14 @@
 package io.micronaut.openapi.visitor
 
 import io.micronaut.openapi.AbstractOpenApiTypeElementSpec
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.ast.Element
+import io.micronaut.inject.visitor.VisitorContext
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.Schema
 import spock.util.environment.RestoreSystemProperties
+
+import java.util.Optional
 
 class OpenApi31DynamicGenericsSpec extends AbstractOpenApiTypeElementSpec {
 
@@ -1192,5 +1197,26 @@ class MyBean {}
         binding.get$ref() == '#/components/schemas/Folder'
         binding.getExtensions().get('$defs')['F']['$ref'] == '#/components/schemas/Document'
         binding.getExtensions().get('$defs')['R']['$ref'] == '#/components/schemas/Resource'
+    }
+
+    void "test array schema annotation supplies missing items"() {
+
+        given:
+        def context = Mock(VisitorContext) {
+            get(_, _) >> Optional.empty()
+        }
+        def element = Mock(Element)
+        def annotation = AnnotationValue.builder(io.swagger.v3.oas.annotations.media.ArraySchema)
+            .member('schema', AnnotationValue.builder(io.swagger.v3.oas.annotations.media.Schema)
+                .member('type', 'string')
+                .build())
+            .build()
+        def schema = new io.swagger.v3.oas.models.media.ArraySchema()
+
+        when:
+        SchemaDefinitionUtils.processArraySchemaAnn(schema, context, element, null, annotation)
+
+        then:
+        schema.items.type == 'string'
     }
 }

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
@@ -1122,4 +1122,75 @@ class MyBean {}
         // This requires the strip to match the @JsonProperty value, not the raw method name.
         !ownBranch.getProperties().containsKey('checksum')
     }
+
+    @RestoreSystemProperties
+    void "test polymorphic array items fold the type variable into oneOf"() {
+
+        setup:
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_31_ENABLED, "true")
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_SCHEMA_DYNAMIC_REFS_ENABLED, "true")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Controller
+class Api {
+    @Get("/ws")
+    public Folder<Document, Resource> get() { return null; }
+}
+
+class Folder<F, R> {
+    @ArraySchema(schema = @Schema(oneOf = { Document.class }))
+    private List<F> children;
+    private List<R> shortcuts;
+    public List<F> getChildren() { return children; }
+    public void setChildren(List<F> children) { this.children = children; }
+    public List<R> getShortcuts() { return shortcuts; }
+    public void setShortcuts(List<R> shortcuts) { this.shortcuts = shortcuts; }
+}
+
+class Document {
+    private String id;
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+}
+
+class Resource {
+    private String id;
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openApi = Utils.testReference
+        Schema folder = openApi.components.schemas['Folder']
+
+        then:
+        folder != null
+        Schema children = folder.properties.children
+        children.type == 'array'
+        Schema items = children.items
+        items.oneOf != null
+        items.oneOf.size() == 2
+        items.oneOf*.get$ref() == ['#/components/schemas/Document', null]
+        items.oneOf*.get$dynamicRef() == [null, '#F']
+        items.get$dynamicRef() == null
+
+        folder.properties.shortcuts.items.get$dynamicRef() == '#R'
+
+        Schema binding = openApi.paths['/ws'].get.responses['200'].content['application/json'].schema
+        binding.get$ref() == '#/components/schemas/Folder'
+        binding.getExtensions().get('$defs')['F']['$ref'] == '#/components/schemas/Document'
+        binding.getExtensions().get('$defs')['R']['$ref'] == '#/components/schemas/Resource'
+    }
 }


### PR DESCRIPTION
A generic type with a polymorphic element — say a folder whose `children` can be either a `Document` or another folder (the type variable) — couldn't express `oneOf[concrete, type variable]` in dynamic-refs mode. This PR makes it work: the type variable is folded into the field's declared `oneOf` as an additional branch.

Follow-up to #2780. Part of the dynamic-refs tracking issue #2786.

Before:
```yaml
children:
  type: array
  items:
    $dynamicRef: '#F'          # sibling of oneOf — JSON Schema 2020-12 short-circuits on this
    oneOf:
      - $ref: '#/components/schemas/Document'
```
After:
```yaml
children:
  type: array
  items:
    oneOf:
      - $ref: '#/components/schemas/Document'
      - $dynamicRef: '#F'      # folded in as a branch, not a sibling
```

## What
One branch in `SchemaDefinitionUtils.processArraySchemaAnn`: when the resolved array items are a `$dynamicRef` slot (only produced while a generic template is being built) and the items annotation carries a `oneOf`, fold the `$dynamicRef` schema in as an additional `oneOf` entry instead of appending it as a sibling. A schema with both `$dynamicRef` and `oneOf` set isn't well-defined (JSON Schema 2020-12 short-circuits on `$dynamicRef`); folding yields the intended `oneOf[concrete $ref, $dynamicRef]`.

No new annotation API: the type variable is already the field's element type, so its `$dynamicRef` branch is inferred from the active template build. The `$dynamicRef` presence is itself the gate — no config check needed.

Usage: `@ArraySchema(schema = @Schema(oneOf = { Document.class }))` on `List<F>` (annotation values are `Class[]`, so the variable can't be named explicitly — it's implicit).

## Scope
- The scalar form (`@Schema(oneOf = {…})` on a plain `F` field) has the same defect on a different code path; not handled here — the array case is the common one.
- Anchor naming (`#F`) is unchanged; descriptive anchor names are a separate, cosmetic concern.

## Testing
`./gradlew :micronaut-openapi:test` green. New case: `@ArraySchema(schema=@Schema(oneOf={Document}))` on `List<F>` → items become `oneOf[{$ref Document}, {$dynamicRef #F}]` with no sibling `$dynamicRef`; the un-annotated second variable is unaffected; the route binding still rebinds both.
