### PR TITLE
fix(openapi): detect mutual named-subtype recursion via in-progress resolution set

### DIFF
--- a/openapi/src/main/java/io/micronaut/openapi/visitor/DynamicRefUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/DynamicRefUtils.java
@@ -543,41 +543,41 @@ public final class DynamicRefUtils {
         }
         resolvingNamedSubtypes.add(typeName);
         try {
-        ClassElement superBinding = parameterizedGenericSuperType(type);
-        if (superBinding == null) {
-            return null;
-        }
-        Schema<?> binding = resolveGenericBinding(openApi, context, superBinding, superBinding.getTypeArguments(), mediaTypes, jsonViewClass);
-        if (binding == null) {
-            return null;
-        }
-        // Compute both name sets once: superNames is reused for the adds-own-field test and for
-        // stripping shadowed inherited names from the own branch below.
-        Set<String> superNames = schemaPropertyNames(superBinding);
-        Set<String> ownNames = schemaPropertyNames(type);
-        ownNames.removeAll(superNames);
-        if (ownNames.isEmpty()) {
-            // Pure specialization: just the binding alias.
-            return binding;
-        }
-        // The subtype adds its own fields: compose the generic binding with an own-properties
-        // object so the extra fields survive (rather than falling back to a fully concrete schema).
-        // populateSchemaProperties filters ordinary inherited bean properties/fields by declaring
-        // type, but inherited @JsonProperty methods and overridden getters can still reach the
-        // own-branch, so strip those against the supertype's emitted keys to avoid duplication.
-        Schema<?> own = SchemaUtils.createSchema();
-        SchemaDefinitionUtils.populateSchemaProperties(openApi, context, type, type.getTypeArguments(), own, mediaTypes, null, jsonViewClass);
-        own.setType("object"); // reassert; swagger-core may drop type on allOf members
-        if (own.getProperties() != null && !superNames.isEmpty()) {
-            own.getProperties().keySet().removeAll(superNames);
-        }
-        if (own.getProperties() == null || own.getProperties().isEmpty()) {
-            return binding;
-        }
-        var composed = SchemaUtils.createComposedSchema();
-        composed.addAllOfItem(binding);
-        composed.addAllOfItem(own);
-        return composed;
+            ClassElement superBinding = parameterizedGenericSuperType(type);
+            if (superBinding == null) {
+                return null;
+            }
+            Schema<?> binding = resolveGenericBinding(openApi, context, superBinding, superBinding.getTypeArguments(), mediaTypes, jsonViewClass);
+            if (binding == null) {
+                return null;
+            }
+            // Compute both name sets once: superNames is reused for the adds-own-field test and for
+            // stripping shadowed inherited names from the own branch below.
+            Set<String> superNames = schemaPropertyNames(superBinding);
+            Set<String> ownNames = schemaPropertyNames(type);
+            ownNames.removeAll(superNames);
+            if (ownNames.isEmpty()) {
+                // Pure specialization: just the binding alias.
+                return binding;
+            }
+            // The subtype adds its own fields: compose the generic binding with an own-properties
+            // object so the extra fields survive (rather than falling back to a fully concrete schema).
+            // populateSchemaProperties filters ordinary inherited bean properties/fields by declaring
+            // type, but inherited @JsonProperty methods and overridden getters can still reach the
+            // own-branch, so strip those against the supertype's emitted keys to avoid duplication.
+            Schema<?> own = SchemaUtils.createSchema();
+            SchemaDefinitionUtils.populateSchemaProperties(openApi, context, type, type.getTypeArguments(), own, mediaTypes, null, jsonViewClass);
+            own.setType("object"); // reassert; swagger-core may drop type on allOf members
+            if (own.getProperties() != null && !superNames.isEmpty()) {
+                own.getProperties().keySet().removeAll(superNames);
+            }
+            if (own.getProperties() == null || own.getProperties().isEmpty()) {
+                return binding;
+            }
+            var composed = SchemaUtils.createComposedSchema();
+            composed.addAllOfItem(binding);
+            composed.addAllOfItem(own);
+            return composed;
         } finally {
             resolvingNamedSubtypes.remove(typeName);
         }

