### PR TITLE
  Fix duplicate schema property for @JsonProperty getters

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=7.1.2-SNAPSHOT
+projectVersion=7.1.2
 projectGroup=io.micronaut.openapi
 
 title=OpenAPI/Swagger Support

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=7.1.2
+projectVersion=7.1.3-SNAPSHOT
 projectGroup=io.micronaut.openapi
 
 title=OpenAPI/Swagger Support

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -1949,6 +1949,9 @@ public final class SchemaDefinitionUtils {
                 if (!methodEl.hasAnnotation(JsonProperty.class) || isVoid(methodEl.getReturnType())) {
                     continue;
                 }
+                if (beanProperties.stream().anyMatch(property -> property.getReadMethod().filter(methodEl::equals).isPresent())) {
+                    continue;
+                }
                 var methodJavadoc = Utils.getJavadocParser().parse(methodEl.getDocumentation().orElse(null));
                 var methodReturnType = methodEl.getReturnType();
 

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -1950,10 +1950,9 @@ public final class SchemaDefinitionUtils {
 
             // also need to check methods with @JsonProperty annotation
             for (var methodEl : classEl.getMethods()) {
-                if (!methodEl.hasAnnotation(JsonProperty.class) || isVoid(methodEl.getReturnType())) {
-                    continue;
-                }
-                if (beanPropertyReadMethods.contains(methodEl)) {
+                if (!methodEl.hasAnnotation(JsonProperty.class)
+                    || isVoid(methodEl.getReturnType())
+                    || beanPropertyReadMethods.contains(methodEl)) {
                     continue;
                 }
                 var methodJavadoc = Utils.getJavadocParser().parse(methodEl.getDocumentation().orElse(null));

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/SchemaDefinitionUtils.java
@@ -1944,12 +1944,16 @@ public final class SchemaDefinitionUtils {
 
             processPropertyElements(openApi, context, type, typeArgs, schema, publicFields, mediaTypes, classJavadoc, jsonViewClass);
 
+            var beanPropertyReadMethods = beanProperties.stream()
+                .flatMap(property -> property.getReadMethod().stream())
+                .collect(Collectors.toSet());
+
             // also need to check methods with @JsonProperty annotation
             for (var methodEl : classEl.getMethods()) {
                 if (!methodEl.hasAnnotation(JsonProperty.class) || isVoid(methodEl.getReturnType())) {
                     continue;
                 }
-                if (beanProperties.stream().anyMatch(property -> property.getReadMethod().filter(methodEl::equals).isPresent())) {
+                if (beanPropertyReadMethods.contains(methodEl)) {
                     continue;
                 }
                 var methodJavadoc = Utils.getJavadocParser().parse(methodEl.getDocumentation().orElse(null));

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerJavaSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiPojoControllerJavaSpec.groovy
@@ -7,6 +7,54 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 
 class OpenApiPojoControllerJavaSpec extends AbstractOpenApiTypeElementSpec {
 
+    void "test named class schema with JsonProperty getter"() {
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
+
+@Controller
+class RevokeController {
+    @Get
+    Revoke get() {
+        return null;
+    }
+}
+
+@Schema(name = "example.Revoke", description = "Class description")
+class Revoke {
+    @Schema(description = "Set description")
+    @JsonProperty("from")
+    private Set<String> from;
+
+    @JsonProperty("from")
+    public Set<String> getFrom() {
+        return from;
+    }
+
+    public void setFrom(Set<String> from) {
+        this.from = from;
+    }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        then:
+        Schema revokeSchema = Utils.testReference.components.schemas['example.Revoke']
+        revokeSchema.properties.keySet() == ['from'] as Set
+        revokeSchema.properties.from.type == 'array'
+        revokeSchema.properties.from.description == 'Set description'
+        revokeSchema.description == 'Class description'
+    }
+
     void "test java"() {
 
         when:


### PR DESCRIPTION
issue : 
 When a Java bean getter is annotated with `@JsonProperty`, the OpenAPI visitor processed it twice:
  1. As a normal bean property.
  2. In the additional `@JsonProperty`-method pass.
  For a class with an explicit `@Schema(name = "...")`, the second pass could inherit the class-level schema name and add a duplicate property keyed by that
  schema name.
  The additional Jackson-method pass now skips methods that are already the read method of a discovered bean property. Standalone non-bean methods annotated with
  `@JsonProperty` continue to be processed.
Published fix locally and test it against reproducer now generates only the 'from' property.
Closes : #2791 