--- a/openapi/src/main/java/io/micronaut/openapi/visitor/DynamicRefUtils.java
+++ b/openapi/src/main/java/io/micronaut/openapi/visitor/DynamicRefUtils.java
@@ -76,6 +76,14 @@ public final class DynamicRefUtils {
     private static Map<String, String> activeTemplates = new HashMap<>();
 
     /**
+     * Named subtypes currently being resolved (keyed by raw type name). Used to detect cycles —
+     * direct (WorkspaceFolder extends Folder&lt;WorkspaceFolder&gt;) or mutual (A extends Folder&lt;B&gt;,
+     * B extends Folder&lt;A&gt;) — so the second entry returns null and falls back to concrete instead
+     * of infinite-looping.
+     */
+    private static Set<String> resolvingNamedSubtypes = new HashSet<>();
+
+    /**
      * Reflective handle to {@link Schema}'s private {@code extensions} map, used by
      * {@link #setSchemaDefs} to inject a {@code $defs} block (a JSON Schema 2020-12 keyword that
      * swagger-core 2.2.x does not model). See {@link #setSchemaDefs} for the full rationale.
@@ -101,6 +109,7 @@ public final class DynamicRefUtils {
         recursiveSchemaAnchors = new HashMap<>();
         templateVarStack = new ArrayList<>();
         activeTemplates = new HashMap<>();
+        resolvingNamedSubtypes = new HashSet<>();
     }
 
     // ---- recursive types ----------------------------------------------------------------
@@ -504,41 +513,15 @@ public final class DynamicRefUtils {
 
     /**
      * Whether the given concrete type is a named subtype of a parameterized generic supertype
-     * (e.g. {@code class PetResponse extends Response<Pet>}). Such a type is emitted as a named
-     * binding component instead of a full concrete schema: a pure-specialization subtype (no fields
-     * of its own) becomes a {@code $ref} to the template plus a {@code $defs} rebinding; a subtype
-     * that adds its own fields becomes an {@code allOf} of that binding and an own-properties
-     * object, so the subtype's fields are preserved rather than dropped.
+     * (e.g. {@code class PetResponse extends Response<Pet>}). Self-referential and mutually
+     * recursive subtypes are detected at resolution time by {@link #resolveNamedSubtypeBinding}'s
+     * in-progress set, not here.
      */
     static boolean isNamedSubtypeBinding(ClassElement type) {
         if (type == null) {
             return false;
         }
-        ClassElement superBinding = parameterizedGenericSuperType(type);
-        if (superBinding == null) {
-            return false;
-        }
-        // A self-referential named subtype (e.g. class WorkspaceFolder extends Folder<WorkspaceFolder,
-        // Resource>) would infinite-loop: resolving its binding resolves the type argument that is
-        // itself, re-entering resolveNamedSubtypeBinding. Fall back to concrete for this case.
-        if (isSelfReferentialSubtype(type, superBinding)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Whether the subtype appears in its own parameterized generic supertype's type arguments
-     * (directly), i.e. it is self-referential through the generic binding.
-     */
-    private static boolean isSelfReferentialSubtype(ClassElement type, ClassElement superBinding) {
-        String name = type.getName();
-        for (ClassElement arg : superBinding.getTypeArguments().values()) {
-            if (name.equals(arg.getName())) {
-                return true;
-            }
-        }
-        return false;
+        return parameterizedGenericSuperType(type) != null;
     }
 
     /**
@@ -554,6 +537,12 @@ public final class DynamicRefUtils {
      */
     static Schema<?> resolveNamedSubtypeBinding(OpenAPI openApi, VisitorContext context, ClassElement type,
                                                 List<MediaType> mediaTypes, @Nullable ClassElement jsonViewClass) {
+        String typeName = type.getName();
+        if (resolvingNamedSubtypes.contains(typeName)) {
+            return null;
+        }
+        resolvingNamedSubtypes.add(typeName);
+        try {
         ClassElement superBinding = parameterizedGenericSuperType(type);
         if (superBinding == null) {
             return null;
@@ -589,6 +578,9 @@ public final class DynamicRefUtils {
         composed.addAllOfItem(binding);
         composed.addAllOfItem(own);
         return composed;
+        } finally {
+            resolvingNamedSubtypes.remove(typeName);
+        }
     }
 
     /**

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
@@ -1007,7 +1007,7 @@ class MyBean {}
     }
 
     @RestoreSystemProperties
-    void "test self-referential named subtype falls back to concrete instead of looping"() {
+    void "test self-referential named subtype emits binding without looping"() {
 
         setup:
         System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_31_ENABLED, "true")
@@ -1057,12 +1057,97 @@ class MyBean {}
         Schema ws = openApi.components.schemas['WorkspaceFolder']
 
         then:
-        // A self-referential named subtype cannot be a binding alias (resolving its binding would
-        // recurse into resolving itself), so it falls back to the default concrete behavior. The
-        // important contract: it terminates (no infinite loop) and emits no leaked dynamic anchor.
+        // A self-referential named subtype now gets a named binding (allOf[binding, own-props])
+        // instead of falling back to concrete — the in-progress set breaks the resolution cycle
+        // (resolving the type argument that is itself returns null, so a concrete $ref fills the
+        // slot). The binding's F slot points back at WorkspaceFolder (recursive $ref).
         ws != null
-        ws.get$ref() == null
-        ws.getExtensions() == null || ws.getExtensions().get('$defs') == null
+        ws.allOf != null
+        ws.allOf.size() == 2
+        ws.allOf[0].get$ref() == '#/components/schemas/Folder'
+        ws.allOf[0].getExtensions().get('$defs')['F']['$ref'] == '#/components/schemas/WorkspaceFolder'
+        ws.allOf[1].getProperties().containsKey('permissions')
+    }
+
+    @RestoreSystemProperties
+    void "test mutual named-subtype recursion terminates and emits bindings"() {
+
+        setup:
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_31_ENABLED, "true")
+        System.setProperty(OpenApiConfigProperty.MICRONAUT_OPENAPI_SCHEMA_DYNAMIC_REFS_ENABLED, "true")
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import java.util.List;
+
+@Controller
+class Api {
+    @Get("/a")
+    public NodeA getNodeA() { return null; }
+}
+
+class Folder<F, R> {
+    private List<F> children;
+    private List<R> shortcuts;
+    public List<F> getChildren() { return children; }
+    public void setChildren(List<F> children) { this.children = children; }
+    public List<R> getShortcuts() { return shortcuts; }
+    public void setShortcuts(List<R> shortcuts) { this.shortcuts = shortcuts; }
+}
+
+// Mutual recursion: NodeA references NodeB and vice versa.
+class NodeA extends Folder<NodeB, Resource> {
+    private String label;
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+}
+
+class NodeB extends Folder<NodeA, Document> {
+    private String title;
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}
+
+class Resource {
+    private String id;
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+}
+
+class Document {
+    private String id;
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+}
+
+@jakarta.inject.Singleton
+class MyBean {}
+''')
+
+        OpenAPI openApi = Utils.testReference
+        Schema nodeA = openApi.components.schemas['NodeA']
+        Schema nodeB = openApi.components.schemas['NodeB']
+
+        then:
+        // Both subtypes are in components and the build terminates (no infinite loop). NodeA gets
+        // a named binding (allOf[binding, own-props]) with its F slot pointing at NodeB. NodeB,
+        // resolved as a type argument during NodeA's binding build (where the gate's definingElement
+        // is null), may be concrete — the in-progress set breaks the cycle, and full binding for
+        // both mutual subtypes is a further refinement.
+        nodeA != null
+        nodeA.allOf != null
+        nodeA.allOf.size() == 2
+        nodeA.allOf[0].get$ref() == '#/components/schemas/Folder'
+        nodeA.allOf[0].getExtensions().get('$defs')['F']['$ref'] == '#/components/schemas/NodeB'
+        nodeA.allOf[1].getProperties().containsKey('label')
+
+        nodeB != null
+        // NodeB was registered during NodeA's resolution — it exists and carries its own field.
+        Utils.getYamlMapper().writeValueAsString(nodeB).contains('title')
     }
 
     @RestoreSystemProperties

--- a/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
+++ b/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApi31DynamicGenericsSpec.groovy
@@ -1107,9 +1107,9 @@ class NodeA extends Folder<NodeB, Resource> {
 }
 
 class NodeB extends Folder<NodeA, Document> {
-    private String title;
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
+    private String bMarker;
+    public String getBMarker() { return bMarker; }
+    public void setBMarker(String bMarker) { this.bMarker = bMarker; }
 }
 
 class Resource {
@@ -1147,7 +1147,8 @@ class MyBean {}
 
         nodeB != null
         // NodeB was registered during NodeA's resolution — it exists and carries its own field.
-        Utils.getYamlMapper().writeValueAsString(nodeB).contains('title')
+        // (bMarker is deliberately not an OpenAPI keyword, so the substring check is unambiguous.)
+        Utils.getYamlMapper().writeValueAsString(nodeB).contains('bMarker')
     }
 
     @RestoreSystemProperties


### PR DESCRIPTION
Named subtypes that form a cycle — direct (WorkspaceFolder extends Folder<WorkspaceFolder>) or mutual (A extends Folder<B>, B extends Folder<A>) — previously infinite-looped: resolving a subtype's binding resolves the type argument that (directly or transitively) is itself, re-entering resolveNamedSubtypeBinding.

## Fix
Replaces the direct-only isSelfReferentialSubtype check with an in-progress resolution set (resolvingNamedSubtypes). When a named subtype is already being resolved when re-entered, resolveNamedSubtypeBinding returns null so the caller falls back to concrete instead of recursing. The set is cleared by clean().

For direct self-reference, the subtype now gets a named binding (the cycle breaks at the type-argument level) instead of the previous concrete fallback — an improvement.

For mutual recursion, the set breaks the cycle; one of the pair may be emitted concrete when resolved as a type argument (the gate's definingElement is null in the slot path). Full binding for both mutual subtypes is a further refinement.

Follow-up to #2780. Part of #2786.

## Testing
`./gradlew :micronaut-openapi:test` green. Updated the self-referential test (now asserts a named binding, not concrete); added a mutual-recursion test (A extends Folder<B>, B extends Folder<A>) that verifies termination and that the first subtype gets a binding.